### PR TITLE
Remove duplicated byline

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -35,6 +35,8 @@ function get_coauthors( $post_id = 0 ) {
 			}
 		} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
 	}
+	// remove duplicate $coauthors objects from mapping user accounts to guest authors accounts
+	$coauthors = array_unique( $coauthors, SORT_REGULAR );
 	return $coauthors;
 }
 


### PR DESCRIPTION
As per #113, if you have an existing post with a guest author and a user, the guest author will show up twice of you map the guest author and user account together.  This fixes it and only shows the guest author    once!