### PR TITLE
Fix invalid CSS for cursor grabbing

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -42,7 +42,7 @@
 				width:200px;
 			}
 			#coauthors-list .ui-sortable-helper .coauthor-tag {
-				cursor: cursor:grabbing;
+				cursor: grabbing;
   				cursor:-moz-grabbing;
   				cursor:-webkit-grabbing;
 			}


### PR DESCRIPTION
The key name is repeated causing a CSS linting error.