### PR TITLE
coauthors_plus->add_coauthors should return a result

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -752,7 +752,7 @@ class coauthors_plus {
 			$term = $this->update_author_term( $author );
 			$coauthors[$key] = $term->slug;
 		}
-		wp_set_post_terms( $post_id, $coauthors, $this->coauthor_taxonomy, $append );
+		return wp_set_post_terms( $post_id, $coauthors, $this->coauthor_taxonomy, $append );
 	}
 
 	/**


### PR DESCRIPTION
The add_coauthors method should return the result of wp_set_post_terms so that those of us programatically assigning co-authors can tell if the assignment was a success.
