### PR TITLE
Increase the typing detection timeout in the AJAX lookup to 1 second

### DIFF
--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -169,7 +169,8 @@ jQuery( document ).ready(function () {
 			})
 			.appendTo( $coauthors_div )
 			.suggest( coAuthorsPlus_ajax_suggest_link, {
-				onSelect: coauthors_autosuggest_select
+				onSelect: coauthors_autosuggest_select,
+				delay: 1000
 			})
 			.keydown( coauthors_autosuggest_keydown )
 			;


### PR DESCRIPTION
In response to https://github.com/Automattic/Co-Authors-Plus/issues/206#issuecomment-136903354, this boosts the typing detection threshold to 1000ms.
On the one hand this means that the suggestions won't appear magically as you type, but on the other hand it also means that poor server setups won't start to chug horribly if the user is a slow typist.

I'll admit that this could probably be fine-tuned; when I picked this value last year it was a high number that happened to solve the problem we were having at the time and there wasn't much scope for testing the limits of what would or wouldn't break the site.