### PR TITLE
use yoda condition in WP CLI

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -97,7 +97,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				$affected++;
 			}
 
-			if ( $count && $count % 500 == 0 ) {
+			if ( $count && 0 === $count % 500 ) {
 				$this->stop_the_insanity();
 				sleep( 1 );
 			}


### PR DESCRIPTION
This also address a strict equality check. It's safe, as `$count` is always an integer.