### PR TITLE
A Fix to modify the user query to return more accurate data Should also Solve #33

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -547,8 +547,8 @@ class coauthors_plus {
 				return $join;
 
 			// Check to see that JOIN hasn't already been added. Props michaelingp and nbaxley
-			$term_relationship_join = " INNER JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
-			$term_taxonomy_join = " INNER JOIN {$wpdb->term_taxonomy} ON ( {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
+			$term_relationship_join = " LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
+			$term_taxonomy_join = " LEFT JOIN {$wpdb->term_taxonomy} ON ( {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
 
 			if( strpos( $join, trim( $term_relationship_join ) ) === false ) {
 				$join .= $term_relationship_join;


### PR DESCRIPTION
I came across this problem where I created 3 posts
1. Post with a native WP user
2. Post with same native user but I removed the native user and added a Guest Author Instead
3. Post with same native user as the two above and added a Guest Author.
The Issue...
When I saw the author page for the Guest Author I saw 2 and 3
When I saw the author page for The Wp native user I saw 1 2 and 3
While the former was as it is supposed to be the latter should have shown only 1 and 3 as the WP user was "not attached" to post

This solution treats a post to be of the user if
1. The User is in Guest Author List
2. The User is in WP User Field and no Guest Author is attached to post

Two things I think I can do to enhance the plugin further
1. I believe we can do away with the force_guest_author flag after this change
2. I believe instead of the 2 INNER JOINS on Line 550 and 551 if we use LEFT Joins it will be more logical and faster in terms of query execution speed

Regards,
Vicky Biswas
