### PR TITLE
Add basic support for the AMP plugin

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -30,6 +30,7 @@ require_once( dirname( __FILE__ ) . '/template-tags.php' );
 require_once( dirname( __FILE__ ) . '/deprecated.php' );
 
 require_once( dirname( __FILE__ ) . '/php/class-coauthors-template-filters.php' );
+require_once( dirname( __FILE__ ) . '/php/integrations/amp.php' );
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once( dirname( __FILE__ ) . '/php/class-wp-cli.php' );

--- a/php/integrations/amp.php
+++ b/php/integrations/amp.php
@@ -1,0 +1,29 @@
+<?php
+
+add_action( 'pre_amp_render_post', 'cap_add_amp_actions' );
+function cap_add_amp_actions() {
+	add_filter( 'amp_post_template_metadata', 'cap_update_amp_json_metadata', 10, 2 );
+	add_filter( 'amp_post_template_file', 'cap_set_amp_author_meta_template', 10, 3 );
+}
+
+function cap_update_amp_json_metadata( $metadata, $post ) {
+	$authors = get_coauthors( $post->ID );
+
+	$authors_json = array();
+	foreach ( $authors as $author ) {
+		$authors_json[] = array(
+			'@type' => 'Person',
+			'name' => $author->display_name,
+		);
+	}
+	$metadata['author'] = $authors_json;
+
+	return $metadata;
+}
+
+function cap_set_amp_author_meta_template( $file, $type, $post ) {
+	if ( 'meta-author' === $type ) {
+		$file = dirname( __FILE__ ) . '/amp/meta-author.php';
+	}
+	return $file;
+}

--- a/php/integrations/amp/meta-author.php
+++ b/php/integrations/amp/meta-author.php
@@ -1,0 +1,4 @@
+<?php $coauthors = get_coauthors( $this->get( 'post_id' ) ); ?>
+<li class="amp-wp-byline">
+	<?php coauthors(); ?>
+</li>


### PR DESCRIPTION
Super basic; nothing fancy.

Overrides the default AMP author meta template with a custom one and outputs co-authors using the `coauthors` template tag.

Also overrides the JSON metadata to properly include all co-authors.

Fixes https://github.com/Automattic/amp-wp/issues/137

/cc @mattoperry Can you take a look?