### PR TITLE
Let the last separator be the only separator between the last two items in template tags

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -165,8 +165,8 @@ function coauthors__echo( $tag, $type = 'tag', $separators = array(), $tag_args 
 			$output .= $separators['between'];
 		
 		if ( $i->is_last() && $i->count() > 1 ) {
-			$output = rtrim( $output, ' ' );
-			$output .= ' ' . $separators['betweenLast'];
+			$output = rtrim( $output, " {$separators['between']}" );
+			$output .= $separators['betweenLast'];
 		}
 		
 		$output .= $author_text;


### PR DESCRIPTION
Currently, `$separators['between']` and  `$separators['betweenLast']` get both applied between the second to last and last item.

This patch will fix that.
