### PR TITLE
coauthor_slug is sometimes based on user_login rather than user_nicename

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -20,6 +20,11 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 			foreach( $coauthor_terms as $coauthor ) {
 				$coauthor_slug = preg_replace( '#^cap\-#', '', $coauthor->slug );
 				$post_author =  $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
+
+				if( empty( $post_author ) ) {
+					$post_author = $coauthors_plus->get_coauthor_by( 'user_login', $coauthor_slug );
+				}
+
 				// In case the user has been deleted while plugin was deactivated
 				if ( !empty( $post_author ) )
 					$coauthors[] = $post_author;


### PR DESCRIPTION
I don't know how it happened, but several months' worth of posts (in the July-September 2012 range) appear to have a coauthor_slug set to cap-{user_login} instead of cap-{user_nicename}, which causes all of the coauthors information (authors column, edit page metabox, coauthors() function) to be empty.  I noticed the empty fields after upgrading to WordPress 3.5.

This commit tries to find the slug in user_login if it's not found in user_nicename.
