### PR TITLE
Set $coauthors_loading

### DIFF
--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -11,7 +11,7 @@ jQuery( document ).ready(function () {
 		return false;
 	};
 
-	var $coauthors_loading;
+	var $coauthors_loading = jQuery("<span id='ajax-loading'></span>");
 
 	function coauthors_delete( elem ) {
 


### PR DESCRIPTION
As per #467, `$coauthors_loading` needs to be set for use on the admin post listing page.

props @mdbitz 