### PR TITLE
Don't show no-js box when post is first created

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -334,7 +334,7 @@ class coauthors_plus {
 		$count = 0;
 		if( !empty( $coauthors ) ) :
 			?>
-			<div id="coauthors-readonly" class="hide-if-js1">
+			<div id="coauthors-readonly" class="hide-if-js">
 				<ul>
 				<?php
 				foreach( $coauthors as $coauthor ) :


### PR DESCRIPTION
Fix a HTML typo that resulted in the no-js author box appearing when the post
was first created
