### PR TITLE
More term ordering fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,15 @@ before_script:
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+    # Properly handle PHPunit versions
+    - export PATH="$HOME/.composer/vendor/bin:$PATH"
+    - |
+        if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+          composer global require "phpunit/phpunit=5.7.*"
+        elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
+          composer global require "phpunit/phpunit=4.8.*"
+        fi
+    - phpunit --version
 
 script:
     # Search for PHP syntax errors.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,30 @@
 language: php
 
 php:
-    - "nightly"
+    - 7.1
 
 env:
     - WP_VERSION=latest
 
 matrix:
+matrix:
   include:
-# nightly+latest already included above as first build.
-#  - php: "nightly"
-#    env: WP_VERSION=latest
-   - php: "nightly"
-     env: WP_VERSION=4.6
-   - php: "nightly"
-     env: WP_VERSION=4.5
    - php: "5.2"
      env: WP_VERSION=latest
    - php: "5.2"
      env: WP_VERSION=4.6
-   - php: "5.2"
-     env: WP_VERSION=4.5
-   - php: "5.6"
-     env: WP_VERSION=latest
    - php: "5.6"
      env:
-         - WP_VERSION=4.6
+         - WP_VERSION=latest
          - SNIFF=1
    - php: "5.6"
-     env: WP_VERSION=4.5
-   - php: "7"
+     env: WP_VERSION=4.6
+   - php: "7.0"
+     env: WP_VERSION=latest
+   - php: "7.0"
+     env: WP_VERSION=4.6
+     # 7.1 / latest already included above as first build.
+   - php: "7.1"
      env: WP_VERSION=4.6
 
 before_script:

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1643,7 +1643,7 @@ function cap_get_coauthor_terms_for_post( $post_id = false ) {
 	global $coauthors_plus;
 
 	$cache_key = 'coauthors_post_' . $post_id;
-	$coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' )
+	$coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' );
 
 	if ( false === $coauthor_terms ) {
 		$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array(

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -119,6 +119,7 @@ class CoAuthors_Plus {
 		// Delete CoAuthor Cache on Post Save & Post Delete
 		add_action( 'save_post', array( $this, 'clear_cache') );
 		add_action( 'delete_post', array( $this, 'clear_cache') );
+		add_action( 'set_object_terms', array( $this, 'clear_cache_on_terms_set' ), 10, 6 );
 	}
 
 	/**
@@ -1481,6 +1482,23 @@ class CoAuthors_Plus {
 	public function clear_cache( $post_id ) {
 		wp_cache_delete( 'coauthors_post_' . $post_id, 'co-authors-plus' );
 	}
+
+	/**
+	 * Callback to clear the cache when an object's terms are changed.
+	 *
+	 * @param $post_id The Post ID.
+	 */
+	public function clear_cache_on_terms_set( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
+
+		// We only care about the coauthors taxonomy
+		if ( $this->coauthor_taxonomy !== $taxonomy ) {
+			return;
+		}
+
+		wp_cache_delete( 'coauthors_post_' . $object_id, 'co-authors-plus' );
+
+	}
+
 }
 
 global $coauthors_plus;

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1624,3 +1624,37 @@ function cap_filter_comment_moderation_email_recipients( $recipients, $comment_i
 	}
 	return $recipients;
 }
+
+/**
+ * Retrieve a list of coauthor terms for a single post.
+ *
+ * Grabs a correctly ordered list of authors for a single post, appropriately
+ * cached because it requires `wp_get_object_terms()` to succeed.
+ *
+ * @param int $post_id ID of the post for which to retrieve authors.
+ * @return array Array of coauthor WP_Term objects
+ */
+function cap_get_coauthor_terms_for_post( $post_id = false ) {
+
+	if ( ! $post_id ) {
+		return array();
+	}
+
+	global $coauthors_plus;
+
+	$cache_key = 'coauthors_post_' . $post_id;
+	$coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' )
+
+	if ( false === $coauthor_terms ) {
+		$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array(
+			'orderby' => 'term_order',
+			'order' => 'ASC',
+		) );
+		wp_cache_set( $cache_key, $coauthor_terms, 'co-authors-plus' );
+	} else {
+		$coauthor_terms = array();
+	}
+
+	return $coauthor_terms;
+
+}

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1493,12 +1493,16 @@ class CoAuthors_Plus {
 		$coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' );
 
 		if ( false === $coauthor_terms ) {
-			$cached = wp_get_object_terms( $post_id, $this->coauthor_taxonomy, array(
+			$coauthor_terms = wp_get_object_terms( $post_id, $this->coauthor_taxonomy, array(
 				'orderby' => 'term_order',
 				'order' => 'ASC',
 			) );
-			// Cache an empty array if the taxonomy doesn't exist.
-			$coauthor_terms = ( is_wp_error( $cached ) ) ? array() : $cached;
+
+			// This usually happens if the taxonomy doesn't exist, which should never happen, but you never know.
+			if ( is_wp_error( $coauthor_terms ) ) {
+				return array();
+			}
+
 			wp_cache_set( $cache_key, $coauthor_terms, 'co-authors-plus' );
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1652,7 +1652,7 @@ function cap_filter_comment_moderation_email_recipients( $recipients, $comment_i
  * @param int $post_id ID of the post for which to retrieve authors.
  * @return array Array of coauthor WP_Term objects
  */
-function cap_get_coauthor_terms_for_post( $post_id = false ) {
+function cap_get_coauthor_terms_for_post( $post_id ) {
 
 	if ( ! $post_id ) {
 		return array();
@@ -1664,13 +1664,13 @@ function cap_get_coauthor_terms_for_post( $post_id = false ) {
 	$coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' );
 
 	if ( false === $coauthor_terms ) {
-		$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array(
+		$cached = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array(
 			'orderby' => 'term_order',
 			'order' => 'ASC',
 		) );
+		// Cache an empty array if the taxonomy doesn't exist.
+		$coauthor_terms = ( is_wp_error( $cached ) ) ? array() : $cached;
 		wp_cache_set( $cache_key, $coauthor_terms, 'co-authors-plus' );
-	} else {
-		$coauthor_terms = array();
 	}
 
 	return $coauthor_terms;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -235,8 +235,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$posts = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ('$post_types')", $user->ID ) );
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
-			if ( $coauthors = cap_get_coauthor_terms_for_post( $post_id ) ) {
-				WP_CLI::line( sprintf( __( 'Skipping - Post #%d already has co-authors assigned: %s', 'co-authors-plus' ), $post_id, implode( ', ', wp_list_pluck( $coauthors, 'slug' ) ) ) );
+			$coauthors = cap_get_coauthor_terms_for_post( $post_id )
+			if ( ! empty( $coauthors ) ) {
+				WP_CLI::line( sprintf(
+					__( 'Skipping - Post #%d already has co-authors assigned: %s', 'co-authors-plus' ),
+					$post_id,
+					implode( ', ', wp_list_pluck( $coauthors, 'slug' ) )
+				) );
 				continue;
 			}
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -235,7 +235,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$posts = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ('$post_types')", $user->ID ) );
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
-			$coauthors = cap_get_coauthor_terms_for_post( $post_id )
+			$coauthors = cap_get_coauthor_terms_for_post( $post_id );
 			if ( ! empty( $coauthors ) ) {
 				WP_CLI::line( sprintf(
 					__( 'Skipping - Post #%d already has co-authors assigned: %s', 'co-authors-plus' ),

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -76,10 +76,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 				$count++;
 
-				$terms = get_the_terms( $single_post->ID, $coauthors_plus->coauthor_taxonomy );
-				
-				if ( is_wp_error( $terms ) ) {
-					WP_CLI::error( $terms->get_error_message() );
+				$terms = cap_get_coauthor_terms_for_post( $single_post->ID );
+				if ( empty( $terms ) ) {
+					WP_CLI::error( sprintf( 'No co-authors found for post #%d.', $single_post->ID ) );
 				}
 
 				if ( ! empty( $terms ) ) {
@@ -236,7 +235,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$posts = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ('$post_types')", $user->ID ) );
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
-			if ( $coauthors = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy ) ) {
+			if ( $coauthors = cap_get_coauthor_terms_for_post( $post_id ) ) {
 				WP_CLI::line( sprintf( __( 'Skipping - Post #%d already has co-authors assigned: %s', 'co-authors-plus' ), $post_id, implode( ', ', wp_list_pluck( $coauthors, 'slug' ) ) ) );
 				continue;
 			}
@@ -545,8 +544,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		while ( $posts->post_count ) {
 
 			foreach ( $posts->posts as $single_post ) {
-				
-				$terms = get_the_terms( $single_post->ID, $coauthors_plus->coauthor_taxonomy );
+
+				$terms = cap_get_coauthor_terms_for_post( $single_post->ID );
 				if ( empty( $terms ) ) {
 					$saved = array(
 							$single_post->ID,
@@ -698,9 +697,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		WP_CLI::line( 'Found ' . count( $ids ) . ' revisions to look through' );
 		$affected = 0;
 		foreach ( $ids as $post_id ) {
-			
-			$terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
-			if ( ! $terms ) {
+
+			$terms = cap_get_coauthor_terms_for_post( $post_id );
+			if ( empty( $terms ) ) {
 				continue;
 			}
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -14,11 +14,7 @@ function get_coauthors( $post_id = 0 ) {
 	}
 
 	if ( $post_id ) {
-		$cache_key = 'coauthors_post_' . $post_id;
-		if ( false === ( $coauthor_terms = wp_cache_get( $cache_key, 'co-authors-plus' ) ) ) {
-			$coauthor_terms = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array( 'orderby' => 'term_order', 'order' => 'ASC' ) );
-			wp_cache_set( $cache_key, $coauthor_terms, 'co-authors-plus' );
-		}
+		$coauthor_terms = cap_get_coauthor_terms_for_post( $post_id );
 		if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
 			foreach ( $coauthor_terms as $coauthor ) {
 				$coauthor_slug = preg_replace( '#^cap\-#', '', $coauthor->slug );

--- a/tests/test-author-queried-object.php
+++ b/tests/test-author-queried-object.php
@@ -6,6 +6,20 @@
 class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 
 	/**
+	 * Set up for test
+	 *
+	 * Don't create tables as 'temporary'.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/398
+	 */
+	function setUp() {
+		parent::setUp();
+
+		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+	}
+
+	/**
 	 * On author pages, the queried object should only be set
 	 * to a user that's not a member of the blog if they
 	 * have at least one published post. This matches core behavior.


### PR DESCRIPTION
Following on from #390 we also needed to revert the change introduce in #367 which meant that the CLI commands would also be affected by the bug.

This change moves the fix from #391 into it's own helper function - `cap_get_coauthor_terms_for_post()` to avoid unnecessary code duplication for the cache getting/setting. It updates the existing uses of the cache to use the helper, and fixes the CLI commands' use of `get_the_terms()` to use our new helper instead.