### PR TITLE
Load CoAuthors_Template_Filters into a global

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -134,7 +134,8 @@ class coauthors_plus {
 
 		// Maybe automatically apply our template tags
 		if ( apply_filters( 'coauthors_auto_apply_template_tags', false ) ) {
-			new CoAuthors_Template_Filters;
+			global $coauthors_plus_template_filters;
+			$coauthors_plus_template_filters = new CoAuthors_Template_Filters;
 		}
 
 	}


### PR DESCRIPTION
Adds consistency with the existing $coauthors_plus global and ease of removing the filters as needed.
