### PR TITLE
Guest authors with special characters

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -772,7 +772,7 @@ class coauthors_plus {
 				check_admin_referer( 'coauthors-edit', 'coauthors-nonce' );
 
 				$coauthors = (array) $_POST['coauthors'];
-				$coauthors = array_map( 'sanitize_text_field', $coauthors );
+				$coauthors = array_map( 'sanitize_title', $coauthors );
 				$this->add_coauthors( $post_id, $coauthors );
 			}
 		} else {

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -199,7 +199,7 @@ jQuery( document ).ready(function () {
 		author.login = jQuery.trim( vals[1] );
 		author.name = jQuery.trim( vals[2] );
 		author.email = jQuery.trim( vals[3] );
-		author.nicename = jQuery.trim( vals[4] );
+		author.nicename = decodeURIComponent( jQuery.trim( vals[4] ) );
 
 		if ( author.id=='New' ) {
 			coauthors_new_author_display( name );
@@ -287,7 +287,7 @@ jQuery( document ).ready(function () {
 							'type': 'hidden',
 							'id': 'coauthors_hidden_input',
 							'name': 'coauthors[]',
-							'value': unescape( author.nicename )
+							'value': decodeURIComponent( author.nicename )
 							})
 						;
 
@@ -369,7 +369,7 @@ jQuery( document ).ready(function () {
 		if ( settings.url.indexOf( coAuthorsPlus_ajax_suggest_link ) != -1 ) {
 			// Including existing authors on the AJAX suggest link
 			// allows us to filter them out of the search request
-			var existing_authors = jQuery( 'input[name="coauthors[]"]' ).map(function(){return jQuery( this ).val();}).get();
+			var existing_authors = jQuery( 'input[name="coauthors[]"]' ).map(function(){ return jQuery( this ).val(); }).get();
 			settings.url = settings.url.split( '&existing_authors' )[0];
 			settings.url += '&existing_authors=' + existing_authors.join( ',' );
 			show_loading();


### PR DESCRIPTION
Fix for Automattic/Co-Authors-Plus#198 to support guest authors with special characters in display names. On the client side we receive URL encoded nicename values, so need to decode them before passing them to jQuery which was double encoding them. Additionally there was an inconsistent use of sanitize_title versus sanitize_text_field used when saving guest authors and then when looking them up when saving a regular post, resolving that allowed you to actually save the authors array when an author had a special character.

Fixes #198 
