### PR TITLE
Send moderation email even if guest author has no email address

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1595,6 +1595,7 @@ function cap_filter_comment_moderation_email_recipients( $recipients, $comment_i
 
 	if ( isset( $post_id ) ) {
 		$coauthors = get_coauthors( $post_id );
+		$extra_recipients = array();
 		foreach ( $coauthors as $user ) {
 			if ( ! empty( $user->user_email ) ) {
 				$extra_recipients[] = $user->user_email;


### PR DESCRIPTION
Currently, if a guest author has no email address set, then no moderation emails are sent to any users if someone comments on a post by that guest author.

This fixes the issue, so that other users still receive emails even if the guest author has no email address set.

fixes #364 