### PR TITLE
Brings single author links into hCard compliance

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -227,23 +227,24 @@ function coauthors_posts_links( $between = null, $betweenLast = null, $before = 
  */
 function coauthors_posts_links_single( $author ) {
 	$args = array(
-		'span_class' => 'author vcard',
+		'before_html' => '',
 		'href' => get_author_posts_url( $author->ID, $author->user_nicename ),
 		'rel' => 'author',
 		'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), get_the_author() ),
-		'link_class' => 'url fn',
+		'class' => 'url fn',
 		'text' => get_the_author(),
+		'after_html' => ''
 	);
 	$args = apply_filters( 'coauthors_posts_link', $args, $author );
-	return sprintf(
-			'<span class="%1$s"><a href="%2$s" title="%3$s" class="%4$s" rel="%5$s">%6$s</a></span>',
-			esc_attr( $args['span_class'] ),
+	$single_link = sprintf(
+			'<a href="%1$s" title="%2$s" class="%3$s" rel="%4$s">%5$s</a>',
 			esc_url( $args['href'] ),
 			esc_attr( $args['title'] ),
-			esc_attr( $args['link_class'] ),
+			esc_attr( $args['class'] ),
 			esc_attr( $args['rel'] ),
 			esc_html( $args['text'] )
 	);
+	return $args['before_html'] . $single_link . $args['after_html'];
 }
 
 /**


### PR DESCRIPTION
Search engines now look for structured data on pages (lacking that data is considered an error by Webmaster Tools). These changes bring Co-Authors-Plus's output in-line with the hAtom hCard microformat for authorship.

There is one downside with this configuration. Strictly speaking the `fn` tag in the link's class designates formatted/full name, which may not be the case depending on the user's configuration. The `fn` tag is required and the output of `get_the_author` may not be full, but it is highly likely to be, at least, formatted, so I feel safe in this setup. Further, this can be filtered by the user if the specific use is out of standard.

For reference:
More info about Google's use of structured data for rich snippets is at https://support.google.com/webmasters/answer/1093493?hl=en

The hAtom spec is at http://microformats.org/wiki/hatom

The hCard spec is at http://microformats.org/wiki/hcard
