### PR TITLE
Allow multiple default co-authors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -318,7 +318,7 @@ class coauthors_plus {
 			// logged in user, so long as force_guest_authors is false. If force_guest_authors = true, we are
 			// OK with having an empty authoring box.
 			if ( !$coauthors_plus->force_guest_authors && empty( $coauthors ) ) {
-				if(is_array($default_user)) {
+				if( is_array( $default_user ) ) {
 					$coauthors = $default_user;
 				} else {
 					$coauthors[] = $default_user;


### PR DESCRIPTION
The `coauthors_default_author` filter worked great for a single default author.

This change allows multiple co-authors to be set in that filter.
