### PR TITLE
add missing spaces in german translation

### DIFF
--- a/languages/co-authors-plus-de_DE.po
+++ b/languages/co-authors-plus-de_DE.po
@@ -473,7 +473,7 @@ msgstr "ID"
 
 #: template-tags.php:136
 msgid " and "
-msgstr "und"
+msgstr " und "
 
 #: co-authors-plus.php:342
 msgid "<strong>Note:</strong> To edit post authors, please enable javascript or use a javascript-capable browser"


### PR DESCRIPTION
The "and" string (line 475) for the front end contains white space. This where missing in the German translation.