### PR TITLE
Prevent doubling up on filters which breaks the the_author_posts_link…

### DIFF
--- a/php/class-coauthors-template-filters.php
+++ b/php/class-coauthors-template-filters.php
@@ -20,6 +20,7 @@ class CoAuthors_Template_Filters {
 	}
 
 	function filter_the_author_posts_link() {
+		remove_filter( 'the_author', array( $this, 'filter_the_author' ) );
 		return coauthors_posts_links( null, null, null, null, false );
 	}
 

--- a/php/class-coauthors-template-filters.php
+++ b/php/class-coauthors-template-filters.php
@@ -21,7 +21,9 @@ class CoAuthors_Template_Filters {
 
 	function filter_the_author_posts_link() {
 		remove_filter( 'the_author', array( $this, 'filter_the_author' ) );
-		return coauthors_posts_links( null, null, null, null, false );
+		$return = coauthors_posts_links( null, null, null, null, false );
+		add_filter( 'the_author', array( $this, 'filter_the_author' ) );
+		return $return;
 	}
 
 	function filter_the_author_rss( $the_author ) {

--- a/template-tags.php
+++ b/template-tags.php
@@ -345,12 +345,16 @@ function coauthors_nicknames( $between = null, $betweenLast = null, $before = nu
  * @param bool $echo Whether the co-authors should be echoed or returned. Defaults to true.
  */
 function coauthors_links( $between = null, $betweenLast = null, $before = null, $after = null, $echo = true ) {
-	return coauthors__echo( 'coauthors_links_single', 'callback', array(
+	global $coauthors_plus_template_filters;
+	remove_filter( 'the_author', array( $coauthors_plus_template_filters, 'filter_the_author' ) );
+	$return = coauthors__echo( 'coauthors_links_single', 'callback', array(
 		'between' => $between,
 		'betweenLast' => $betweenLast,
 		'before' => $before,
 		'after' => $after,
 	), null, $echo );
+	add_filter( 'the_author', array( $coauthors_plus_template_filters, 'filter_the_author' ) );
+	return $return;
 }
 
 /**


### PR DESCRIPTION
Prevent doubling up on filters which breaks the `the_author_posts_link` template tag. Fixes #279 and subsequently the broken test in the pending merge #301
