### PR TITLE
Updated delete_user_action function to fix issues #268 and #312

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -3,7 +3,7 @@
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
 Description: Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
-Version: 3.2
+Version: 3.2.1
 Author: Mohammad Jangda, Daniel Bachhuber, Automattic
 Copyright: 2008-2015 Shared and distributed between Mohammad Jangda, Daniel Bachhuber, Weston Ruter
 
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 */
 
-define( 'COAUTHORS_PLUS_VERSION', '3.1.2' );
+define( 'COAUTHORS_PLUS_VERSION', '3.2.1' );
 
 require_once( dirname( __FILE__ ) . '/template-tags.php' );
 require_once( dirname( __FILE__ ) . '/deprecated.php' );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -3,7 +3,7 @@
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
 Description: Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
-Version: 3.1.2
+Version: 3.2
 Author: Mohammad Jangda, Daniel Bachhuber, Automattic
 Copyright: 2008-2015 Shared and distributed between Mohammad Jangda, Daniel Bachhuber, Weston Ruter
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -676,7 +676,7 @@ class CoAuthors_Guest_Authors
 			$pm_key = $this->get_post_meta_key( $field['key'] );
 			$value = get_post_meta( $post->ID, $pm_key, true );
 			echo '<tr><th>';
-			echo '<label for="' . esc_attr( $pm_key . '">' ) . esc_html( $field['label'] ) . '</label>';
+			echo '<label for="' . esc_attr( $pm_key ) . '">' . esc_html( $field['label'] ) . '</label>';
 			echo '</th><td>';
 			echo '<textarea style="width:300px;margin-bottom:6px;" name="' . esc_attr( $pm_key ) . '">' . esc_textarea( $value ) . '</textarea>';
 			echo '</td></tr>';

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: batmoo, danielbachhuber, automattic
 Tags: authors, users, multiple authors, coauthors, multi-author, publishing
 Tested up to: 4.5.2
 Requires at least: 4.1
-Stable tag: 3.2
+Stable tag: 3.2.1
 
 Assign multiple bylines to posts, pages, and custom post types via a search-as-you-type input box
 
@@ -57,14 +57,15 @@ Bug fixes and minor enhancements
 
 == Changelog ==
 
-= 3.2 =
+= 3.2.1 (May 16, 2016) =
+* Hotfix for broken Guest Author bio metabox (props JS Morisset)
+
+= 3.2 (May 12, 2016) =
 Various minor bug and security fixes
 
 = 3.1.2 (Aug. 31, 2015) =
 * Minor bug fixes and coding standards changes.
 * The author's display name is now filtered through the_author in coauthors_posts_links_single()
