### PR TITLE
Change the meta box title so it's not specific to Posts

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -311,7 +311,7 @@ class coauthors_plus {
 	function add_coauthors_box() {
 
 		if( $this->is_post_type_enabled() && $this->current_user_can_set_authors() )
-			add_meta_box( $this->coauthors_meta_box_name, __('Post Authors', 'co-authors-plus'), array( $this, 'coauthors_meta_box' ), get_post_type(), apply_filters( 'coauthors_meta_box_context', 'normal'), apply_filters( 'coauthors_meta_box_priority', 'high'));
+			add_meta_box( $this->coauthors_meta_box_name, __('Authors', 'co-authors-plus'), array( $this, 'coauthors_meta_box' ), get_post_type(), apply_filters( 'coauthors_meta_box_context', 'normal'), apply_filters( 'coauthors_meta_box_priority', 'high'));
 	}
 
 	/**


### PR DESCRIPTION
When you're editing Pages or custom post types, the title of the Co-Authors Plus meta box still says 'Post Authors'. It makes more sense just to say 'Authors' so it's post type agnostic.
