### PR TITLE
Guest author links should be filterable

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -149,7 +149,7 @@ class CoAuthors_Guest_Authors
 		global $post;
 
 		$guest_author = $this->get_guest_author_by( 'ID', $post->ID );
-		$guest_author_link = $this->filter_author_link( '', $guest_author->ID, $guest_author->user_nicename );
+		$guest_author_link = get_author_posts_url( $guest_author->ID, $guest_author->user_nicename );
 
 		$messages[$this->post_type] = array(
 			0 => '', // Unused. Messages start at index 1.

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1319,23 +1319,14 @@ class CoAuthors_Guest_Authors
 
 		// If we're using this at the top of the loop on author.php,
 		// our queried object should be set correctly
-		if ( !$author_nicename && is_author() && get_queried_object() )
+		if ( !$author_nicename && is_author() && get_queried_object() ) {
 			$author_nicename = get_queried_object()->user_nicename;
 
-		if ( empty($link) ) {
-			$link = add_query_arg( 'author_name', $author_nicename, home_url() );
-		} else {
-			global $wp_rewrite;
-			$link = $wp_rewrite->get_author_permastruct();
-			if ( $link ) {
-				$link = str_replace('%author%', $author_nicename, $link);
-				$link = home_url( user_trailingslashit( $link ) );
-			} else {
-				$link = add_query_arg( 'author_name', $author_nicename, home_url() );
-			}
+			// Use get_author_posts_url() so we have access to the author_link filter
+			$link = get_author_posts_url( $author_id, $author_nicename );
 		}
-		return $link;
 
+		return $link;
 	}
 
 	/**


### PR DESCRIPTION
With two small, but significant, exceptions, the code in `CoAuthors_Guest_Authors:filter_author_link()` is the same as the function it's trying to filter, `get_author_posts_url()`.

The first difference, is where the `user_nicename` is set for guest authors. Without it, guest author links aren't appropriately created.

The other difference, is the lack of the `author_link` filter. Anyone trying to manipulate links returned by `get_author_posts_url()` or use a non-standard rewrite tag in WP_Rewrite::author_base, will find that they're filters fail. Found this while try to track down an issue a user was having with my [Edit Author Slug](https://github.com/thebrandonallen/edit-author-slug/commits/peter-debug) plugin.

This pull request keeps us DRY, and maintains the `author_link` filter on guest authors.