### PR TITLE
Add filter to get_coauthors

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -36,7 +36,7 @@ function get_coauthors( $post_id = 0 ) {
 			}
 		} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
 	}
-	return $coauthors;
+	return apply_filters( 'get_coauthors', $coauthors, $post_id );
 }
 
 /**

--- a/template-tags.php
+++ b/template-tags.php
@@ -38,7 +38,8 @@ function get_coauthors( $post_id = 0 ) {
 	}
 	// remove duplicate $coauthors objects from mapping user accounts to guest authors accounts
 	$coauthors = array_unique( $coauthors, SORT_REGULAR );
-	return apply_filters( 'get_coauthors', $coauthors, $post_id );
+	$coauthors = apply_filters( 'get_coauthors', $coauthors, $post_id );
+	return $coauthors;
 }
 
 /**

--- a/template-tags.php
+++ b/template-tags.php
@@ -36,6 +36,8 @@ function get_coauthors( $post_id = 0 ) {
 			}
 		} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
 	}
+	// remove duplicate $coauthors objects from mapping user accounts to guest authors accounts
+	$coauthors = array_unique( $coauthors, SORT_REGULAR );
 	return apply_filters( 'get_coauthors', $coauthors, $post_id );
 }
 


### PR DESCRIPTION
Adds a filter to get_coauthors to allow hooking in and providing coauthor objects that might not exist in the db. Use case: we have several places in our site where we output authors based on get_coauthors (templates, some custom POST requests we send out to some API's, etc). We have the need to "fake" some coauthors in some instances, and want to be able to dynamically insert them in when a post meets certain criteria. Being able to filter the data that gets returned when calling get_coauthors will allow us to take advantage of all existing code where we use get_coauthors, but will allow us to dynamically inject "fake" authors when needed.
