### PR TITLE
remove duplicates from linked accounts on coauthors_wp_list_authors()

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -473,6 +473,12 @@ function coauthors_wp_list_authors( $args = array() ) {
 
 	$authors = apply_filters( 'coauthors_wp_list_authors_array', $authors );
 
+	// remove duplicates from linked accounts
+	$linked_accounts = array_unique( array_column( $authors, 'linked_account' ) );
+	foreach ( $linked_accounts as $linked_account ) {
+		unset( $authors[$linked_account] );
+	}
+
 	foreach ( (array) $authors as $author ) {
 
 		$link = '';


### PR DESCRIPTION
As per #119, any guest accounts that were linked to a user were showing up twice in the template tag `coauthors_wp_list_authors()`.  This addresses that issue.  