### PR TITLE
Prevent notices when editing a custom post type post

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -822,7 +822,7 @@ class coauthors_plus {
 		$post_type_object = get_post_type_object( $post->post_type );
 		
 		// Bail out if there's no post type object
-		if ( empty($post_type_object) )
+		if ( ! is_object( $post_type_object ) )
 			return $allcaps;
 
 		// Bail out if we're not asking about a post


### PR DESCRIPTION
`$post_type_object = get_post_type_object( $post->post_type );` can return a null object, which causes all the other turtles to throw notices because `$post_type_object->cap` isn't set.  This bails if `$post_type_object` is empty to prevent that.  (Went with `empty()` instead of `is_null()` in case the `get_post_type_object()` return type changes.)

It's  a notice, but it kills my dev environment with "header already sent" =P
