### PR TITLE
Accurate Guest Author post count on linked accounts

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1344,11 +1344,17 @@ class CoAuthors_Plus {
 		if ( false !== ( $term = wp_cache_get( $cache_key, 'co-authors-plus' ) ) ) {
 			return $term;
 		}
-
-		// See if the prefixed term is available, otherwise default to just the nicename
-		$term = get_term_by( 'slug', 'cap-' . $coauthor->user_nicename, $this->coauthor_taxonomy );
-		if ( ! $term ) {
-			$term = get_term_by( 'slug', $coauthor->user_nicename, $this->coauthor_taxonomy );
+		
+		// use linked user for accurate post count
+		if ( ! empty ( $coauthor->linked_account ) ) {
+			$term = get_term_by( 'slug', 'cap-' . $coauthor->linked_account, $this->coauthor_taxonomy );
+		}
+		else {
+			// See if the prefixed term is available, otherwise default to just the nicename
+			$term = get_term_by( 'slug', 'cap-' . $coauthor->user_nicename, $this->coauthor_taxonomy );
+			if ( ! $term ) {
+				$term = get_term_by( 'slug', $coauthor->user_nicename, $this->coauthor_taxonomy );
+			}
 		}
 		wp_cache_set( $cache_key, $term, 'co-authors-plus' );
 		return $term;

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1348,6 +1348,9 @@ class CoAuthors_Plus {
 		// use linked user for accurate post count
 		if ( ! empty ( $coauthor->linked_account ) ) {
 			$term = get_term_by( 'slug', 'cap-' . $coauthor->linked_account, $this->coauthor_taxonomy );
+			if ( ! $term ) {
+				$term = get_term_by( 'slug', $coauthor->linked_account, $this->coauthor_taxonomy );
+			}
 		}
 		else {
 			// See if the prefixed term is available, otherwise default to just the nicename


### PR DESCRIPTION
As per #228, once you link a guest author account to a user with pre-existing posts, the Guest Authors "Posts" column does not update to reflect an accurate count.  This patch fixes the issue.