### PR TITLE
Feature authors

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -23,7 +23,7 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 				if ( !empty( $post_author ) )
 					$coauthors[] = $post_author;
 			}
-		} else {
+		} else if ( !$coauthors_plus->force_guest_authors ) {
 			if ( $post ) {
 				$post_author = get_userdata( $post->post_author );
 			} else {
@@ -31,7 +31,7 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 			}
 			if ( !empty( $post_author ) )
 				$coauthors[] = $post_author;
-		}
+		} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
 	}
 	return $coauthors;
 }


### PR DESCRIPTION
2/3 of the major tasks to finish guest authors for NYO production use are complete:
- Associate real users to guest authors in the admin area.
- Guest author links and content pages work now

The last remaining piece is to override logic in coauthors-plus.php that puts the current WordPress user ID in place when a post is new. We need it to look for an associated guest author and use that instead.

Relevant changes to think more about:
- I had to change the tag name to be the author's display name for the /author/slug page to display the right title without bending over backward to detect if the author is a guest author, and if so, load the post just for the title—anyways, the upshot of that is we're on tag slug instead in https://github.com/Automattic/Co-Authors-Plus/blob/feature-authors/template-tags.php#L21
- The 'user' capability_type was not working. Saving a guest author yielded an error every time. I removed it since the post capability_type seems to suffice for our purposes, but if I was just doing something please correct me.
