### PR TITLE
Moving coauthors_loading to global scope

### DIFF
--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -11,6 +11,8 @@ jQuery( document ).ready(function () {
 		return false;
 	};
 
+	var $coauthors_loading;
+
 	function coauthors_delete( elem ) {
 
 		var $coauthor_row = jQuery( elem ).closest( '.coauthor-row' );
@@ -332,7 +334,6 @@ jQuery( document ).ready(function () {
 
 		// Create new author-suggest and append it to a new row
 		var newCO = coauthors_create_autosuggest( '', false );
-		var $coauthors_loading;
 		coauthors_add_to_table( newCO );
 
 		$coauthors_loading = jQuery( '#ajax-loading' ).clone().attr( 'id', 'coauthors-loading' );


### PR DESCRIPTION
coauthors_loading is being referenced in `show_loading`, `hide_loading` and `move_loading` but it's being declared in `coauthors_initialize`. 

It needs to be defined globally in the script file or it will not exist in the other functions.