### PR TITLE
Avoiding redefinition of core function wp_notify_moderator

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -109,7 +109,7 @@ class coauthors_plus {
 		add_filter( 'jetpack_open_graph_tags', array( $this, 'filter_jetpack_open_graph_tags' ), 10, 2 );
 		
 		// Filter to send comment moderation notification e-mail to multiple authors
-		add_filter( 'comment_moderation_recipients', 'filter_comment_moderation_email_recipients' );
+		add_filter( 'comment_moderation_recipients', 'cap_filter_comment_moderation_email_recipients', 10, 2 );
 
 	}
 
@@ -1472,16 +1472,17 @@ endif;
  * Filter array of moderation notification email addresses
  * 
  * @param array $recipients
+ * @param int $comment_id
  * @return array
  */
-function filter_comment_moderation_email_recipients( $recipients ) {
-	global $post;
-
-	if ( isset($post->ID) ) {
-		$coauthors = get_coauthors( $post->ID );
+function cap_filter_comment_moderation_email_recipients( $recipients, $comment_id ) {
+	$comment = get_comment( $comment_id );
+	$post_id = $comment->comment_post_ID;
+	
+	if ( isset($post_id) ) {
+		$coauthors = get_coauthors( $post_id );
 		foreach ( $coauthors as $user ) {
-			// "edit_comment" capability == "edit_post" capability
-			if ( user_can($user->ID, 'edit_post', $post->ID) && !empty($user->user_email) )
+			if ( !empty($user->user_email) )
 				$extra_recipients[] = $user->user_email;
 		}
 


### PR DESCRIPTION
This patch is to replace the redefinition of a core function by adding a filter for comment notification recipients.
Instead of redefining wp_modify_moderator() only to be able to get the co-authors e-mails, I've added a filter to the plugin, "filter_comment_moderation_email_recipients", which filters the comment moderation recipient list and adds the co-authors e-mails.

On WP 3.7.0, a new filter was applied to the core wp_modify_moderator() function ("comment_moderation_recipients"), and the lack of the application of this filter on the modified plugin version was preventing other plugins that use "comment_moderation_recipients" from working.

Probably the same approach can be used on the wp_notify_postauthor() function on this plugin on a future work.
