### PR TITLE
preg_replace in where should replace all, not just first instance

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -683,7 +683,7 @@ class coauthors_plus {
 				}
 				$terms_implode = rtrim( $terms_implode, ' OR' );
 				$this->having_terms = rtrim( $this->having_terms, ' OR' );
-				$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(\d+))/', '(' . $maybe_both_query . ' ' . $terms_implode . ')', $where, 1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+				$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(\d+))/', '(' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
 			}
 		}
 		return $where;


### PR DESCRIPTION
Takes care of issues where posts still won't show up under **Mine** in the posts list if they are marked private and your co-author doesn't have `read_private_posts` capability already. This is because that type of query has a where clause in which `post_author` is compared more than just once. We should just replace all instances of the `post_author` comparison, not just the first.