### PR TITLE
Fix author feed link

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1337,7 +1337,7 @@ class coauthors_plus {
 		// Get author, then check if author is guest-author because 
 		// that's the only type that will need to be adjusted
 		$author = get_queried_object();
-		if ( empty ( $author ) || 'guest-author' != $author['type'] ) {
+		if ( empty ( $author ) || 'guest-author' != $author->type ) {
 			return $feed_link;
 		}
 


### PR DESCRIPTION
On the author page it was showing a random feed url this fixes it by making it use the feed url for the guest author.
