### PR TITLE
Guest-Authors Need Support for Other Input types than "text"

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -579,14 +579,16 @@ class CoAuthors_Guest_Authors
 			echo '<label for="' . esc_attr( $pm_key ) . '">' . $field['label'] . '</label>';
 			echo '</th><td>';
 			
-			if(!isset($field['input'])){ $field['input'] = "text"; }
-			$field['input'] = apply_filters("$pm_key_input", $field['input']);
-			switch($field['input']){
+			if( !isset( $field['input'] ) ) {
+				$field['input'] = "text"; 
+			}
+			$field['input'] = apply_filters( 'cap-contact_info-'. $pm_key , $field['input']);
+			switch( $field['input'] ) {
 				case "checkbox":
-					echo '<input type="checkbox" name="' . esc_attr( $pm_key ) . '"'. checked('1',$value,false) .' value="1"/>';
+					echo '<input type="checkbox" name="' . esc_attr( $pm_key ) . '"'. checked( '1', $value, false ) .' value="1"/>';
 				break;
 				default:
-					echo '<input type="'. esc_attr($field['input']) .'" name="' . esc_attr( $pm_key ) . '" value="' . esc_attr( $value ) . '" class="regular-text" />';
+					echo '<input type="'. esc_attr( $field['input'] )  .'" name="' . esc_attr( $pm_key ) . '" value="' . esc_attr( $value ) . '" class="regular-text" />';
 			break;
 			} 
 			echo '</td></tr>';
@@ -612,14 +614,16 @@ class CoAuthors_Guest_Authors
 			echo '<label for="' . esc_attr( $pm_key ) . '">' . $field['label'] . '</label>';
 			echo '</th><td>';
 			
-			if(!isset($field['input'])){ $field['input'] = "text"; }
-			$field['input'] = apply_filters("$pm_key_input", $field['input']);
-			switch($field['input']){
+			if( !isset( $field['input'] ) ) {
+				$field['input'] = "text";
+			}
+			$field['input'] = apply_filters( 'cap-contact_info-'. $pm_key , $field['input']);
+			switch( $field['input'] ) {
 				case "checkbox":
-					echo '<input type="checkbox" name="' . esc_attr( $pm_key ) . '"'. checked('1',$value,false) .' value="1"/>';
+					echo '<input type="checkbox" name="' . esc_attr( $pm_key ) . '"'. checked( '1', $value, false ) .' value="1"/>';
 				break;
 				default:
-					echo '<input type="'. esc_attr($field['input']) .'" name="' . esc_attr( $pm_key ) . '" value="' . esc_attr( $value ) . '" class="regular-text" />';
+					echo '<input type="'. esc_attr( $field['input'] ) .'" name="' . esc_attr( $pm_key ) . '" value="' . esc_attr( $value ) . '" class="regular-text" />';
 			break;
 			} 
 
@@ -873,7 +877,7 @@ class CoAuthors_Guest_Authors
 						'key'      => 'ID',
 						'label'    => __( 'ID', 'co-authors-plus' ),
 						'group'    => 'hidden',
-						'input'	=> 'hidden',
+						'input'	   => 'hidden',
 					),
 				// Name
 				array(
@@ -903,7 +907,7 @@ class CoAuthors_Guest_Authors
 						'key'      => 'user_email',
 						'label'    => __( 'E-mail', 'co-authors-plus' ),
 						'group'    => 'contact-info',
-						'input'	=> 'email',
+						'input'	   => 'email',
 					),
 				array(
 						'key'      => 'linked_account',
@@ -914,7 +918,7 @@ class CoAuthors_Guest_Authors
 						'key'      => 'website',
 						'label'    => __( 'Website', 'co-authors-plus' ),
 						'group'    => 'contact-info',
-						'input'	=> 'url',
+						'input'	   => 'url',
 					),
 				array(
 						'key'      => 'aim',


### PR DESCRIPTION
Right now, for any of the existing groups in a guest author's profile, the only allowed input type is text, as hardcoded by `metabox_manage_guest_author_slug()` and `metabox_manage_guest_author_name()`.

You can get around this by create a new group and metabox, but that is more work than should be needed. 

I propose, as my pull request commits state, 3 Changes to make this happen.
1). Add an optional attribute to the fields, to allow it to hold the requested input type. Anything without this set, would fall back to text. 
2). A change in how the form is echoed out, so that fields like checkbox can act and look differently (Checkbox should not have the class of "regular-text"). My method is a switch statement, but it could be a filter that is/can be applied to a entry based on its name and field input type. 

3) A Filter, to allow easy overriding of the default on a per field basis.

4) Optional: change email's input type to 'email', website to 'url', and apply input type 'hidden' to the ID field. 

Below is an example of what's possible with my code:
![co-authors-plus-improved-guest-author-profiles](https://f.cloud.github.com/assets/138439/1766823/b2f431c2-674a-11e3-9921-334a1e9f215b.PNG)
