### PR TITLE
prevent | in author display name from breaking author assigning

### DIFF
--- a/co-authors-plus-lipemat.php
+++ b/co-authors-plus-lipemat.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Co-Authors Plus
+Plugin Name: Co-Authors Plus - lipemat
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
 Description: Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
 Version: 3.2.2

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Co-Authors Plus - lipemat
+Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
 Description: Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
 Version: 3.2.2

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1066,7 +1066,7 @@ class CoAuthors_Plus {
 		$authors = $this->search_authors( $search, $ignore );
 
 		foreach ( $authors as $author ) {
-			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . $author->display_name . ' | ' . $author->user_email . ' | ' . $author->user_nicename ) . "\n";
+			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . str_replace( '|', "&#108;", $author->display_name ) . ' | ' . $author->user_email . ' | ' . $author->user_nicename ) . "\n";
 		}
 
 		die();


### PR DESCRIPTION
When an author's display name contains a | character the assigning breaks due to the current js use of this.value.split( '|' ); within coauthors_autosuggest_select().

I was able to resolve this with a simple convert to &#108; which display almost identical to | but does not break the js logic. 
