### PR TITLE
Add correct context to an `_x()` call

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -94,7 +94,7 @@ class CoAuthors_Guest_Authors
 				'labels' => array(
 						'name' => $this->labels['plural'],
 						'singular_name' => $this->labels['singular'],
-						'add_new' => _x( 'Add New', 'co-authors-plus' ),
+						'add_new' => _x( 'Add New', 'guest author', 'co-authors-plus' ),
 						'all_items' => $this->labels['all_items'],
 						'add_new_item' => $this->labels['add_new_item'],
 						'edit_item' => $this->labels['edit_item'],


### PR DESCRIPTION
There's a call to `_x()` when building the guest author post type labels that doesn't pass context, meaning the label is not translatable.
