### PR TITLE
Let guest authors query args (admin-side) be filtered

### DIFF
--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -64,6 +64,8 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 				'order'          => 'ASC',
 			);
 
+		$args = apply_filters( 'coauthors_guest_author_query_args', $args );
+
 		if ( isset( $_REQUEST['orderby'] ) ) {
 			switch ( $_REQUEST['orderby'] ) {
 				case 'display_name':


### PR DESCRIPTION
Add filter to allow query args to be filtered for the guest authors listing. Allows, for example, sorting by last-name-first-name.

see #371 