### PR TITLE
A few bugfixes

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1199,10 +1199,10 @@ class coauthors_plus {
 
 		$current_user = wp_get_current_user();
 		if ( 'publish' == get_post_status( $post_id ) && 
-			( isset( $obj->cap->edit_published_posts ) && ! empty( $current_user->allcaps[$obj->cap->edit_published_posts] ) ) )
+			( isset( $obj->cap->edit_published_posts ) && empty( $current_user->allcaps[$obj->cap->edit_published_posts] ) ) )
 			$allcaps[$obj->cap->edit_published_posts] = true;
 		elseif ( 'private' == get_post_status( $post_id ) && 
-			( isset( $obj->cap->edit_private_posts ) && ! empty( $current_user->allcaps[$obj->cap->edit_private_posts] ) ) )
+			( isset( $obj->cap->edit_private_posts ) && empty( $current_user->allcaps[$obj->cap->edit_private_posts] ) ) )
 			$allcaps[$obj->cap->edit_private_posts] = true;
 
 		$allcaps[$obj->cap->edit_others_posts] = true;


### PR DESCRIPTION
These bugfixes should take care of issues that people are probably having with this plugin.
The first takes care of issues where posts still won't show up under 'Mine' in the posts list if they are marked private and your co-author doesn't have read_private_posts capability. This is because that type of query has a where clause in which post_author is compared twice, not just once. We should just replace all instances of the post_author comparison, not just the first.
The second really is just correcting some logic. We should add the capability if the user doesn't have it already, not re-add it if they already do. The difference between the ! empty vs. empty.
