### PR TITLE
Don't check is_user_member_of_blog(), native WP doesn't

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -241,7 +241,7 @@ class coauthors_plus {
 				if ( 'login' == $key || 'slug' == $key )
 					$value = preg_replace( '#^cap\-#', '', $value );
 				$user = get_user_by( $key, $value );
-				if ( !$user || !is_user_member_of_blog( $user->ID ) )
+				if ( ! $user )
 					return false;
 				$user->type = 'wpuser';
 				// However, if guest authors are enabled and there's a guest author linked to this


### PR DESCRIPTION
Conform to native WP behavior, don't check `is_user_member_of_blog()` on authors attached to a post.

This fixes problems where users have been removed from a blog, but remain as authors of posts in it.
