### PR TITLE
coauthors_wp_list_authors() has option to list only guest authors now

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -448,6 +448,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 		'style'            => 'list',
 		'html'             => true,
 		'number'           => 20, // A sane limit to start to avoid breaking all the things
+		'guest_authors_only' => false
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -472,6 +473,17 @@ function coauthors_wp_list_authors( $args = array() ) {
 	}
 
 	$authors = apply_filters( 'coauthors_wp_list_authors_array', $authors );
+	
+	// only show guest authors if the $args is set to true
+	if ( $args['guest_authors_only'] ) {
+		$guest_authors = [];
+		foreach ( $authors as $author ) {
+			if ( $author->type === 'guest-author' ) {
+				$guest_authors[] = $author;
+			}
+		}
+		$authors = $guest_authors;
+	}
 
 	foreach ( (array) $authors as $author ) {
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -438,16 +438,16 @@ function coauthors_wp_list_authors( $args = array() ) {
 	global $coauthors_plus;
 
 	$defaults = array(
-		'optioncount'      => false,
-		'show_fullname'    => false,
-		'hide_empty'       => true,
-		'feed'             => '',
-		'feed_image'       => '',
-		'feed_type'        => '',
-		'echo'             => true,
-		'style'            => 'list',
-		'html'             => true,
-		'number'           => 20, // A sane limit to start to avoid breaking all the things
+		'optioncount'        => false,
+		'show_fullname'      => false,
+		'hide_empty'         => true,
+		'feed'               => '',
+		'feed_image'         => '',
+		'feed_type'          => '',
+		'echo'               => true,
+		'style'              => 'list',
+		'html'               => true,
+		'number'           	 => 20, // A sane limit to start to avoid breaking all the things
 		'guest_authors_only' => false
 	);
 
@@ -460,6 +460,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 			'number'       => (int) $args['number'],
 		);
 	$author_terms = get_terms( $coauthors_plus->coauthor_taxonomy, $term_args );
+
 	$authors = array();
 	foreach ( $author_terms as $author_term ) {
 		// Something's wrong in the state of Denmark
@@ -469,21 +470,16 @@ function coauthors_wp_list_authors( $args = array() ) {
 
 		$authors[ $author_term->name ] = $coauthor;
 
-		$authors[ $author_term->name ]->post_count = $author_term->count;
+		// only show guest authors if the $args is set to true
+		if ( ! $args['guest_authors_only'] ||  $authors[ $author_term->name ]->type === 'guest-author' ) {
+			$authors[ $author_term->name ]->post_count = $author_term->count;
+		}
+		else {
+			unset( $authors[ $author_term->name ] );
+		}
 	}
 
 	$authors = apply_filters( 'coauthors_wp_list_authors_array', $authors );
-	
-	// only show guest authors if the $args is set to true
-	if ( $args['guest_authors_only'] ) {
-		$guest_authors = [];
-		foreach ( $authors as $author ) {
-			if ( $author->type === 'guest-author' ) {
-				$guest_authors[] = $author;
-			}
-		}
-		$authors = $guest_authors;
-	}
 
 	foreach ( (array) $authors as $author ) {
 


### PR DESCRIPTION
As per #118, with the template tag `coauthors_wp_list_authors()` it included all users and guest authors.  Some wanted the feature to only list guest authors because the core function `wp_list_authors()` already lists all users with posts.  Now with this fix, if you pass in the `$args` of `guest_authors_only` to be true, then the template tag will list only guest authors.