### PR TITLE
Fix get_guest_author_by returning empty objects.

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -831,7 +831,7 @@ class CoAuthors_Guest_Authors
 		switch ( $key ) {
 			case 'ID':
 			case 'id':
-				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID=%d", $value );
+				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID=%d AND post_type = %s", $value, $this->post_type );
 				$post_id = $wpdb->get_var( $query );
 				if ( empty( $post_id ) ) {
 					$post_id = '0';


### PR DESCRIPTION
When querying by ID, get_guest_author_by only looks for whether a post_ID exists, this also adds a post_type check to ensure it's only checking within the 'guest-author' post type.

Fixes #212.