### PR TITLE
Remove extraneous space between last two items.

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -169,8 +169,8 @@ function coauthors__echo( $tag, $type = 'tag', $separators = array(), $tag_args 
 			$output .= $separators['between'];
 		
 		if ( $i->is_last() && $i->count() > 1 ) {
-			$output = rtrim( $output, " {$separators['between']}" );
-			$output .= ' ' . $separators['betweenLast'];
+			$output = rtrim( $output, $separators['between'] );
+			$output .= $separators['betweenLast'];
 		}
 		
 		$output .= $author_text;


### PR DESCRIPTION
There is an extra space between the last two items, so the output of `coauthors()` would generate the output `John Smith, John Doe  and Jane Doe`. It was really noticeable when I tried adding a serial comma with `coauthors( null, ', and ' )`. The output was `John Smith, John Doe , and Jane Doe` (notice the extra space between John Doe and the comma). 
