### PR TITLE
Fixes logic for DOING_AUTOSAVE check

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -729,7 +729,7 @@ class CoAuthors_Plus {
 	function coauthors_set_post_author_field( $data, $postarr ) {
 
 		// Bail on autosave
-		if ( defined( 'DOING_AUTOSAVE' ) && ! DOING_AUTOSAVE ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return $data;
 		}
 
@@ -772,7 +772,7 @@ class CoAuthors_Plus {
 	 */
 	function coauthors_update_post( $post_id, $post ) {
 
-		if ( defined( 'DOING_AUTOSAVE' ) && ! DOING_AUTOSAVE ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
 


### PR DESCRIPTION
The logic for checking whether Autosave is occurring is reversed.  It doesn't look like this bug is very serious, as it doesn't prevent data from being saved during a normal post save.  I think mainly this fix would help with performance.  Autosave occurs every few seconds on the edit screen, so on a site with a lot of users, this could add up.