### PR TITLE
improved search results for backend suggestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,4 @@ lint:
 
 phpunit:
 	phpunit
+

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1122,12 +1122,24 @@ class coauthors_plus {
 		}
 
 		// Get the co-author objects
+		$wp_users = $found_users; // We keep a copy of the found user matching the searched string
 		$found_users = array();
 		foreach ( $found_terms as $found_term ) {
 			$found_user = $this->get_coauthor_by( 'user_nicename', $found_term->slug );
 			if ( ! empty( $found_user ) ) {
 				$found_users[ $found_user->user_login ] = $found_user;
 			}
+		}
+
+		/**
+		 * We now transform WP_Users to coauthor_objects so that we can use them to fetch against roles.
+		 * Doing this we will have a more wide result set.
+		 * @var WP_User $wpUser
+		 */
+		foreach ($wp_users as $wpUser) {
+			$found_user = $this->get_coauthor_by('user_nicename' , $wpUser->user_nicename);
+			if ( !empty( $found_user ) )
+				$found_users[$found_user->user_login] = $found_user;
 		}
 
 		// Allow users to always filter out certain users if needed (e.g. administrators)

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1152,7 +1152,7 @@ class coauthors_plus {
 				unset( $found_users[ $key ] );
 			}
 		}
-		return (array) $found_users;
+		return (array) array_slice($found_users,0,10);
 	}
 
 	/**

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -1,5 +1,7 @@
 jQuery( document ).ready(function () {
 
+    var $coauthors_loading;
+    $coauthors_loading = jQuery( '#ajax-loading' ).clone().attr( 'id', 'coauthors-loading' );
 	/*
 	 * Click handler for the delete button
 	 * @param event
@@ -169,7 +171,8 @@ jQuery( document ).ready(function () {
 			})
 			.appendTo( $coauthors_div )
 			.suggest( coAuthorsPlus_ajax_suggest_link, {
-				onSelect: coauthors_autosuggest_select
+				onSelect: coauthors_autosuggest_select,
+                delay: 500
 			})
 			.keydown( coauthors_autosuggest_keydown )
 			;
@@ -378,6 +381,7 @@ jQuery( document ).ready(function () {
 		if ( settings.url.indexOf( coAuthorsPlus_ajax_suggest_link ) != -1 )
 			hide_loading();
 	});
+
 
 	if ( 'post-php' == adminpage || 'post-new-php' == adminpage ) {
 		var $post_coauthor_logins = jQuery( 'input[name="coauthors[]"]' );

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -720,6 +720,7 @@ class CoAuthors_Guest_Authors
 
 		// Guest authors can't be created with the same user_login as a user
 		$user_nicename = str_replace( 'cap-', '', $slug );
+		$user_nicename = str_replace( 'cap2-', '', $user_nicename );
 		$user = get_user_by( 'slug', $user_nicename );
 		if ( $user
 			&& is_user_member_of_blog( $user->ID, get_current_blog_id() )
@@ -860,6 +861,7 @@ class CoAuthors_Guest_Authors
 				// Ensure we aren't doing the lookup by the prefixed value
 				if ( 'user_login' == $key ) {
 					$value = preg_replace( '#^cap\-#', '', $value );
+					$value = preg_replace( '#^cap2\-#', '', $value );
 				}
 				$query = $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s AND meta_value=%s;", $this->get_post_meta_key( $key ), $value );
 				$post_id = $wpdb->get_var( $query );
@@ -1032,6 +1034,17 @@ class CoAuthors_Guest_Authors
 		if ( 0 !== stripos( $key, 'cap-' ) ) {
 			$key = 'cap-' . $key;
 		}
+        $capTerm = get_term_by("slug",$key,"author");
+        if( !$capTerm ){
+            $key = str_replace("cap-","",$key);
+            if ( 0 !== stripos( $key, 'cap2-' ) ) {
+                $key = 'cap2-' . $key;
+            }
+            $capTerm = get_term_by("slug",$key,"author");
+            if( $capTerm ){
+                return $key;
+            }
+        }
 
 		return $key;
 	}

--- a/template-tags.php
+++ b/template-tags.php
@@ -19,6 +19,7 @@ function get_coauthors( $post_id = 0 ) {
 		if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
 			foreach ( $coauthor_terms as $coauthor ) {
 				$coauthor_slug = preg_replace( '#^cap\-#', '', $coauthor->slug );
+				$coauthor_slug = preg_replace( '#^cap2\-#', '', $coauthor_slug );
 				$post_author = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
 				// In case the user has been deleted while plugin was deactivated
 				if ( ! empty( $post_author ) ) {

--- a/tmpquery.sql
+++ b/tmpquery.sql
@@ -1,0 +1,25 @@
+SELECT wp_posts.* 
+FROM wp_posts
+LEFT JOIN wp_term_relationships ON (wp_posts.ID = wp_term_relationships.object_id)
+LEFT JOIN wp_term_taxonomy ON ( wp_term_relationships.term_taxonomy_id = wp_term_taxonomy.term_taxonomy_id )
+WHERE 1=1
+  AND (
+        (wp_posts.post_author = 2 OR
+          (wp_term_taxonomy.taxonomy = 'author'  AND wp_term_taxonomy.term_id = '20940')  OR
+          (wp_term_taxonomy.taxonomy = 'author' AND wp_term_taxonomy.term_id = '906')
+        )
+      )
+  AND wp_posts.post_type = 'post'
+      AND (
+        wp_posts.post_status = 'publish'
+        OR wp_posts.post_status = 'future'
+        OR wp_posts.post_status = 'draft'
+        OR wp_posts.post_status = 'pending'
+        OR wp_posts.post_status = 'private'
+      )
+GROUP BY wp_posts.ID HAVING MAX(
+                    IF ( wp_term_taxonomy.taxonomy = 'author',
+                      IF (  wp_term_taxonomy.term_id = '20940' OR  wp_term_taxonomy.term_id = '906',2,1 )
+                      ,0 )
+                  ) <> 1
+ORDER BY wp_posts.post_date DESC


### PR DESCRIPTION
It looks like that backend suggestion searching is not fully accurate. For example we have multiple users that have "re" in their data but whenever we try to use that search string we just get a few results while as i said they should be many more.

In this commit i fetch the users you got to keep backwards compatibility and add them to the valid result set which will be filtered using the user capabilities.

Doing this in my environment (3.5k + users) provides a much more accurate results.
