### PR TITLE
prevent errors caused by accessing a post that is not a guest author

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -147,26 +147,27 @@ class CoAuthors_Guest_Authors
 	 */
 	function filter_post_updated_messages( $messages ) {
 		global $post;
+		if( $post->post_type === $this->post_type ) {
+			$guest_author = $this->get_guest_author_by( 'ID', $post->ID );
+			$guest_author_link = $this->filter_author_link( '', $guest_author->ID, $guest_author->user_nicename );
 
-		$guest_author = $this->get_guest_author_by( 'ID', $post->ID );
-		$guest_author_link = $this->filter_author_link( '', $guest_author->ID, $guest_author->user_nicename );
-
-		$messages[ $this->post_type ] = array(
-			0 => '', // Unused. Messages start at index 1.
-			1 => sprintf( __( 'Guest author updated. <a href="%s">View profile</a>', 'co-authors-plus' ), esc_url( $guest_author_link ) ),
-			2 => __( 'Custom field updated.', 'co-authors-plus' ),
-			3 => __( 'Custom field deleted.', 'co-authors-plus' ),
-			4 => __( 'Guest author updated.', 'co-authors-plus' ),
-			/* translators: %s: date and time of the revision */
-			5 => isset($_GET['revision']) ? sprintf( __( 'Guest author restored to revision from %s', 'co-authors-plus' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
-			6 => sprintf( __( 'Guest author updated. <a href="%s">View profile</a>', 'co-authors-plus' ), esc_url( $guest_author_link ) ),
-			7 => __( 'Guest author saved.', 'co-authors-plus' ),
-			8 => sprintf( __( 'Guest author submitted. <a target="_blank" href="%s">Preview profile</a>', 'co-authors-plus' ), esc_url( add_query_arg( 'preview', 'true', $guest_author_link ) ) ),
-			9 => sprintf( __( 'Guest author scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview profile</a>', 'co-authors-plus' ),
-			// translators: Publish box date format, see http://php.net/date
-			date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( $guest_author_link ) ),
-			10 => sprintf( __( 'Guest author updated. <a target="_blank" href="%s">Preview profile</a>', 'co-authors-plus' ), esc_url( add_query_arg( 'preview', 'true', $guest_author_link ) ) ),
-		);
+			$messages[ $this->post_type ] = array(
+				0 => '', // Unused. Messages start at index 1.
+				1 => sprintf( __( 'Guest author updated. <a href="%s">View profile</a>', 'co-authors-plus' ), esc_url( $guest_author_link ) ),
+				2 => __( 'Custom field updated.', 'co-authors-plus' ),
+				3 => __( 'Custom field deleted.', 'co-authors-plus' ),
+				4 => __( 'Guest author updated.', 'co-authors-plus' ),
+				/* translators: %s: date and time of the revision */
+				5 => isset($_GET['revision']) ? sprintf( __( 'Guest author restored to revision from %s', 'co-authors-plus' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+				6 => sprintf( __( 'Guest author updated. <a href="%s">View profile</a>', 'co-authors-plus' ), esc_url( $guest_author_link ) ),
+				7 => __( 'Guest author saved.', 'co-authors-plus' ),
+				8 => sprintf( __( 'Guest author submitted. <a target="_blank" href="%s">Preview profile</a>', 'co-authors-plus' ), esc_url( add_query_arg( 'preview', 'true', $guest_author_link ) ) ),
+				9 => sprintf( __( 'Guest author scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview profile</a>', 'co-authors-plus' ),
+				// translators: Publish box date format, see http://php.net/date
+				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ), esc_url( $guest_author_link ) ),
+				10 => sprintf( __( 'Guest author updated. <a target="_blank" href="%s">Preview profile</a>', 'co-authors-plus' ), esc_url( add_query_arg( 'preview', 'true', $guest_author_link ) ) ),
+			);
+		}
 		return $messages;
 	}
 


### PR DESCRIPTION
Getting errors on post edit pages for other post types since the global post isn't a guest-author.