### PR TITLE
Better formatting for metabox_manage_guest_author_bio()

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -675,11 +675,21 @@ class CoAuthors_Guest_Authors
 		foreach ( $fields as $field ) {
 			$pm_key = $this->get_post_meta_key( $field['key'] );
 			$value = get_post_meta( $post->ID, $pm_key, true );
-			echo '<tr><th>';
-			echo '<label for="' . esc_attr( $pm_key ) . '">' . esc_html( $field['label'] ) . '</label>';
-			echo '</th><td>';
-			echo '<textarea style="width:300px;margin-bottom:6px;" name="' . esc_attr( $pm_key ) . '">' . esc_textarea( $value ) . '</textarea>';
-			echo '</td></tr>';
+			printf( '
+				<tr>
+					<th>
+						<label for="%s">%s</label>
+					</th>
+					<td>
+						<textarea style="width:300px;margin-bottom:6px;" name="%s">%s</textarea>
+					</td>
+				</tr>
+				',
+				esc_attr( $pm_key ),
+				esc_html( $field['label'] ),
+				esc_attr( $pm_key ),
+				esc_textarea( $value )
+			);
 		}
 		echo '</tbody></table>';
 


### PR DESCRIPTION
Better formatting for metabox_manage_guest_author_bio(), use `printf` instead of concatenating and echoing strings. Originally, this was a fix for a bug that turns out was already fixed by @mjangda in 8b98ad049d19d96bec6a832b27a96ba7d5cabe0a

I decided to submit nevertheless because it's easier on the eyes.

Cheers.