### PR TITLE
`$args` param in `get_coauthors()` is ignored

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -1,6 +1,6 @@
 <?php
 
-function get_coauthors( $post_id = 0, $args = array() ) {
+function get_coauthors( $post_id = 0 ) {
 	global $post, $post_ID, $coauthors_plus, $wpdb;
 	
 	$coauthors = array();
@@ -9,12 +9,9 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 		$post_id = $post_ID;
 	if ( !$post_id && $post )
 		$post_id = $post->ID;
-
-	$defaults = array('orderby'=>'term_order', 'order'=>'ASC');
-	$args = wp_parse_args( $args, $defaults );
 	
 	if ( $post_id ) {
-		$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy, $args );
+		$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
 		
 		if ( is_array( $coauthor_terms ) && !empty( $coauthor_terms ) ) {
 			foreach( $coauthor_terms as $coauthor ) {


### PR DESCRIPTION
This was altered about a year ago in 2d8709bf30945fb407d85be72595b9d5128c016a, and it's interesting that it hasn't been caught. `wp_get_post_terms()` was replaced with `get_the_terms()`, but [`get_the_terms()`](https://github.com/WordPress/WordPress/blob/master/wp-includes/category-template.php#L1084-L1100) does not accept arguments.
