### PR TITLE
use underscores in class names for consistency

### DIFF
--- a/languages/co-authors-plus-de_DE.po
+++ b/languages/co-authors-plus-de_DE.po
@@ -516,8 +516,8 @@ msgid "Search for an author"
 msgstr "Suche nach einem Autor"
 
 #: template-tags.php:82
-msgid "No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?"
-msgstr "Keine Artikel ID für den CoAuthorsIterator Konstruktor verf&uuml;gbar. Bist du nicht im Loop oder wurde $post nicht gesetzt?"
+msgid "No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop or is $post not set?"
+msgstr "Keine Artikel ID für den CoAuthors_Iterator Konstruktor verf&uuml;gbar. Bist du nicht im Loop oder wurde $post nicht gesetzt?"
 
 #: template-tags.php:208 template-tags.php:365
 msgid "Posts by %s"

--- a/languages/co-authors-plus-es_ES.po
+++ b/languages/co-authors-plus-es_ES.po
@@ -562,10 +562,10 @@ msgstr "¡Todo listo! %d poseeos fueron afectados."
 
 #: template-tags.php:82
 msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
+"No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop "
 "or is $post not set?"
 msgstr ""
-"El constructor CoAuthorsIterator no recibió un ID de entrada como parámetro. "
+"El constructor CoAuthors_Iterator no recibió un ID de entrada como parámetro. "
 "Verifica que estás dentro del loop/bucle y que $post esté definida."
 
 #: template-tags.php:136

--- a/languages/co-authors-plus-fr_FR.po
+++ b/languages/co-authors-plus-fr_FR.po
@@ -565,10 +565,10 @@ msgstr "Terminé ! %d articles ont été concernés."
 
 #: template-tags.php:82
 msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
+"No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop "
 "or is $post not set?"
 msgstr ""
-"Aucune ID d'article n'a été fournie au constructeur CoAuthorsIterator. Ne "
+"Aucune ID d'article n'a été fournie au constructeur CoAuthors_Iterator. Ne "
 "seriez-vous pas à l'extérieur d'une boucle ou $post n'est-il pas défini ?"
 
 #: template-tags.php:136

--- a/languages/co-authors-plus-nl_NL.po
+++ b/languages/co-authors-plus-nl_NL.po
@@ -513,8 +513,8 @@ msgid "Search for an author"
 msgstr "Zoek voor een auteur"
 
 #: template-tags.php:82
-msgid "No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?"
-msgstr "Geen bericht ID gevonden voor CoAuthorsIterator constructor. Is er geen $post ingesteld?"
+msgid "No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop or is $post not set?"
+msgstr "Geen bericht ID gevonden voor CoAuthors_Iterator constructor. Is er geen $post ingesteld?"
 
 #: template-tags.php:208 template-tags.php:365
 msgid "Posts by %s"

--- a/languages/co-authors-plus-ru_RU.po
+++ b/languages/co-authors-plus-ru_RU.po
@@ -544,7 +544,7 @@ msgstr ""
 
 #: template-tags.php:79
 msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
+"No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop "
 "or is $post not set?"
 msgstr ""
 

--- a/languages/co-authors-plus-sv_SE.po
+++ b/languages/co-authors-plus-sv_SE.po
@@ -563,10 +563,10 @@ msgstr "Allt klart! %d inlägg berördes."
 
 #: template-tags.php:82
 msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
+"No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop "
 "or is $post not set?"
 msgstr ""
-"Inga inläggs-id skickades med till \"CoAuthorsIterator\"'s constructor. Är "
+"Inga inläggs-id skickades med till \"CoAuthors_Iterator\"'s constructor. Är "
 "du inte i en llop eller är inte $post satt?"
 
 #: template-tags.php:136

--- a/languages/co-authors-plus-uk.po
+++ b/languages/co-authors-plus-uk.po
@@ -546,7 +546,7 @@ msgstr ""
 
 #: template-tags.php:79
 msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
+"No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop "
 "or is $post not set?"
 msgstr ""
 

--- a/languages/co-authors-plus.pot
+++ b/languages/co-authors-plus.pot
@@ -539,7 +539,7 @@ msgstr ""
 
 #: template-tags.php:79
 msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
+"No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop "
 "or is $post not set?"
 msgstr ""
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -6,9 +6,9 @@
  * @since 3.0
  * @see https://github.com/wp-cli/wp-cli
  */
-WP_CLI::add_command( 'co-authors-plus', 'CoAuthorsPlus_Command' );
+WP_CLI::add_command( 'co-authors-plus', 'CoAuthors_Plus_Command' );
 
-class CoAuthorsPlus_Command extends WP_CLI_Command {
+class CoAuthors_Plus_Command extends WP_CLI_Command {
 
 	/**
 	 * Subcommand to create guest authors based on users

--- a/template-tags.php
+++ b/template-tags.php
@@ -77,7 +77,7 @@ function is_coauthor_for_post( $user, $post_id = 0 ) {
 	return false;
 }
 
-class CoAuthorsIterator {
+class CoAuthors_Iterator {
 	var $position = -1;
 	var $original_authordata;
 	var $current_author;
@@ -92,7 +92,7 @@ class CoAuthorsIterator {
 		}
 
 		if ( ! $postID ) {
-			trigger_error( __( 'No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?', 'co-authors-plus' ) ); // return null;
+			trigger_error( __( 'No post ID provided for CoAuthors_Iterator constructor. Are you not in a loop or is $post not set?', 'co-authors-plus' ) ); // return null;
 		}
 
 		$this->original_authordata = $this->current_author = $authordata;
@@ -167,7 +167,7 @@ function coauthors__echo( $tag, $type = 'tag', $separators = array(), $tag_args 
 
 	$output = '';
 
-	$i = new CoAuthorsIterator();
+	$i = new CoAuthors_Iterator();
 	$output .= $separators['before'];
 	$i->iterate();
 	do {

--- a/tests/coauthorsplus-testcase.php
+++ b/tests/coauthorsplus-testcase.php
@@ -4,7 +4,7 @@
  * Base unit test class for Co-Authors Plus
  */
 
-class CoAuthorsPlus_TestCase extends WP_UnitTestCase {
+class CoAuthors_Plus_TestCase extends WP_UnitTestCase {
 
 	protected $suppress = false;
 

--- a/tests/test-author-queries.php
+++ b/tests/test-author-queries.php
@@ -3,7 +3,7 @@
  * Test Co-Authors Plus' modifications of author queries
  */
 
-class Test_Author_Queries extends CoAuthorsPlus_TestCase {
+class Test_Author_Queries extends CoAuthors_Plus_TestCase {
 
 	/**
 	 * On author pages, the queried object should only be set

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -1,6 +1,6 @@
 <?php
 
-class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
+class Test_Manage_CoAuthors extends CoAuthors_Plus_TestCase {
 
 	/**
 	 * Test assigning a Co-Author to a post


### PR DESCRIPTION
Most classes had underscores already; now they all do.
