### PR TITLE
Fixing failing wp_get_object_terms filter during bulk edit

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -901,11 +901,26 @@ class coauthors_plus {
 		$orderby = 'ORDER BY tr.term_order';
 		$order = 'ASC';
 		$object_ids = (int) $object_ids;
-		$query = $wpdb->prepare( "SELECT t.slug, t.term_id FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON tt.term_id = t.term_id INNER JOIN $wpdb->term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN (%s) AND tr.object_id IN (%s) $orderby $order", $taxonomies, $object_ids );
+		$query = $wpdb->prepare( "SELECT t.name, t.term_id, tt.term_taxonomy_id FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON tt.term_id = t.term_id INNER JOIN $wpdb->term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN (%s) AND tr.object_id IN (%s) $orderby $order", $this->coauthor_taxonomy, $object_ids );
 		$raw_coauthors = $wpdb->get_results( $query );
 		$terms = array();
 		foreach ( $raw_coauthors as $author ) {
-			$terms[] = $author->slug;
+			if ( true === is_array( $args ) && true === isset( $args['fields'] ) ) {
+				switch( $args['fields'] ) {
+					case 'names' :
+						$terms[] = $author->name;
+						break;
+					case 'tt_ids' :
+						$terms[] = $author->term_taxonomy_id;
+						break;
+					case 'all' :
+					default :
+						$terms[] = get_term( $author->term_id, $this->coauthor_taxonomy );
+						break;
+				}
+			} else {
+				$terms[] = get_term( $author->term_id, $this->coauthor_taxonomy );
+			}
 		}
 
 		return $terms;


### PR DESCRIPTION
The filter applied inside `wp_get_object_terms` triggered only during a `bulk_edit` REQUEST is failing from multiple reasons resulting in lost co authors plus data during said action.

First of all, the `$taxonomy` variable already contains sanitized string ('author') and thus is being double-quoted by `$wpdb->prepare` resulting in failing MySQL query. I'm fixing that by using `$this->coauthor_taxonomy` instead of `$taxonomy` variable.

Further the filter gets called multiple times during a request, but with different arguments - it's not always asking for a list of slugs (actually never). I'm fixinig it by switch which returns approapriate data in accordance with arguments passed to filter. This requires updating the query to select t.name instead of t.slug and extra tt.term_taxonomy_id.

fixes #282