### PR TITLE
fixed broken author+term query

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -544,8 +544,8 @@ class coauthors_plus {
 				return $join;
 
 			// Check to see that JOIN hasn't already been added. Props michaelingp and nbaxley
-			$term_relationship_join = " INNER JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
-			$term_taxonomy_join = " INNER JOIN {$wpdb->term_taxonomy} ON ( {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
+			$term_relationship_join = " INNER JOIN {$wpdb->term_relationships} AS catr ON ({$wpdb->posts}.ID = catr.object_id)";
+			$term_taxonomy_join = " INNER JOIN {$wpdb->term_taxonomy} ON ( catr.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
 
 			if( strpos( $join, trim( $term_relationship_join ) ) === false ) {
 				$join .= str_replace( "INNER JOIN", "LEFT JOIN", $term_relationship_join );


### PR DESCRIPTION
when co-author-plus plugin is enabled, we noticed that we were not getting results when searching for author and another taxonomy term. it looks like co-author-plus is actually not adding the join term it needs when a WP query also contains a taxonomy query, because the taxonomy query generates a join clause that's identical to what co-author-plus generates and co-author-plus cannot tell whether that clause is a duplicate or not.

the fix makes the co-author-plus-generated sql join clause slightly different (by using an alias for the wp_term_relationships table). i think this does not change the functionality of the plugin but avoids confusing sql clauses from different sources.
