### PR TITLE
Remove redundant test for 404 on Author Archive

### DIFF
--- a/tests/test-author-queried-object.php
+++ b/tests/test-author-queried-object.php
@@ -52,12 +52,6 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 		$this->go_to( get_author_posts_url( $author1 ) );
 		$this->assertQueryTrue( 'is_author', 'is_archive' );
 
-		/**
-		 * Author 2 is not yet an author on the blog
-		 */
-		$this->go_to( get_author_posts_url( $author2 ) );
-		$this->assertQueryTrue( 'is_404' );
-
 		// Add the user to the blog
 		add_user_to_blog( $blog2, $author2, 'author' );
 
@@ -93,7 +87,6 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 		 * Author 2 is no more
 		 */
 		$this->go_to( get_author_posts_url( $author2 ) );
-		$this->assertQueryTrue( 'is_404' );
 		$this->assertEquals( false, get_user_by( 'id', $author2 ) );
 
 		restore_current_blog();


### PR DESCRIPTION
Since we made CAP consistent with core in it's handling of author archives where there are no posts (see #425) we no longer expect there to be a 404 response on the author archive for a guest author.