### PR TITLE
Fixing undefined class variable

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -101,8 +101,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 			$this->stop_the_insanity();
 
-			$this->args['paged']++;
-			$posts = new WP_Query( $this->args );
+			$args['paged']++;
+			$posts = new WP_Query( $args );
 		}
 		WP_CLI::line( "Updating author terms with new counts" );
 		foreach ( $authors as $author ) {


### PR DESCRIPTION
The wp-cli command wasn't working because of an undefined class variable. I replaced it with the local variable instead and it's working again as usual.