### PR TITLE
Bring back strict equality checks in guest author lookup caching

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -779,7 +779,7 @@ class CoAuthors_Guest_Authors
 
 		$cache_key = $this->get_cache_key( $key, $value );
 
-		if ( false == $force && false != ( $retval = wp_cache_get( $cache_key, self::$cache_group ) ) ) {
+		if ( false == $force && false !== ( $retval = wp_cache_get( $cache_key, self::$cache_group ) ) ) {
 			// Properly catch our false condition cache
 			if ( is_object( $retval ) )
 				return $retval;


### PR DESCRIPTION
The non-strict equality check causes negative cache entries to always
hit the database and re-set themselves.

This reverts commit 6ad24ff7f853f7c6df613456f02051d711456a65.

See #218

Fixes #219
