### PR TITLE
Add offset and number to create-guest-authors

### DIFF
--- a/features/create-guest-author.feature
+++ b/features/create-guest-author.feature
@@ -23,3 +23,29 @@ Feature: Guest authors can be created
       - 0 guest author profiles were created
       - 1 users already had guest author profiles
       """
+
+	Scenario: Process a chunk of users with --offset and --number
+		Given I run `wp user create alice alice@example.com --role=author --porcelain`
+		And I run `wp user create bob bob@example.com --role=author --porcelain`
+		And I run `wp user create carol carol@example.com --role=author --porcelain`
+		When I run `wp co-authors-plus create-guest-authors --offset=1 --number=2`
+		Then STDOUT should be:
+      """
+      Attempting to create guest author profiles for 2 users.
+      All done! Here are your results:
+      - 2 guest author profiles were created
+      - 0 users already had guest author profiles
+      """
+
+	Scenario: Resume an interrupted import by re-running the command
+		Given I run `wp user create alice alice@example.com --role=author --porcelain`
+		And I run `wp user create bob bob@example.com --role=author --porcelain`
+		And I run `wp co-authors-plus create-guest-authors --number=2`
+		When I run `wp co-authors-plus create-guest-authors`
+		Then STDOUT should be:
+      """
+      Attempting to create guest author profiles for 3 users.
+      All done! Here are your results:
+      - 1 guest author profiles were created
+      - 2 users already had guest author profiles
+      """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -20,16 +20,18 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @since 3.0
 	 *
 	 * @subcommand create-guest-authors
+	 * @synopsis [--offset=<offset>] [--number=<number>]
 	 */
 	public function create_guest_authors( $args, $assoc_args ): void {
 		global $coauthors_plus;
 
 		$defaults = array(
-				// There are no arguments at this time
+			'offset' => '',
+			'number' => '',
 		);
 		$this->args = wp_parse_args( $assoc_args, $defaults );
 
-		$users    = get_users();
+		$users    = get_users( $this->args );
 		$count    = count( $users );
 		$created  = 0;
 		$skipped  = 0;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -15,7 +15,23 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	private $args;
 
 	/**
-	 * Subcommand to create guest authors based on users
+	 * Subcommand to create guest authors based on users.
+	 *
+	 * Users that already have a linked guest author are skipped, so the command
+	 * is safe to re-run. `--offset` and `--number` allow the user list to be
+	 * processed in chunks, which is useful for very large sites where running
+	 * the full import in one invocation is impractical for memory or runtime
+	 * reasons. Because existing guest authors are skipped, an interrupted run
+	 * can also be resumed by simply re-running the command, with or without
+	 * chunking.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--offset=<offset>]
+	 * : Number of users to skip before processing begins. Defaults to 0.
+	 *
+	 * [--number=<number>]
+	 * : Maximum number of users to process in this run. Defaults to all users.
 	 *
 	 * @since 3.0
 	 *
@@ -31,6 +47,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		);
 		$this->args = wp_parse_args( $assoc_args, $defaults );
 
+		// Chunked runs rely on a stable ordering across invocations. get_users()
+		// orders by user_login ASC by default, which is stable provided users
+		// are not added or removed between chunks.
 		$users    = get_users( $this->args );
 		$count    = count( $users );
 		$created  = 0;


### PR DESCRIPTION
Currently, create-guest-authors is an all or nothing proposition. What happens though when you are 50% complete with a 30,000 user import and then accidently close your terminal window?  You have to start over.  By allowing chunking of create-guest-authors, this can be continued from the number that have been completed rather than starting from scratch.  

Anecdotally, running it in chunks seems to be quicker. 
