### PR TITLE
Fixed JS error $coauthors_loading undefined error

### DIFF
--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -420,6 +420,7 @@ jQuery(document).ready(function () {
 	
 		// Create new author-suggest and append it to a new row
 		var newCO = coauthors_create_autosuggest('', false);
+		var $coauthors_loading;
 		coauthors_add_to_table(newCO);
 	
 		$coauthors_loading = jQuery('#ajax-loading').clone().attr('id', 'coauthors-loading');


### PR DESCRIPTION
There is a $coauthors_loading variable undefined JavaScript error in the Posts->All
posts page, while searching / filtering as Authors. This is fixed by adding var $coauthors_loading; statement before using, defining the variable.