### PR TITLE
Pages archive now displays coauthors and quick edit works

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -293,11 +293,9 @@ class CoAuthors_Plus {
 	public function is_post_type_enabled( $post_type = null ) {
 
 		if ( ! $post_type ) {
-			if ( is_admin() ) {
+			$post_type = get_post_type();
+			if ( is_admin() && ! $post_type) {
 				$post_type = get_current_screen()->post_type;
-			}
-			else {
-				$post_type = get_post_type();
 			}
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1256,7 +1256,9 @@ class CoAuthors_Plus {
 	 */
 	public function js_vars() {
 
-		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled() || ! $this-> current_user_can_set_authors() ) {
+		$post_type = get_current_screen()->post_type;
+
+		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled( $post_type ) || ! $this-> current_user_can_set_authors() ) {
 			return;
 		}
 		?>

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -616,10 +616,9 @@ class CoAuthors_Plus {
 
 			// Check to see that JOIN hasn't already been added. Props michaelingp and nbaxley
 			$term_relationship_inner_join = " INNER JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
-			$term_relationship_left_join = " LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
+			$term_relationship_left_join = " LEFT JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)";
 
-			$term_taxonomy_join  = " INNER JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)";
-			$term_taxonomy_join .= " INNER JOIN {$wpdb->term_taxonomy} ON ( tr1.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
+			$term_taxonomy_join = " INNER JOIN {$wpdb->term_taxonomy} ON ( tr1.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
 
 			// 4.6+ uses a LEFT JOIN for tax queries so we need to check for both
 			if ( false === strpos( $join, trim( $term_relationship_inner_join ) )

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -293,7 +293,12 @@ class CoAuthors_Plus {
 	public function is_post_type_enabled( $post_type = null ) {
 
 		if ( ! $post_type ) {
-			$post_type = get_post_type();
+			if ( is_admin() ) {
+				$post_type = get_current_screen()->post_type;
+			}
+			else {
+				$post_type = get_post_type();
+			}
 		}
 
 		return (bool) in_array( $post_type, $this->supported_post_types );
@@ -414,9 +419,7 @@ class CoAuthors_Plus {
 
 		$new_columns = array();
 
-		$post_type = get_current_screen()->post_type;
-
-		if ( ! $this->is_post_type_enabled( $post_type ) ) {
+		if ( ! $this->is_post_type_enabled() ) {
 			return $posts_columns;
 		}
 
@@ -1256,9 +1259,7 @@ class CoAuthors_Plus {
 	 */
 	public function js_vars() {
 
-		$post_type = get_current_screen()->post_type;
-
-		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled( $post_type ) || ! $this-> current_user_can_set_authors() ) {
+		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled() || ! $this-> current_user_can_set_authors() ) {
 			return;
 		}
 		?>

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -616,9 +616,10 @@ class CoAuthors_Plus {
 
 			// Check to see that JOIN hasn't already been added. Props michaelingp and nbaxley
 			$term_relationship_inner_join = " INNER JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
-			$term_relationship_left_join = " LEFT JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)";
+			$term_relationship_left_join = " LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
 
-			$term_taxonomy_join = " INNER JOIN {$wpdb->term_taxonomy} ON ( tr1.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
+			$term_taxonomy_join  = " INNER JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)";
+			$term_taxonomy_join .= " INNER JOIN {$wpdb->term_taxonomy} ON ( tr1.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
 
 			// 4.6+ uses a LEFT JOIN for tax queries so we need to check for both
 			if ( false === strpos( $join, trim( $term_relationship_inner_join ) )

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -413,7 +413,10 @@ class CoAuthors_Plus {
 	function _filter_manage_posts_columns( $posts_columns ) {
 
 		$new_columns = array();
-		if ( ! $this->is_post_type_enabled() ) {
+
+		$post_type = get_current_screen()->post_type;
+
+		if ( ! $this->is_post_type_enabled( $post_type ) ) {
 			return $posts_columns;
 		}
 
@@ -959,11 +962,16 @@ class CoAuthors_Plus {
 		if ( ! $post ) {
 			$post = get_post();
 			if ( ! $post ) {
-				return false;
+				// if user is on pages, you need to grab post type another way
+				$post_type = get_current_screen()->post_type;
+			}
+			else {
+				$post_type = $post->post_type;
 			}
 		}
-
-		$post_type = $post->post_type;
+		else {
+			$post_type = $post->post_type;
+		}
 
 		// TODO: need to fix this; shouldn't just say no if don't have post_type
 		if ( ! $post_type ) {
@@ -1177,7 +1185,9 @@ class CoAuthors_Plus {
 	function enqueue_scripts( $hook_suffix ) {
 		global $pagenow, $post;
 
-		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled() || ! $this->current_user_can_set_authors() ) {
+		$post_type = get_current_screen()->post_type;
+
+		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled( $post_type ) || ! $this->current_user_can_set_authors() ) {
 			return;
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -418,7 +418,6 @@ class CoAuthors_Plus {
 	function _filter_manage_posts_columns( $posts_columns ) {
 
 		$new_columns = array();
-
 		if ( ! $this->is_post_type_enabled() ) {
 			return $posts_columns;
 		}

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1187,9 +1187,7 @@ class CoAuthors_Plus {
 	function enqueue_scripts( $hook_suffix ) {
 		global $pagenow, $post;
 
-		$post_type = get_current_screen()->post_type;
-
-		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled( $post_type ) || ! $this->current_user_can_set_authors() ) {
+		if ( ! $this->is_valid_page() || ! $this->is_post_type_enabled() || ! $this->current_user_can_set_authors() ) {
 			return;
 		}
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -78,7 +78,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 				$terms = cap_get_coauthor_terms_for_post( $single_post->ID );
 				if ( empty( $terms ) ) {
-					WP_CLI::error( sprintf( 'No co-authors found for post #%d.', $single_post->ID ) );
+					WP_CLI::line( sprintf( 'No co-authors found for post #%d.', $single_post->ID ) );
+					continue;
 				}
 
 				if ( ! empty( $terms ) ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -78,8 +78,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 				$terms = cap_get_coauthor_terms_for_post( $single_post->ID );
 				if ( empty( $terms ) ) {
-					WP_CLI::line( sprintf( 'No co-authors found for post #%d.', $single_post->ID ) );
-					continue;
+					WP_CLI::error( sprintf( 'No co-authors found for post #%d.', $single_post->ID ) );
 				}
 
 				if ( ! empty( $terms ) ) {


### PR DESCRIPTION
As per #401, admin can now use quick edit for co-authors on pages and co-authors on pages archive display correctly.

get_post_type() was returning false on pages archive which broke is_post_type_enabled and current_user_can_set_authors()
