### PR TITLE
Fix #215 "Cannot remove the last author once post is saved"

### DIFF
--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -16,10 +16,6 @@ jQuery(document).ready(function () {
 		var $coauthor_row = jQuery(elem).closest('.coauthor-row');
 		$coauthor_row.remove();
 
-		// Hide the delete button when there's only one Co-Author
-		if ( jQuery( '#coauthors-list .coauthor-row .coauthor-tag' ).length <= 1 )
-			jQuery( '#coauthors-list .coauthor-row .coauthors-author-options' ).addClass('hidden');
-		
 		return true;
 	}
 	


### PR DESCRIPTION
Problem: "If you assign a co-author to a post, save it, and reload the page, the Remove link disappears. You can no longer remove that author."

Fix: Remove the comment // Hide the delete button if there's only one co-author and the two lines of code that follow. The lines in question hide the "X" button. Removing those lines means the X button stays, allowing users to remove the last author.
