### PR TITLE
Missing method `get_guest_author_thumbnail` is throwing a notice and fatal

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -745,7 +745,7 @@ class CoAuthors_Guest_Authors
 		global $wpdb;
 
 		$cache_key = $this->get_cache_key( $key, $value );
-		
+
 		if ( false == $force && false !== ( $retval = wp_cache_get( $cache_key, self::$cache_group ) ) )
 			return $retval;
 
@@ -811,6 +811,31 @@ class CoAuthors_Guest_Authors
 		wp_cache_set( $cache_key, (object)$guest_author, self::$cache_group );
 
 		return (object)$guest_author;
+	}
+
+	/**
+	 * Get an thumbnail for a Guest Author object
+	 *
+	 * @param 	object 	The Guest Author object for which to retrieve the thumbnail
+	 * @param 	int 	The desired image size
+	 * @return 	string 	The thumbnail image tag, or null if one doesn't exist
+	 */
+	function get_guest_author_thumbnail( $guest_author, $size ) {
+		// See if the guest author has an avatar
+		if ( ! has_post_thumbnail( $guest_author->ID ) )
+			return null;
+
+		$args = array(
+				'class' => "avatar avatar-{$size} photo",
+			);
+		if ( in_array( $size, $this->avatar_sizes ) )
+			$size = 'guest-author-' . $size;
+		else
+			$size = array( $size, $size );
+
+		$thumbnail = get_the_post_thumbnail( $guest_author->ID, $size, $args );
+
+		return $thumbnail;
 	}
 
 	/**
@@ -1220,7 +1245,6 @@ class CoAuthors_Guest_Authors
 	 * @since 3.0
 	 */
 	function filter_get_avatar( $avatar, $id_or_email, $size, $default ) {
-
 		if ( is_object( $id_or_email ) || !is_email( $id_or_email ) )
 			return $avatar;
 
@@ -1229,18 +1253,10 @@ class CoAuthors_Guest_Authors
 		if ( ! $guest_author )
 			return $avatar;
 
-		// See if the guest author as an avatar
-		if ( ! has_post_thumbnail( $guest_author->ID ) )
-			return $avatar;
+		$thumbnail = $this->get_guest_author_thumbnail( $guest_author, $size );
 
-		$args = array(
-				'class' => "avatar avatar-{$size} photo",
-			);
-		if ( in_array( $size, $this->avatar_sizes ) )
-			$size = 'guest-author-' . $size;
-		else
-			$size = array( $size, $size );
-		$avatar = get_the_post_thumbnail( $guest_author->ID, $size, $args );
+		if ( $thumbnail )
+			return $thumbnail;
 
 		return $avatar;
 	}


### PR DESCRIPTION
[this line](https://github.com/Automattic/Co-Authors-Plus/blob/ead0cb739646aeedba460df0dab23a5bf9f5bb99/template-tags.php#L514), introduced in ead0cb7396, is trying to use a method that does not exist anywhere in the codebase. This can cause a PHP notice on new post screens and a fatal error when listing authors.

It almost seems like there was a missed commit somewhere? I'm avoiding a PR right now as I'm not entirely sure what the exact intent was.
