### PR TITLE
Bug Fix: Co-Author Order Not Retained in WordPress 4.7

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -116,6 +116,9 @@ class CoAuthors_Plus {
 		// Support infinite scroll for Guest Authors on author pages
 		add_filter( 'infinite_scroll_js_settings', array( $this, 'filter_infinite_scroll_js_settings' ), 10, 2 );
 
+		// Delete CoAuthor Cache on Post Save
+		add_action( 'save_post', array( $this, 'clear_cache') );
+		add_action( 'delete_post', array( $this, 'clear_cache') );
 	}
 
 	/**
@@ -1468,6 +1471,10 @@ class CoAuthors_Plus {
 
 		// Send back the updated Open Graph Tags
 		return apply_filters( 'coauthors_open_graph_tags', $og_tags );
+	}
+
+	public function clear_cache( $post_id ) {
+		wp_cache_delete( 'coauthors_post_' . $post_id );
 	}
 }
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -116,7 +116,7 @@ class CoAuthors_Plus {
 		// Support infinite scroll for Guest Authors on author pages
 		add_filter( 'infinite_scroll_js_settings', array( $this, 'filter_infinite_scroll_js_settings' ), 10, 2 );
 
-		// Delete CoAuthor Cache on Post Save
+		// Delete CoAuthor Cache on Post Save & Post Delete
 		add_action( 'save_post', array( $this, 'clear_cache') );
 		add_action( 'delete_post', array( $this, 'clear_cache') );
 	}
@@ -1473,6 +1473,11 @@ class CoAuthors_Plus {
 		return apply_filters( 'coauthors_open_graph_tags', $og_tags );
 	}
 
+	/**
+	 * Callback to clear the cache on post save and post delete.
+	 *
+	 * @param $post_id The Post ID.
+	 */
 	public function clear_cache( $post_id ) {
 		wp_cache_delete( 'coauthors_post_' . $post_id );
 	}

--- a/template-tags.php
+++ b/template-tags.php
@@ -14,8 +14,7 @@ function get_coauthors( $post_id = 0 ) {
 	}
 
 	if ( $post_id ) {
-		$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
-
+		$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array( 'orderby' => 'term_order', 'order' => 'ASC' ) );
 		if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
 			foreach ( $coauthor_terms as $coauthor ) {
 				$coauthor_slug = preg_replace( '#^cap\-#', '', $coauthor->slug );

--- a/template-tags.php
+++ b/template-tags.php
@@ -14,7 +14,11 @@ function get_coauthors( $post_id = 0 ) {
 	}
 
 	if ( $post_id ) {
-		$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array( 'orderby' => 'term_order', 'order' => 'ASC' ) );
+		$cache_key = 'coauthors_post_' . $post_id;
+		if ( false === ( $coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' ) ) ) {
+			$coauthor_terms = wp_get_object_terms($post_id, $coauthors_plus->coauthor_taxonomy, array('orderby' => 'term_order', 'order' => 'ASC'));
+			wp_cache_set( $cache_key, $coauthor_terms, 'co-authors-plus' );
+		}
 		if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
 			foreach ( $coauthor_terms as $coauthor ) {
 				$coauthor_slug = preg_replace( '#^cap\-#', '', $coauthor->slug );

--- a/template-tags.php
+++ b/template-tags.php
@@ -16,7 +16,7 @@ function get_coauthors( $post_id = 0 ) {
 	if ( $post_id ) {
 		$cache_key = 'coauthors_post_' . $post_id;
 		if ( false === ( $coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' ) ) ) {
-			$coauthor_terms = wp_get_object_terms($post_id, $coauthors_plus->coauthor_taxonomy, array('orderby' => 'term_order', 'order' => 'ASC'));
+			$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array( 'orderby' => 'term_order', 'order' => 'ASC' ) );
 			wp_cache_set( $cache_key, $coauthor_terms, 'co-authors-plus' );
 		}
 		if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {


### PR DESCRIPTION
After upgrading to WordPress 4.7, the order of the co-authors always displayed alphabetical.  Changing the order in the admin interface stopped working.  

It looks like `get_the_terms` is defaulting to order by name.  Unfortunately, `get_the_terms` does not accept an orderby parameter, but the function it calls, `wp_get_object_terms` does.

Since  `wp_get_object_terms` is an uncached function, I've added caching.