-
-= ??? (??? ?? ????) =
 * New Russian and Ukrainian translations, courtesy of [Jurko Chervony](http://skinik.name/).
 
 = 3.1.1 (Mar. 20, 2014) =

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Co-Authors Plus ===
 Contributors: batmoo, danielbachhuber, automattic
 Tags: authors, users, multiple authors, coauthors, multi-author, publishing
-Tested up to: 4.5
+Tested up to: 4.5.2
 Requires at least: 4.1
-Stable tag: 3.1.1
+Stable tag: 3.2
 
 Assign multiple bylines to posts, pages, and custom post types via a search-as-you-type input box
 
@@ -56,6 +56,9 @@ Bug fixes and the ability to automatically add co-authors to your feeds.
 Bug fixes and minor enhancements
 
 == Changelog ==
+
+= 3.2 =
+Various minor bug and security fixes
 
 = 3.1.2 (Aug. 31, 2015) =
 * Minor bug fixes and coding standards changes.

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Auto-apply Co-Authors Plus template tags on themes that are properly using the_author()
+ * and the_author_posts_link()
+ * Auto-apply Co-Authors Plus in oembed endpoint
+ */
+$wpcom_coauthors_plus_auto_apply_themes = array(
+		'premium/portfolio',
+		'premium/zuki',
+		'pub/editor',
+	);
+if ( in_array( get_option( 'template' ), $wpcom_coauthors_plus_auto_apply_themes )
+	|| ( true === defined( 'WPCOM_VIP_IS_OEMBED' )
+		&& true === constant( 'WPCOM_VIP_IS_OEMBED' )
+		&& true === apply_filters( 'wpcom_vip_coauthors_replace_oembed', false, 'author_name' )	 
+	) ) {
+	add_filter( 'coauthors_auto_apply_template_tags', '__return_true' );
+}
+
+/**
+ * If Co-Authors Plus is enabled on an Enterprise site and hasn't yet been integrated with the theme
+ * show an admin notice
+ */
+if ( function_exists( 'Enterprise' ) ) {
+	if ( Enterprise()->is_enabled() && ! in_array( get_option( 'template' ), $wpcom_coauthors_plus_auto_apply_themes ) )
+		add_action( 'admin_notices', function() {
+
+			// Allow this to be short-circuted in mu-plugins
+			if ( ! apply_filters( 'wpcom_coauthors_show_enterprise_notice', true ) )
+				return;
+
+			echo '<div class="error"><p>' . __( "Co-Authors Plus isn't yet integrated with your theme. Please contact support to make it happen." ) . '</p></div>';
+		} );
+}
+
+/**
+ * We want to let Elasticsearch know that it should search the author taxonomy's name as a search field
+ * See: https://elasticsearchp2.wordpress.com/2015/01/08/in-36757-z-vanguard-says-they/
+ *
+ * @param $es_wp_query_args The ElasticSearch Query Parameters
+ * @param $query
+ *
+ * @return mixed
+ */
+function co_author_plus_es_support( $es_wp_query_args, $query ){
+	if ( empty( $es_wp_query_args['query_fields'] ) ) {
+		$es_wp_query_args['query_fields'] = array( 'title', 'content', 'author', 'tag', 'category' );
+	}
+
+	// Search CAP author names
+	$es_wp_query_args['query_fields'][] = 'taxonomy.author.name';
+
+	// Filter based on CAP names
+	if ( !empty( $query->query['author'] ) ) {
+		$es_wp_query_args['terms']['author'] = 'cap-' . $query->query['author'];
+	}
+
+	return $es_wp_query_args;
+}
+add_filter('wpcom_elasticsearch_wp_query_args', 'co_author_plus_es_support', 10, 2 );
+
+
+/**
+ * Change the post authors in the subscription email.
+ *
+ * Creates an array of authors, that will be used later.
+ *
+ * @param $author WP_User the original author
+ * @param $post_id
+ *
+ * @return array of coauthors
+ */
+add_filter( 'wpcom_subscriber_email_author', function( $author, $post_id ) {
+
+	$authors = get_coauthors( $post_id );
+	return $authors;
+
+}, 10, 2 );
+
+/**
+ * Change the author avatar url. If there are multiple authors, link the avatar to the post.
+ *
+ * @param $author_url
+ * @param $post_id
+ * @param $authors
+ *
+ * @return string with new author url.
+ */
+add_filter( 'wpcom_subscriber_email_author_url', function( $author_url, $post_id, $authors ) {
+	if( is_array( $authors ) ) {
+		if ( count( $authors ) > 1 ) {
+			return get_permalink( $post_id );
+		}
+
+		return get_author_posts_url( $authors[0]->ID, $authors[0]->user_nicename );
+	}
+
+	return get_author_posts_url( $authors->ID, $authors->user_nicename );
+}, 10, 3);
+
+/**
+ * Change the avatar to be the avatar of the first author
+ *
+ * @param $author_avatar
+ * @param $post_id
+ * @param $authors
+ *
+ * @return string with the html for the avatar
+ */
+add_filter( 'wpcom_subscriber_email_author_avatar', function( $author_avatar, $post_id, $authors ) {
+	if( is_array( $authors ) )
+		return coauthors_get_avatar( $authors[0], 50 );
+
+	return coauthors_get_avatar( $authors, 50 );
+}, 10, 3);
+
+/**
+ * Changes the author byline in the subscription email to include all the authors of the post
+ *
+ * @param $author_byline
+ * @param $post_id
+ * @param $authors
+ *
+ * @return string with the byline html
+ */
+add_filter( 'wpcom_subscriber_email_author_byline_html', function( $author_byline, $post_id, $authors ) {
+	// Check if $authors is a valid array
+	if( ! is_array( $authors ) ) {
+		$authors = array( $authors );
+	}
+
+	$byline = 'by ';
+	foreach( $authors as $author ) {
+		$byline .= '<a href="' . esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ) . '" style="color: #888 !important;">' . esc_html( $author->display_name ) . '</a>';
+		if ( $author != end( $authors ) ) {
+			$byline .= ', ';
+		}
+	}
+
+	return $byline;
+}, 10, 3);
+
+/**
+ * Change the meta information to include all the authors
+ *
+ * @param $meta
+ * @param $post_id
+ * @param $authors
+ *
+ * @return array with new meta information
+ */
+add_filter( 'wpcom_subscriber_email_meta', function( $meta, $post_id, $authors ) {
+	// Check if $authors is a valid array
+	if( ! is_array( $authors ) ) {
+		$authors = array( $authors );
+	}
+
+	$author_meta = '';
+	foreach( $authors as $author ) {
+		$author_meta .= '<strong><a href="' . esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ) . '">' . esc_html( $author->display_name ) . '</a></strong>';
+
+		if ( $author != end( $authors ) ) {
+			$author_meta .= ', ';
+		}
+	}
+
+	// Only the first entry of meta includes the author listing
+	$meta[0] = $author_meta;
+
+	return $meta;
+}, 10, 3);
+
+/**
+ * Change the author information in the text-only subscription email.
+ *
+ * @param $author
+ * @param $post_id
+ *
+ * @returns string with the authors
+ */
+add_filter( 'wpcom_subscriber_text_email_author', function( $author, $post_id ) {
+	// Check if $authors is a valid array
+	$authors = get_coauthors( $post_id );
+
+	$author_text = '';
+	foreach( $authors as $author ) {
+		$author_text .= esc_html( $author->display_name );
+		if ( $author != end( $authors ) ) {
+			$author_text .= ', ';
+		}
+	}
+
+	return $author_text;
+}, 10, 2);
+
+/**
+ * Replace author_url in oembed endpoint response
+ * Since the oembed specification does not allow multiple urls, we'll go with the first coauthor
+ *
+ * The function is meant as a filter for `get_author_posts_url` function, which it is using as well
+ * Recursion is prevented by a simple check agains original attributes passed to the funciton. That
+ * also prevents execution in case the only coauthor is real author.
+ *
+ * This function is hooked only to oembed endpoint and it should stay that way
+ */
+
+function wpcom_vip_cap_replace_author_link( $link, $author_id, $author_nicename ) {
+	
+	//get coauthors and iterate to the first one
+	//in case there are no coauthors, the Iterator returns current author
+	$i = new CoAuthorsIterator();
+	$i->iterate();
+
+	//check if the current $author_id and $author_nicename is not the same as the first coauthor
+	if ( $i->current_author->ID !== $author_id || $i->current_author->user_nicename !== $author_nicename ) {
+		
+		//alter the author_url
+		$link = get_author_posts_url( $i->current_author->ID, $i->current_author->user_nicename );
+
+	}
+
+	return $link;
+}
+//Hook the above callback only on oembed endpoint reply
+if ( true === defined( 'WPCOM_VIP_IS_OEMBED' ) && true === constant( 'WPCOM_VIP_IS_OEMBED' ) && true === apply_filters( 'wpcom_vip_coauthors_replace_oembed', false, 'author_url' ) ) {
+	add_filter( 'author_link', 'wpcom_vip_cap_replace_author_link', 99, 3 );
+}


### PR DESCRIPTION
I've updated the delete_user_action to correct two issues (#268 and #312).

To fix #268 I've pulled the coauthor_term to utilize it's term_id in the wp_delete_term so as to properly delete the author term. Previously was using the user_login which does nothing. To reproduce the original issue you can delete a coauthor through the user_delete mechanism, then if you add a user with the exact same username they'll show up again on the post as a coauthor. This fix fully removes the relation to the post.

To fix #312 I've updated the posts lookup from the broken sql statement to a get_posts using the tax_query. Previously delete user would only reassign if the deleted user was the primary author as they'd be set as post_author, any secondary authors were overlooked. Now by using the get_posts and tax_query we cover all bases and properly reassign ALL posts/cpt/etc. to the reassign user.

Thoughts/Feedback? Happy to discuss.
Cheers
