### PR TITLE
Fix the issue where guest authors with non-ASCII characters can't be used as co-authors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -766,7 +766,10 @@ class CoAuthors_Plus {
 
 		// This action happens when a post is saved while editing a post
 		if ( isset( $_REQUEST['coauthors-nonce'] ) && isset( $_POST['coauthors'] ) && is_array( $_POST['coauthors'] ) ) {
-			$author = sanitize_text_field( $_POST['coauthors'][0] );
+
+			// urlencode() is for encoding coauthor name with special characters to compare names when getting coauthor.
+			$author = urlencode( sanitize_text_field( $_POST['coauthors'][0] ) );
+
 			if ( $author ) {
 				$author_data = $this->get_coauthor_by( 'user_nicename', $author );
 				// If it's a guest author and has a linked account, store that information in post_author
@@ -812,7 +815,7 @@ class CoAuthors_Plus {
 				check_admin_referer( 'coauthors-edit', 'coauthors-nonce' );
 
 				$coauthors = (array) $_POST['coauthors'];
-				$coauthors = array_map( 'sanitize_text_field', $coauthors );
+				$coauthors = array_map( 'sanitize_title', $coauthors );
 				$this->add_coauthors( $post_id, $coauthors );
 			}
 		} else {
@@ -1134,7 +1137,7 @@ class CoAuthors_Plus {
 		if( empty( $authors ) ) echo apply_filters( 'coauthors_no_matching_authors_message', 'Sorry, no matching authors found.');
 
 		foreach ( $authors as $author ) {
-			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . $author->display_name . ' | ' . $author->user_email . ' | ' . $author->user_nicename ) . "\n";
+			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . $author->display_name . ' | ' . $author->user_email . ' | ' . urldecode( $author->user_nicename ) ) . "\n";
 		}
 
 		die();

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -767,8 +767,8 @@ class CoAuthors_Plus {
 		// This action happens when a post is saved while editing a post
 		if ( isset( $_REQUEST['coauthors-nonce'] ) && isset( $_POST['coauthors'] ) && is_array( $_POST['coauthors'] ) ) {
 
-			// urlencode() is for encoding coauthor name with special characters to compare names when getting coauthor.
-			$author = urlencode( sanitize_text_field( $_POST['coauthors'][0] ) );
+			// rawurlencode() is for encoding coauthor name with special characters to compare names when getting coauthor.
+			$author = rawurlencode( sanitize_text_field( $_POST['coauthors'][0] ) );
 
 			if ( $author ) {
 				$author_data = $this->get_coauthor_by( 'user_nicename', $author );
@@ -1137,7 +1137,7 @@ class CoAuthors_Plus {
 		if( empty( $authors ) ) echo apply_filters( 'coauthors_no_matching_authors_message', 'Sorry, no matching authors found.');
 
 		foreach ( $authors as $author ) {
-			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . $author->display_name . ' | ' . $author->user_email . ' | ' . urldecode( $author->user_nicename ) ) . "\n";
+			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . $author->display_name . ' | ' . $author->user_email . ' | ' . rawurldecode( $author->user_nicename ) ) . "\n";
 		}
 
 		die();

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -99,7 +99,8 @@ jQuery( document ).ready(function () {
 		co.bind( 'blur', coauthors_stop_editing );
 
 		// Set the value for the auto-suggest box to the co-author's name and hide it
-		co.val( unescape( author.name ) )
+		// unescape() is deprecated, so replacing it with decodeURIComponent() here and every places.
+		co.val( decodeURIComponent( author.name ) )
 			.hide()
 			.unbind( 'focus' )
 			;
@@ -178,7 +179,7 @@ jQuery( document ).ready(function () {
 			;
 
 		if ( authorName )
-			$co.attr( 'value', unescape( authorName ) );
+			$co.attr( 'value', decodeURIComponent( authorName ) );
 		else
 			$co.attr( 'value', coAuthorsPlusStrings.search_box_text )
 				.focus( function(){ $co.val( '' ) } )
@@ -199,7 +200,9 @@ jQuery( document ).ready(function () {
 		author.login = jQuery.trim( vals[1] );
 		author.name = jQuery.trim( vals[2] );
 		author.email = jQuery.trim( vals[3] );
-		author.nicename = jQuery.trim( vals[4] );
+
+		// Decode user-nicename if it has special characters in it.
+		author.nicename = decodeURIComponent( jQuery.trim( vals[4] ) );
 
 		if ( author.id=='New' ) {
 			coauthors_new_author_display( name );
@@ -240,7 +243,7 @@ jQuery( document ).ready(function () {
 	function coauthors_create_author_tag( author ) {
 
 		var $tag = jQuery( '<span></span>' )
-							.html( unescape( author.name ) )
+							.html( decodeURIComponent( author.name ) )
 							.attr( 'title', coAuthorsPlusStrings.input_box_title )
 							.addClass( 'coauthor-tag' )
 							// Add Click event to edit
@@ -287,7 +290,7 @@ jQuery( document ).ready(function () {
 							'type': 'hidden',
 							'id': 'coauthors_hidden_input',
 							'name': 'coauthors[]',
-							'value': unescape( author.nicename )
+							'value': decodeURIComponent( author.nicename )
 							})
 						;
 

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -243,7 +243,7 @@ jQuery( document ).ready(function () {
 	function coauthors_create_author_tag( author ) {
 
 		var $tag = jQuery( '<span></span>' )
-							.html( decodeURIComponent( author.name ) )
+							.text( decodeURIComponent( author.name ) )
 							.attr( 'title', coAuthorsPlusStrings.input_box_title )
 							.addClass( 'coauthor-tag' )
 							// Add Click event to edit

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -5,6 +5,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->admin1 = $this->factory->user->create( array( 'role' => 'administrator', 'user_login' => 'admin1' ) );
 		$this->author1 = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'author1' ) );
 		$this->editor1 = $this->factory->user->create( array( 'role' => 'editor', 'user_login' => 'editor2' ) );
 
@@ -144,5 +145,108 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		$coauthors_plus->add_coauthors( $this->author1_page2, array( $author1->user_login ) );
 		$this->assertEquals( 1, count_user_posts( $editor1->ID ) );
 
+	}
+
+	/**
+	 * When filtering post data before saving to db, post_author should be set appropriately
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
+	 */
+	public function test_wp_insert_post_data_set_post_author() {
+
+		global $coauthors_plus;
+
+		$this->assertEquals( 10, has_filter( 'wp_insert_post_data', array(
+			$coauthors_plus,
+			'coauthors_set_post_author_field',
+		) ) );
+
+		wp_set_current_user( $this->author1 );
+
+		$author1       = get_user_by( 'id', $this->author1 );
+		$author1_post1 = get_post( $this->author1_post1 );
+		$data          = array(
+			'post_type'   => $author1_post1->post_type,
+			'post_author' => $author1_post1->post_author,
+		);
+
+		// Check post type is enabled or not.
+		$this->assertTrue( $coauthors_plus->is_post_type_enabled( $data['post_type'] ) );
+
+		// Encoding user nicename if it has any special characters in it.
+		$author = urlencode( sanitize_text_field( $author1->user_nicename ) );
+		$this->assertNotEmpty( $author );
+
+		// Create guest author with linked account with user.
+		$coauthors_plus->guest_authors = new CoAuthors_Guest_Authors;
+		$coauthors_plus->guest_authors->create_guest_author_from_user_id( $this->editor1 );
+
+		$editor1      = get_user_by( 'id', $this->editor1 );
+		$editor1_data = $coauthors_plus->get_coauthor_by( 'user_nicename', $editor1->user_nicename );
+
+		$this->assertEquals( 'guest-author', $editor1_data->type );
+		$this->assertNotEmpty( $editor1_data->linked_account );
+
+		// Main WP user.
+		$author_data = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
+		$this->assertEquals( 'wpuser', $author_data->type );
+
+		// Checks if post_author is unset somehow and it is available from wp_get_current_user().
+		unset( $data['post_author'] );
+
+		$user = wp_get_current_user();
+
+		$this->assertNotEmpty( $user->ID );
+		$this->assertGreaterThan( 0, $user->ID );
+	}
+
+	/**
+	 * Adding coauthors when saving post.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
+	 */
+	public function test_save_post_to_update_post_coauthor() {
+
+		global $coauthors_plus;
+
+		$this->assertEquals( 10, has_filter( 'wp_insert_post_data', array(
+			$coauthors_plus,
+			'coauthors_set_post_author_field'
+		) ) );
+
+		$author1_post1 = get_post( $this->author1_post1 );
+
+		// Check post type is enabled or not.
+		$this->assertTrue( $coauthors_plus->is_post_type_enabled( $author1_post1->post_type ) );
+
+		// If post does not have author terms.
+		$post_id = $this->factory->post->create();
+		$post    = get_post( $post_id );
+		$user    = get_userdata( $post->post_author );
+
+		$this->assertFalse( $coauthors_plus->has_author_terms( $post_id ) );
+		$this->assertFalse( $user );
+
+		// If current user is not allowed to set authors.
+		wp_set_current_user( $this->author1 );
+
+		$this->assertFalse( $coauthors_plus->current_user_can_set_authors( $author1_post1 ) );
+		$this->assertTrue( $coauthors_plus->has_author_terms( $this->author1_post1 ) );
+
+		// If current user is allowed to set authors.
+		wp_set_current_user( $this->admin1 );
+
+		$this->assertTrue( $coauthors_plus->current_user_can_set_authors( $author1_post1 ) );
+
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$coauthors_plus->add_coauthors( $this->author1_post1, array( $editor1->user_login ), true );
+
+		$_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );
+		$_POST['coauthors']          = get_coauthors( $this->author1_post1 );
+
+		$this->assertNotEmpty( $_REQUEST['coauthors-nonce'] );
+		$this->assertNotEmpty( $_POST['coauthors'] );
+		$this->assertNotEmpty( check_admin_referer( 'coauthors-edit', 'coauthors-nonce' ) );
 	}
 }

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -227,7 +227,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		$post_backup    = $_POST;
 		$request_backup = $_REQUEST;
 
-		$_REQUEST['coauthors-nonce'] = '';
+		$_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );;
 		$_POST['coauthors']          = array(
 			$user->user_nicename,
 		);
@@ -278,7 +278,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		$post_backup    = $_POST;
 		$request_backup = $_REQUEST;
 
-		$_REQUEST['coauthors-nonce'] = '';
+		$_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );;
 		$_POST['coauthors']          = array(
 			$author1->user_nicename,
 		);

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -48,10 +48,6 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		);
 
 		$this->author1_page2 = wp_insert_post( $page );
-
-		$this->post_array = array(
-			'ID' => $this->author1,
-		);
 	}
 
 	public function tearDown() {
@@ -156,7 +152,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_set_post_author_field()
+	 * @covers ::coauthors_set_post_author_field()
 	 */
 	public function test_coauthors_set_post_author_field_when_post_type_is_attachment() {
 
@@ -174,12 +170,13 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$post = get_post( $post_id );
 
-		$data = array(
+		$data = $post_array = array(
+			'ID'          => $post->ID,
 			'post_type'   => $post->post_type,
 			'post_author' => $post->post_author,
 		);
 
-		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $this->post_array );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $post_array );
 
 		$this->assertEquals( $data, $new_data );
 	}
@@ -189,7 +186,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_set_post_author_field()
+	 * @covers ::coauthors_set_post_author_field()
 	 */
 	public function test_coauthors_set_post_author_field_when_coauthor_is_not_set() {
 
@@ -197,12 +194,13 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$author1_post1 = get_post( $this->author1_post1 );
 
-		$data = array(
+		$data = $post_array = array(
+			'ID'          => $author1_post1->ID,
 			'post_type'   => $author1_post1->post_type,
 			'post_author' => $author1_post1->post_author,
 		);
 
-		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $this->post_array );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $post_array );
 
 		$this->assertEquals( $data, $new_data );
 	}
@@ -212,7 +210,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_set_post_author_field()
+	 * @covers ::coauthors_set_post_author_field()
 	 */
 	public function test_coauthors_set_post_author_field_when_coauthor_is_set() {
 
@@ -225,6 +223,10 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$user = get_user_by( 'id', $user_id );
 
+		// Backing up global variables.
+		$post_backup    = $_POST;
+		$request_backup = $_REQUEST;
+
 		$_REQUEST['coauthors-nonce'] = '';
 		$_POST['coauthors']          = array(
 			$user->user_nicename,
@@ -236,14 +238,19 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$post = get_post( $post_id );
 
-		$data = array(
+		$data = $post_array = array(
+			'ID'          => $post->ID,
 			'post_type'   => $post->post_type,
 			'post_author' => $post->post_author,
 		);
 
-		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $this->post_array );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $post_array );
 
 		$this->assertEquals( $data, $new_data );
+
+		// Store global variables from backup.
+		$_POST    = $post_backup;
+		$_REQUEST = $request_backup;
 	}
 
 	/**
@@ -251,7 +258,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_set_post_author_field()
+	 * @covers ::coauthors_set_post_author_field()
 	 */
 	public function test_coauthors_set_post_author_field_when_guest_author_is_linked_with_wp_user() {
 
@@ -261,10 +268,15 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$author1_post1 = get_post( $this->author1_post1 );
 
-		$data = array(
+		$data = $post_array = array(
+			'ID'          => $author1_post1->ID,
 			'post_type'   => $author1_post1->post_type,
 			'post_author' => $author1_post1->post_author,
 		);
+
+		// Backing up global variables.
+		$post_backup    = $_POST;
+		$request_backup = $_REQUEST;
 
 		$_REQUEST['coauthors-nonce'] = '';
 		$_POST['coauthors']          = array(
@@ -275,9 +287,13 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		$coauthors_plus->guest_authors = new CoAuthors_Guest_Authors;
 		$coauthors_plus->guest_authors->create_guest_author_from_user_id( $this->author1 );
 
-		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $this->post_array );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $post_array );
 
 		$this->assertEquals( $data, $new_data );
+
+		// Store global variables from backup.
+		$_POST    = $post_backup;
+		$_REQUEST = $request_backup;
 	}
 
 	/**
@@ -285,7 +301,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_set_post_author_field()
+	 * @covers ::coauthors_set_post_author_field()
 	 */
 	public function test_coauthors_set_post_author_field_when_post_author_is_not_set() {
 
@@ -293,11 +309,29 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		wp_set_current_user( $this->author1 );
 
+		// Backing up global variables.
+		$post_backup    = $_POST;
+		$request_backup = $_REQUEST;
+
 		$_REQUEST = $_POST = array();
-		$data     = array( 'post_type' => 'post' );
-		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $this->post_array );
+
+		$author1_post1 = get_post( $this->author1_post1 );
+
+		$data = $post_array = array(
+			'ID'          => $author1_post1->ID,
+			'post_type'   => $author1_post1->post_type,
+			'post_author' => $author1_post1->post_author,
+		);
+
+		unset( $data['post_author'] );
+
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $post_array );
 
 		$this->assertEquals( $this->author1, $new_data['post_author'] );
+
+		// Store global variables from backup.
+		$_POST    = $post_backup;
+		$_REQUEST = $request_backup;
 	}
 
 	/**
@@ -305,7 +339,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_update_post()
+	 * @covers ::coauthors_update_post()
 	 */
 	public function test_coauthors_update_post_when_post_type_is_attachment() {
 
@@ -328,11 +362,11 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	}
 
 	/**
-	 * Checks coauthors when current user cal set authors.
+	 * Checks coauthors when current user can set authors.
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_update_post()
+	 * @covers ::coauthors_update_post()
 	 */
 	public function test_coauthors_update_post_when_current_user_can_set_authors() {
 
@@ -349,6 +383,10 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$post = get_post( $post_id );
 
+		// Backing up global variables.
+		$post_backup    = $_POST;
+		$request_backup = $_REQUEST;
+
 		$_POST['coauthors-nonce'] = $_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );
 		$_POST['coauthors']       = array(
 			$admin1->user_nicename,
@@ -357,9 +395,13 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		$coauthors_plus->coauthors_update_post( $post_id, $post );
 
-		$coauthors = get_coauthors( $this->author1_post1 );
+		$coauthors = get_coauthors( $post_id );
 
-		$this->assertEquals( array( $this->author1 ), wp_list_pluck( $coauthors, 'ID' ) );
+		$this->assertEquals( array( $this->admin1, $this->author1 ), wp_list_pluck( $coauthors, 'ID' ) );
+
+		// Store global variables from backup.
+		$_POST    = $post_backup;
+		$_REQUEST = $request_backup;
 	}
 
 	/**
@@ -368,7 +410,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	 *
 	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/198
 	 *
-	 * @covers :: coauthors_update_post()
+	 * @covers ::coauthors_update_post()
 	 */
 	public function test_coauthors_update_post_when_post_has_not_author_terms() {
 


### PR DESCRIPTION
## See #198 

- Used `urlencode()` to encode special characters for coauthor to compare names
- Used `urldecode()` for display purpose in autocomplete with special characters in `user_nicename`
- Replaced `unescape()` with `decodeURIComponent()` in JS because `unescape()` is deprecated.
- Added unit test case for the fix and also covered additional unit test cases.