### PR TITLE
Give user capabilty if they don't have it

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1282,10 +1282,10 @@ class coauthors_plus {
 
 		$current_user = wp_get_current_user();
 		if ( 'publish' == get_post_status( $post_id ) &&
-			( isset( $obj->cap->edit_published_posts ) && ! empty( $current_user->allcaps[ $obj->cap->edit_published_posts ] ) ) ) {
+			( isset( $obj->cap->edit_published_posts ) && empty( $current_user->allcaps[ $obj->cap->edit_published_posts ] ) ) ) {
 			$allcaps[ $obj->cap->edit_published_posts ] = true;
 		} elseif ( 'private' == get_post_status( $post_id ) &&
-			( isset( $obj->cap->edit_private_posts ) && ! empty( $current_user->allcaps[ $obj->cap->edit_private_posts ] ) ) ) {
+			( isset( $obj->cap->edit_private_posts ) && empty( $current_user->allcaps[ $obj->cap->edit_private_posts ] ) ) ) {
 			$allcaps[ $obj->cap->edit_private_posts ] = true;
 		}
 


### PR DESCRIPTION
We should add the capability if the user *does not* have it already (`empty`), 
not re-add it if they already do (`! empty`).