### PR TITLE
Introduce a `coauthors_display_name` filter

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -253,9 +253,9 @@ function coauthors_posts_links_single( $author ) {
 		'before_html' => '',
 		'href' => get_author_posts_url( $author->ID, $author->user_nicename ),
 		'rel' => 'author',
-		'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), $author->display_name ),
+		'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), apply_filters( 'coauthors_display_name', $author->display_name, $author ) ),
 		'class' => 'author url fn',
-		'text' => $author->display_name,
+		'text' => apply_filters( 'coauthors_display_name', $author->display_name, $author ),
 		'after_html' => '',
 	);
 	$args = apply_filters( 'coauthors_posts_link', $args, $author );


### PR DESCRIPTION
Introduce a `coauthors_display_name` filter so the final display name output for each author can be filtered. Passes the `$author` object for context.