### PR TITLE
Fix coauthors_links_single()

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -131,17 +131,7 @@ class CoAuthors_Guest_Authors
 		register_post_type( $this->post_type, $args );
 
 		// Some of the common sizes used by get_avatar
-		$this->avatar_sizes = array(
-				32,
-				50,
-				64,
-				96,
-				128,
-			);
-		$this->avatar_sizes = apply_filters( 'coauthors_guest_author_avatar_sizes', $this->avatar_sizes );
-		foreach ( $this->avatar_sizes as $size ) {
-			add_image_size( 'guest-author-' . $size, $size, $size, true );
-		}
+		$this->avatar_sizes = array();
 
 		// Hacky way to remove the title and the editor
 		remove_post_type_support( $this->post_type, 'title' );
@@ -940,11 +930,8 @@ class CoAuthors_Guest_Authors
 		$args = array(
 				'class' => "avatar avatar-{$size} photo",
 			);
-		if ( in_array( $size, $this->avatar_sizes ) ) {
-			$size = 'guest-author-' . $size;
-		} else {
-			$size = array( $size, $size );
-		}
+
+		$size = array( $size, $size );
 
 		$thumbnail = get_the_post_thumbnail( $guest_author->ID, $size, $args );
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -484,7 +484,7 @@ class CoAuthors_Guest_Authors
 			// Leave mapped to a linked account
 			if ( get_user_by( 'login', $guest_author->linked_account ) ) {
 				echo '<li><label for="leave-assigned">';
-				echo '<input type="radio" id="leave-assigned" class="reassign-option" name="reassign" value="leave-assigned" />&nbsp;&nbsp;' . esc_html( sprintf( __( 'Leave posts assigned to the mapped user, %s.', 'co-authors-plus' ) ), $guest_author->linked_account );
+				echo '<input type="radio" id="leave-assigned" class="reassign-option" name="reassign" value="leave-assigned" />&nbsp;&nbsp;' . esc_html( sprintf( __( 'Leave posts assigned to the mapped user, %s.', 'co-authors-plus' ), $guest_author->linked_account ) );
 				echo '</label></li>';
 			}
 			// Remove bylines from the posts

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -89,6 +89,10 @@ class CoAuthors_Guest_Authors
 			'not_found_in_trash' => __( 'No guest authors found in Trash', 'co-authors-plus' ),
 			'update_item' => __( 'Update Guest Author', 'co-authors-plus' ),
 			'metabox_about' => __( 'About the guest author', 'co-authors-plus' ),
+			'featured_image' => __( 'Avatar', 'co-authors-plus' ),
+			'set_featured_image' => __( 'Set Avatar', 'co-authors-plus' ),
+			'use_featured_image' => __( 'Use Avatar', 'co-authors-plus' ),
+			'remove_featured_image' => __( 'Remove Avatar', 'co-authors-plus' ),
 		) );
 
 		// Register a post type to store our guest authors 
@@ -106,6 +110,10 @@ class CoAuthors_Guest_Authors
 						'search_items' => $this->labels['search_items'],
 						'not_found' => $this->labels['not_found'],
 						'not_found_in_trash' => $this->labels['not_found_in_trash'],
+						'featured_image' => $this->labels['featured_image'],
+						'set_featured_image' => $this->labels['set_featured_image'],
+						'use_featured_image' => $this->labels['use_featured_image'],
+						'remove_featured_image' => $this->labels['remove_featured_image']
 					),
 				'public' => true,
 				'publicly_queryable' => false,

--- a/template-tags.php
+++ b/template-tags.php
@@ -378,14 +378,26 @@ function coauthors_emails( $between = null, $betweenLast = null, $before = null,
  * @return string
  */
 function coauthors_links_single( $author ) {
-	if ( get_the_author_meta( 'url' ) ) {
-		return sprintf( '<a href="%s" title="%s" rel="external">%s</a>',
-			get_the_author_meta( 'url' ),
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
-			get_the_author()
-		);
-	} else {
-		return get_the_author();
+	if ( 'guest-author' === $author->type ) {
+		if ( get_the_author_meta( 'website' ) ) {
+			return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
+				get_the_author_meta( 'website' ),
+				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
+				get_the_author()
+			);
+		} 
+	}
+	else {
+		if ( get_the_author_meta( 'url' ) ) {
+			return sprintf( '<a href="%s" title="%s" rel="external">%s</a>',
+				get_the_author_meta( 'url' ),
+				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
+				get_the_author()
+			);
+		} 
+		else {
+			return get_the_author();
+		}
 	}
 }
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -387,17 +387,15 @@ function coauthors_links_single( $author ) {
 			);
 		} 
 	}
+	elseif ( get_the_author_meta( 'url' ) ) {
+		return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
+			get_the_author_meta( 'url' ),
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
+			get_the_author()
+		);
+	} 
 	else {
-		if ( get_the_author_meta( 'url' ) ) {
-			return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
-				get_the_author_meta( 'url' ),
-				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
-				get_the_author()
-			);
-		} 
-		else {
-			return get_the_author();
-		}
+		return get_the_author();
 	}
 }
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -389,7 +389,7 @@ function coauthors_links_single( $author ) {
 	}
 	else {
 		if ( get_the_author_meta( 'url' ) ) {
-			return sprintf( '<a href="%s" title="%s" rel="external">%s</a>',
+			return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
 				get_the_author_meta( 'url' ),
 				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
 				get_the_author()

--- a/template-tags.php
+++ b/template-tags.php
@@ -35,6 +35,8 @@ function get_coauthors( $post_id = 0 ) {
 			}
 		} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
 	}
+	// remove duplicate $coauthors objects from mapping user accounts to guest authors accounts
+	$coauthors = array_unique( $coauthors, SORT_REGULAR );
 	return $coauthors;
 }
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -381,21 +381,21 @@ function coauthors_links_single( $author ) {
 	if ( 'guest-author' === $author->type ) {
 		if ( get_the_author_meta( 'website' ) ) {
 			return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
-				get_the_author_meta( 'website' ),
-				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
-				get_the_author()
+				esc_url( get_the_author_meta( 'website' ) ),
+				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
+				esc_html( get_the_author() )
 			);
 		} 
 	}
 	elseif ( get_the_author_meta( 'url' ) ) {
 		return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
-			get_the_author_meta( 'url' ),
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
-			get_the_author()
+			esc_url( get_the_author_meta( 'url' ) ),
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
+			esc_html( get_the_author() )
 		);
 	} 
 	else {
-		return get_the_author();
+		return esc_html( get_the_author() );
 	}
 }
 


### PR DESCRIPTION
As per #132, the template tag `coauthors_links()` was not working for guest authors.  This patch addresses the issue.