### PR TITLE
Unit tests/Fix warnings for template tags

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -537,12 +537,16 @@ function coauthors_wp_list_authors( $args = array() ) {
 				if ( empty( $args['feed_image'] ) ) {
 					$link .= '(';
 				}
-				$link .= '<a href="' . get_author_feed_link( $author->ID ) . '"';
+				$link .= '<a href="' . get_author_feed_link( $author->ID, $args['feed_type'] ) . '"';
+
+				$alt   = '';
+				$title = '';
 
 				if ( ! empty( $args['feed'] ) ) {
+
 					$title = ' title="' . esc_attr( $args['feed'] ) . '"';
-					$alt = ' alt="' . esc_attr( $args['feed'] ) . '"';
-					$name = $feed;
+					$alt   = ' alt="' . esc_attr( $args['feed'] ) . '"';
+					$name  = $args['feed'];
 					$link .= $title;
 				}
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -537,7 +537,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 				if ( empty( $args['feed_image'] ) ) {
 					$link .= '(';
 				}
-				$link .= '<a href="' . get_author_feed_link( $author->ID, $args['feed_type'] ) . '"';
+				$link .= '<a href="' . esc_url( get_author_feed_link( $author->ID, $args['feed_type'] ) ) . '"';
 
 				$alt   = '';
 				$title = '';

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -186,12 +186,10 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$coauthors = coauthors( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->display_name, $coauthors );
-		$this->assertEquals( 1, substr_count( $coauthors, $this->author1->display_name ) );
 
 		$coauthors = coauthors( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->display_name . '</span>', $coauthors );
-		$this->assertEquals( 1, substr_count( $coauthors, $this->author1->display_name ) );
 
 		// Checks for multiple post author.
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
@@ -199,14 +197,10 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$coauthors = coauthors( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->display_name . ' and ' . $this->editor1->display_name, $coauthors );
-		$this->assertEquals( 1, substr_count( $coauthors, $this->author1->display_name ) );
-		$this->assertEquals( 1, substr_count( $coauthors, $this->editor1->display_name ) );
 
 		$coauthors = coauthors( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->display_name . '</span><span>' . $this->editor1->display_name . '</span>', $coauthors );
-		$this->assertEquals( 1, substr_count( $coauthors, $this->author1->display_name ) );
-		$this->assertEquals( 1, substr_count( $coauthors, $this->editor1->display_name ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;
@@ -244,30 +238,26 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$post = $this->post;
 
+		// Checking when first name is not set for user, so it should match with user_login.
 		$first_names = coauthors_firstnames( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_login, $first_names );
-		$this->assertEquals( 1, substr_count( $first_names, $this->author1->user_login ) );
 
 		$first_names = coauthors_firstnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_login . '</span>', $first_names );
-		$this->assertEquals( 1, substr_count( $first_names, $this->author1->user_login ) );
 
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
 
 		$first_names = coauthors_firstnames( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_login . ' and ' . $this->editor1->user_login, $first_names );
-		$this->assertEquals( 1, substr_count( $first_names, $this->author1->user_login ) );
-		$this->assertEquals( 1, substr_count( $first_names, $this->editor1->user_login ) );
 
 		$first_names = coauthors_firstnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_login . '</span><span>' . $this->editor1->user_login . '</span>', $first_names );
-		$this->assertEquals( 1, substr_count( $first_names, $this->author1->user_login ) );
-		$this->assertEquals( 1, substr_count( $first_names, $this->editor1->user_login ) );
 
+		// Checking when first name is set for user.
 		$first_name = 'Test';
 		$user_id    = $this->factory->user->create( array(
 			'first_name' => $first_name,
@@ -279,7 +269,6 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$first_names = coauthors_firstnames( null, null, null, null, false );
 
 		$this->assertEquals( $first_name, $first_names );
-		$this->assertEquals( 1, substr_count( $first_names, $first_name ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;
@@ -300,30 +289,26 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$post = $this->post;
 
+		// Checking when last name is not set for user, so it should match with user_login.
 		$last_names = coauthors_lastnames( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_login, $last_names );
-		$this->assertEquals( 1, substr_count( $last_names, $this->author1->user_login ) );
 
 		$last_names = coauthors_lastnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_login . '</span>', $last_names );
-		$this->assertEquals( 1, substr_count( $last_names, $this->author1->user_login ) );
 
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
 
 		$last_names = coauthors_lastnames( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_login . ' and ' . $this->editor1->user_login, $last_names );
-		$this->assertEquals( 1, substr_count( $last_names, $this->author1->user_login ) );
-		$this->assertEquals( 1, substr_count( $last_names, $this->editor1->user_login ) );
 
 		$last_names = coauthors_lastnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_login . '</span><span>' . $this->editor1->user_login . '</span>', $last_names );
-		$this->assertEquals( 1, substr_count( $last_names, $this->author1->user_login ) );
-		$this->assertEquals( 1, substr_count( $last_names, $this->editor1->user_login ) );
 
+		// Checking when last name is set for user.
 		$last_name = 'Test';
 		$user_id   = $this->factory->user->create( array(
 			'last_name' => $last_name,
@@ -335,7 +320,6 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$last_names = coauthors_lastnames( null, null, null, null, false );
 
 		$this->assertEquals( $last_name, $last_names );
-		$this->assertEquals( 1, substr_count( $last_names, $last_name ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;
@@ -356,30 +340,26 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$post = $this->post;
 
+		// Checking when nickname is not set for user, so it should match with user_login.
 		$nick_names = coauthors_nicknames( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_login, $nick_names );
-		$this->assertEquals( 1, substr_count( $nick_names, $this->author1->user_login ) );
 
 		$nick_names = coauthors_nicknames( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_login . '</span>', $nick_names );
-		$this->assertEquals( 1, substr_count( $nick_names, $this->author1->user_login ) );
 
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
 
 		$nick_names = coauthors_nicknames( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_login . ' and ' . $this->editor1->user_login, $nick_names );
-		$this->assertEquals( 1, substr_count( $nick_names, $this->author1->user_login ) );
-		$this->assertEquals( 1, substr_count( $nick_names, $this->editor1->user_login ) );
 
 		$nick_names = coauthors_nicknames( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_login . '</span><span>' . $this->editor1->user_login . '</span>', $nick_names );
-		$this->assertEquals( 1, substr_count( $nick_names, $this->author1->user_login ) );
-		$this->assertEquals( 1, substr_count( $nick_names, $this->editor1->user_login ) );
 
+		// Checking when nickname is set for user.
 		$nick_name = 'Test';
 		$user_id   = $this->factory->user->create( array(
 			'nickname' => $nick_name,
@@ -391,7 +371,6 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$nick_names = coauthors_nicknames( null, null, null, null, false );
 
 		$this->assertEquals( $nick_name, $nick_names );
-		$this->assertEquals( 1, substr_count( $nick_names, $nick_name ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;
@@ -415,26 +394,20 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$emails = coauthors_emails( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_email, $emails );
-		$this->assertEquals( 1, substr_count( $emails, $this->author1->user_email ) );
 
 		$emails = coauthors_emails( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_email . '</span>', $emails );
-		$this->assertEquals( 1, substr_count( $emails, $this->author1->user_email ) );
 
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
 
 		$emails = coauthors_emails( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->user_email . ' and ' . $this->editor1->user_email, $emails );
-		$this->assertEquals( 1, substr_count( $emails, $this->author1->user_email ) );
-		$this->assertEquals( 1, substr_count( $emails, $this->editor1->user_email ) );
 
 		$emails = coauthors_emails( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->user_email . '</span><span>' . $this->editor1->user_email . '</span>', $emails );
-		$this->assertEquals( 1, substr_count( $emails, $this->author1->user_email ) );
-		$this->assertEquals( 1, substr_count( $emails, $this->editor1->user_email ) );
 
 		$email   = 'test@example.org';
 		$user_id = $this->factory->user->create( array(
@@ -447,7 +420,6 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$emails = coauthors_emails( null, null, null, null, false );
 
 		$this->assertEquals( $email, $emails );
-		$this->assertEquals( 1, substr_count( $emails, $email ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;
@@ -561,26 +533,20 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$ids = coauthors_ids( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->ID, $ids );
-		$this->assertEquals( 1, substr_count( $ids, $this->author1->ID ) );
 
 		$ids = coauthors_ids( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->ID . '</span>', $ids );
-		$this->assertEquals( 1, substr_count( $ids, $this->author1->ID ) );
 
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
 
 		$ids = coauthors_ids( null, null, null, null, false );
 
 		$this->assertEquals( $this->author1->ID . ' and ' . $this->editor1->ID, $ids );
-		$this->assertEquals( 1, substr_count( $ids, $this->author1->ID ) );
-		$this->assertEquals( 1, substr_count( $ids, $this->editor1->ID ) );
 
 		$ids = coauthors_ids( '</span><span>', '</span><span>', '<span>', '</span>', false );
 
 		$this->assertEquals( '<span>' . $this->author1->ID . '</span><span>' . $this->editor1->ID . '</span>', $ids );
-		$this->assertEquals( 1, substr_count( $ids, $this->author1->ID ) );
-		$this->assertEquals( 1, substr_count( $ids, $this->editor1->ID ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -87,6 +87,39 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 	}
 
 	/**
+	 * Checks coauthors order.
+	 *
+	 * @covers ::get_coauthors()
+	 */
+	public function test_coauthors_order() {
+
+		global $coauthors_plus;
+
+		$post_id = $this->factory->post->create();
+
+		// Checks when no author exist.
+		$this->assertEmpty( get_coauthors( $post_id ) );
+
+		// Checks coauthors order.
+		$coauthors_plus->add_coauthors( $post_id, array( $this->author1->user_login ), true );
+		$coauthors_plus->add_coauthors( $post_id, array( $this->editor1->user_login ), true );
+
+		$expected = array( $this->author1->user_login, $this->editor1->user_login );
+
+		$this->assertEquals( $expected, wp_list_pluck( get_coauthors( $post_id ), 'user_login' ) );
+
+		// Checks coauthors order after modifying.
+		$post_id = $this->factory->post->create();
+
+		$coauthors_plus->add_coauthors( $post_id, array( $this->editor1->user_login ), true );
+		$coauthors_plus->add_coauthors( $post_id, array( $this->author1->user_login ), true );
+
+		$expected = array( $this->editor1->user_login, $this->author1->user_login );
+
+		$this->assertEquals( $expected, wp_list_pluck( get_coauthors( $post_id ), 'user_login' ) );
+	}
+
+	/**
 	 * Checks whether user is a coauthor of the post when user or post not exists.
 	 *
 	 * @covers ::is_coauthor_for_post()

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -599,4 +599,50 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Restore global author data from backup.
 		$authordata = $authordata_backup;
 	}
+
+	/**
+	 * Checks co-authors IDs.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_ids()
+	 */
+	public function test_coauthors_ids() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post    = get_post( $this->post_id );
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$ids = coauthors_ids( null, null, null, null, false );
+
+		$this->assertEquals( $author1->ID, $ids );
+		$this->assertEquals( 1, substr_count( $ids, $author1->ID ) );
+
+		$ids = coauthors_ids( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->ID . '</span>', $ids );
+		$this->assertEquals( 1, substr_count( $ids, $author1->ID ) );
+
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$ids = coauthors_ids( null, null, null, null, false );
+
+		$this->assertEquals( $author1->ID . ' and ' . $editor1->ID, $ids );
+		$this->assertEquals( 1, substr_count( $ids, $author1->ID ) );
+		$this->assertEquals( 1, substr_count( $ids, $editor1->ID ) );
+
+		$ids = coauthors_ids( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->ID . '</span><span>' . $editor1->ID . '</span>', $ids );
+		$this->assertEquals( 1, substr_count( $ids, $author1->ID ) );
+		$this->assertEquals( 1, substr_count( $ids, $editor1->ID ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -362,13 +362,13 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( 1, substr_count( $last_names, $editor1->user_login ) );
 
 		$last_name = 'Test';
-		$user_id    = $this->factory->user->create( array(
+		$user_id   = $this->factory->user->create( array(
 			'last_name' => $last_name,
 		) );
-		$post_id    = $this->factory->post->create( array(
+		$post_id   = $this->factory->post->create( array(
 			'post_author' => $user_id,
 		) );
-		$post       = get_post( $post_id );
+		$post      = get_post( $post_id );
 
 		$last_names = coauthors_lastnames( null, null, null, null, false );
 
@@ -434,6 +434,66 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$this->assertEquals( $nick_name, $nick_names );
 		$this->assertEquals( 1, substr_count( $nick_names, $nick_name ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
+
+	/**
+	 * Checks co-authors email addresses.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_emails()
+	 */
+	public function test_coauthors_emails() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post    = get_post( $this->post_id );
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$emails = coauthors_emails( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_email, $emails );
+		$this->assertEquals( 1, substr_count( $emails, $author1->user_email ) );
+
+		$emails = coauthors_emails( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_email . '</span>', $emails );
+		$this->assertEquals( 1, substr_count( $emails, $author1->user_email ) );
+
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$emails = coauthors_emails( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_email . ' and ' . $editor1->user_email, $emails );
+		$this->assertEquals( 1, substr_count( $emails, $author1->user_email ) );
+		$this->assertEquals( 1, substr_count( $emails, $editor1->user_email ) );
+
+		$emails = coauthors_emails( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_email . '</span><span>' . $editor1->user_email . '</span>', $emails );
+		$this->assertEquals( 1, substr_count( $emails, $author1->user_email ) );
+		$this->assertEquals( 1, substr_count( $emails, $editor1->user_email ) );
+
+		$email   = 'test@example.org';
+		$user_id = $this->factory->user->create( array(
+			'user_email' => $email,
+		) );
+		$post_id = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+		$post    = get_post( $post_id );
+
+		$emails = coauthors_emails( null, null, null, null, false );
+
+		$this->assertEquals( $email, $emails );
+		$this->assertEquals( 1, substr_count( $emails, $email ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -249,6 +249,13 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( 1, substr_count( $author_link, ">{$author1->display_name}<" ) );
 	}
 
+	/**
+	 * Checks co-authors first names, without links to their posts.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_firstnames()
+	 */
 	public function test_coauthors_firstnames() {
 
 		global $post, $coauthors_plus;

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -228,4 +228,24 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Restore global post from backup.
 		$post = $post_backup;
 	}
+
+	/**
+	 * Checks single co-author linked to their post archive.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_posts_links_single()
+	 */
+	public function test_coauthors_posts_links_single() {
+
+		$author1     = get_user_by( 'id', $this->author1 );
+		$author_link = coauthors_posts_links_single( $author1 );
+
+		$this->assertContains( 'href="' . get_author_posts_url( $author1->ID, $author1->user_nicename ) . '"', $author_link, 'Author link not found.' );
+		$this->assertContains( $author1->display_name, $author_link, 'Author name not found.' );
+
+		// Here we are checking author name should not be more then one time.
+		// Asserting ">{$author1->display_name}<" because "$author1->display_name" can be multiple times like in href, title, etc.
+		$this->assertEquals( 1, substr_count( $author_link, ">{$author1->display_name}<" ) );
+	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -297,4 +297,53 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Restore global post from backup.
 		$post = $post_backup;
 	}
+
+	/**
+	 * Checks co-authors last names, without links to their posts.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_lastnames()
+	 */
+	public function test_coauthors_lastnames() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post    = get_post( $this->post_id );
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$last_names = coauthors_lastnames( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_login, $last_names );
+		$this->assertEquals( 1, substr_count( $last_names, $author1->user_login ) );
+
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$last_names = coauthors_lastnames( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_login . ' and ' . $editor1->user_login, $last_names );
+		$this->assertEquals( 1, substr_count( $last_names, $author1->user_login ) );
+		$this->assertEquals( 1, substr_count( $last_names, $editor1->user_login ) );
+
+		$last_name = 'Test';
+		$user_id    = $this->factory->user->create( array(
+			'last_name' => $last_name,
+		) );
+		$post_id    = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+		$post       = get_post( $post_id );
+
+		$last_names = coauthors_lastnames( null, null, null, null, false );
+
+		$this->assertEquals( $last_name, $last_names );
+		$this->assertEquals( 1, substr_count( $last_names, $last_name ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -1,0 +1,193 @@
+<?php
+
+class Test_Template_Tags extends CoAuthorsPlus_TestCase {
+
+	public function setUp() {
+
+		parent::setUp();
+
+		$this->author1 = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'author1' ) );
+		$this->editor1 = $this->factory->user->create( array( 'role' => 'editor', 'user_login' => 'editor1' ) );
+
+		$this->post_id = wp_insert_post( array(
+			'post_author'  => $this->author1,
+			'post_status'  => 'publish',
+			'post_content' => rand_str(),
+			'post_title'   => rand_str(),
+			'post_type'    => 'post',
+		) );
+	}
+
+	/**
+	 * Checks coauthors when post not exist.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::get_coauthors()
+	 */
+	public function test_get_coauthors_when_post_not_exists() {
+
+		$this->assertEmpty( get_coauthors() );
+	}
+
+	/**
+	 * Checks coauthors when post exist (not global).
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::get_coauthors()
+	 */
+	public function test_get_coauthors_when_post_exists() {
+
+		global $coauthors_plus;
+
+		// Compare single author.
+		$coauthors = get_coauthors( $this->post_id );
+		$this->assertEquals( array( $this->author1 ), wp_list_pluck( $coauthors, 'ID' ) );
+
+		// Compare multiple authors.
+		$editor1 = get_user_by( 'id', $this->editor1 );
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$coauthors = get_coauthors( $this->post_id );
+		$this->assertEquals( array( $this->author1, $this->editor1 ), wp_list_pluck( $coauthors, 'ID' ) );
+	}
+
+	/**
+	 * Checks coauthors when terms for post not exist.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::get_coauthors()
+	 */
+	public function test_get_coauthors_when_terms_for_post_not_exists() {
+
+		$post_id = $this->factory->post->create();
+		$this->assertEmpty( get_coauthors( $post_id ) );
+	}
+
+	/**
+	 * Checks coauthors when post not exist.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::get_coauthors()
+	 */
+	public function test_get_coauthors_when_global_post_exists() {
+
+		global $post;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post_id = $this->factory->post->create();
+		$post    = get_post( $post_id );
+
+		$this->assertEmpty( get_coauthors( $post_id ) );
+
+		$user_id   = $this->factory->user->create();
+		$post_id   = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+		$post      = get_post( $post_id );
+		$coauthors = get_coauthors( $post_id );
+
+		$this->assertEquals( array( $user_id ), wp_list_pluck( $coauthors, 'ID' ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
+
+	/**
+	 * Checks whether user is a coauthor of the post when user or post not exists.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::is_coauthor_for_post()
+	 */
+	public function test_is_coauthor_for_post_when_user_or_post_not_exists() {
+
+		global $post;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$this->assertFalse( is_coauthor_for_post( '' ) );
+		$this->assertFalse( is_coauthor_for_post( '', $this->post_id ) );
+		$this->assertFalse( is_coauthor_for_post( $this->author1 ) );
+
+		$post = get_post( $this->post_id );
+
+		$this->assertFalse( is_coauthor_for_post( '' ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
+
+	/**
+	 * Checks whether user is a coauthor of the post when user is not expected as ID,
+	 * or user_login is not set in user object.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::is_coauthor_for_post()
+	 */
+	public function test_is_coauthor_for_post_when_user_not_numeric_or_user_login_not_set() {
+
+		$this->assertFalse( is_coauthor_for_post( 'test' ) );
+	}
+
+	/**
+	 * Checks whether user is a coauthor of the post when user is set in either way,
+	 * as user_id or user object but he/she is not coauthor of the post.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::is_coauthor_for_post()
+	 */
+	public function test_is_coauthor_for_post_when_user_numeric_or_user_login_set_but_no_coauthor() {
+
+		$this->assertFalse( is_coauthor_for_post( $this->editor1, $this->post_id ) );
+
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$this->assertFalse( is_coauthor_for_post( $editor1, $this->post_id ) );
+	}
+
+	/**
+	 * Checks whether user is a coauthor of the post.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::is_coauthor_for_post()
+	 */
+	public function test_is_coauthor_for_post_when_user_is_coauthor() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$this->assertTrue( is_coauthor_for_post( $this->author1, $this->post_id ) );
+		$this->assertTrue( is_coauthor_for_post( $author1, $this->post_id ) );
+
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$this->assertTrue( is_coauthor_for_post( $this->editor1, $this->post_id ) );
+		$this->assertTrue( is_coauthor_for_post( $editor1, $this->post_id ) );
+
+		$post = get_post( $this->post_id );
+
+		$this->assertTrue( is_coauthor_for_post( $this->author1 ) );
+		$this->assertTrue( is_coauthor_for_post( $author1 ) );
+
+		$this->assertTrue( is_coauthor_for_post( $this->editor1 ) );
+		$this->assertTrue( is_coauthor_for_post( $editor1 ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
+}

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -248,4 +248,46 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Asserting ">{$author1->display_name}<" because "$author1->display_name" can be multiple times like in href, title, etc.
 		$this->assertEquals( 1, substr_count( $author_link, ">{$author1->display_name}<" ) );
 	}
+
+	public function test_coauthors_firstnames() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post    = get_post( $this->post_id );
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$first_names = coauthors_firstnames( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_login, $first_names );
+		$this->assertEquals( 1, substr_count( $first_names, $author1->user_login ) );
+
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$first_names = coauthors_firstnames( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_login . ' and ' . $editor1->user_login, $first_names );
+		$this->assertEquals( 1, substr_count( $first_names, $author1->user_login ) );
+		$this->assertEquals( 1, substr_count( $first_names, $editor1->user_login ) );
+
+		$first_name = 'Test';
+		$user_id    = $this->factory->user->create( array(
+			'first_name' => $first_name,
+		) );
+		$post_id    = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+		$post       = get_post( $post_id );
+
+		$first_names = coauthors_firstnames( null, null, null, null, false );
+
+		$this->assertEquals( $first_name, $first_names );
+		$this->assertEquals( 1, substr_count( $first_names, $first_name ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -498,4 +498,105 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Restore global post from backup.
 		$post = $post_backup;
 	}
+
+	/**
+	 * Checks single co-author if he/she is a guest author.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_links_single()
+	 */
+	public function test_coauthors_links_single_when_guest_author() {
+
+		global $authordata;
+
+		// Backing up global author data.
+		$authordata_backup = $authordata;
+
+		$author1       = get_user_by( 'id', $this->author1 );
+		$author1->type = 'guest-author';
+		$author_link   = coauthors_links_single( $author1 );
+
+		$this->assertNull( $author_link );
+
+		update_user_meta( $this->author1, 'website', 'example.org' );
+
+		$author_link = coauthors_links_single( $author1 );
+
+		$this->assertNull( $author_link );
+
+		$authordata  = $author1;
+		$author_link = coauthors_links_single( $author1 );
+
+		$this->assertContains( get_the_author_meta( 'website' ), $author_link, 'Author link not found.' );
+		$this->assertContains( get_the_author(), $author_link, 'Author name not found.' );
+
+		// Here we are checking author name should not be more then one time.
+		// Asserting ">get_the_author()<" because "get_the_author()" can be multiple times like in href, title, etc.
+		$this->assertEquals( 1, substr_count( $author_link, '>' . get_the_author() . '<' ) );
+
+		// Restore global author data from backup.
+		$authordata = $authordata_backup;
+	}
+
+	/**
+	 * Checks single co-author when user's url is set and not a guest author.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_links_single()
+	 */
+	public function test_coauthors_links_single_author_url_is_set() {
+
+		global $authordata;
+
+		// Backing up global author data.
+		$authordata_backup = $authordata;
+
+		$user_id = $this->factory->user->create( array(
+			'user_url' => 'example.org',
+		) );
+		$user    = get_user_by( 'id', $user_id );
+
+		$authordata  = $user;
+		$author_link = coauthors_links_single( $user );
+
+		$this->assertContains( get_the_author_meta( 'url' ), $author_link, 'Author link not found.' );
+		$this->assertContains( get_the_author(), $author_link, 'Author name not found.' );
+
+		// Here we are checking author name should not be more then one time.
+		// Asserting ">get_the_author()<" because "get_the_author()" can be multiple times like in href, title, etc.
+		$this->assertEquals( 1, substr_count( $author_link, '>' . get_the_author() . '<' ) );
+
+		// Restore global author data from backup.
+		$authordata = $authordata_backup;
+	}
+
+	/**
+	 * Checks single co-author when user's website/url not exist.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_links_single()
+	 */
+	public function test_coauthors_links_single_when_url_not_exist() {
+
+		global $authordata;
+
+		// Backing up global author data.
+		$authordata_backup = $authordata;
+
+		$author1     = get_user_by( 'id', $this->author1 );
+		$author_link = coauthors_links_single( $author1 );
+
+		$this->assertEmpty( $author_link );
+
+		$authordata  = $author1;
+		$author_link = coauthors_links_single( $author1 );
+
+		$this->assertEquals( get_the_author(), $author_link );
+
+		// Restore global author data from backup.
+		$authordata = $authordata_backup;
+	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -645,4 +645,33 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Restore global post from backup.
 		$post = $post_backup;
 	}
+
+	/**
+	 * Checks co-authors meta.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::get_the_coauthor_meta()
+	 */
+	public function test_get_the_coauthor_meta() {
+
+		global $post;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$this->assertEmpty( get_the_coauthor_meta( '' ) );
+
+		update_user_meta( $this->author1, 'test_meta', 'test_meta' );
+
+		$this->assertEmpty( get_the_coauthor_meta( 'test_meta' ) );
+
+		$post = get_post( $this->post_id );
+		$meta = get_the_coauthor_meta( 'test_meta' );
+
+		$this->assertEquals( 'test_meta', $meta[ $this->author1 ] );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
 }

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -214,7 +214,11 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$this->assertEquals( $author1->display_name, $coauthors );
 		$this->assertEquals( 1, substr_count( $coauthors, $author1->display_name ) );
-		$this->assertEquals( 0, substr_count( $coauthors, $editor1->display_name ) );
+
+		$coauthors = coauthors( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->display_name . '</span>', $coauthors );
+		$this->assertEquals( 1, substr_count( $coauthors, $author1->display_name ) );
 
 		// Checks for multiple post author.
 		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
@@ -222,6 +226,12 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$coauthors = coauthors( null, null, null, null, false );
 
 		$this->assertEquals( $author1->display_name . ' and ' . $editor1->display_name, $coauthors );
+		$this->assertEquals( 1, substr_count( $coauthors, $author1->display_name ) );
+		$this->assertEquals( 1, substr_count( $coauthors, $editor1->display_name ) );
+
+		$coauthors = coauthors( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->display_name . '</span><span>' . $editor1->display_name . '</span>', $coauthors );
 		$this->assertEquals( 1, substr_count( $coauthors, $author1->display_name ) );
 		$this->assertEquals( 1, substr_count( $coauthors, $editor1->display_name ) );
 
@@ -272,11 +282,22 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( $author1->user_login, $first_names );
 		$this->assertEquals( 1, substr_count( $first_names, $author1->user_login ) );
 
+		$first_names = coauthors_firstnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_login . '</span>', $first_names );
+		$this->assertEquals( 1, substr_count( $first_names, $author1->user_login ) );
+
 		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
 
 		$first_names = coauthors_firstnames( null, null, null, null, false );
 
 		$this->assertEquals( $author1->user_login . ' and ' . $editor1->user_login, $first_names );
+		$this->assertEquals( 1, substr_count( $first_names, $author1->user_login ) );
+		$this->assertEquals( 1, substr_count( $first_names, $editor1->user_login ) );
+
+		$first_names = coauthors_firstnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_login . '</span><span>' . $editor1->user_login . '</span>', $first_names );
 		$this->assertEquals( 1, substr_count( $first_names, $author1->user_login ) );
 		$this->assertEquals( 1, substr_count( $first_names, $editor1->user_login ) );
 
@@ -321,11 +342,22 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( $author1->user_login, $last_names );
 		$this->assertEquals( 1, substr_count( $last_names, $author1->user_login ) );
 
+		$last_names = coauthors_lastnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_login . '</span>', $last_names );
+		$this->assertEquals( 1, substr_count( $last_names, $author1->user_login ) );
+
 		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
 
 		$last_names = coauthors_lastnames( null, null, null, null, false );
 
 		$this->assertEquals( $author1->user_login . ' and ' . $editor1->user_login, $last_names );
+		$this->assertEquals( 1, substr_count( $last_names, $author1->user_login ) );
+		$this->assertEquals( 1, substr_count( $last_names, $editor1->user_login ) );
+
+		$last_names = coauthors_lastnames( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_login . '</span><span>' . $editor1->user_login . '</span>', $last_names );
 		$this->assertEquals( 1, substr_count( $last_names, $author1->user_login ) );
 		$this->assertEquals( 1, substr_count( $last_names, $editor1->user_login ) );
 
@@ -342,6 +374,66 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$this->assertEquals( $last_name, $last_names );
 		$this->assertEquals( 1, substr_count( $last_names, $last_name ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
+
+	/**
+	 * Checks co-authors nicknames, without links to their posts.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors_nicknames()
+	 */
+	public function test_coauthors_nicknames() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post    = get_post( $this->post_id );
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		$nick_names = coauthors_nicknames( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_login, $nick_names );
+		$this->assertEquals( 1, substr_count( $nick_names, $author1->user_login ) );
+
+		$nick_names = coauthors_nicknames( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_login . '</span>', $nick_names );
+		$this->assertEquals( 1, substr_count( $nick_names, $author1->user_login ) );
+
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$nick_names = coauthors_nicknames( null, null, null, null, false );
+
+		$this->assertEquals( $author1->user_login . ' and ' . $editor1->user_login, $nick_names );
+		$this->assertEquals( 1, substr_count( $nick_names, $author1->user_login ) );
+		$this->assertEquals( 1, substr_count( $nick_names, $editor1->user_login ) );
+
+		$nick_names = coauthors_nicknames( '</span><span>', '</span><span>', '<span>', '</span>', false );
+
+		$this->assertEquals( '<span>' . $author1->user_login . '</span><span>' . $editor1->user_login . '</span>', $nick_names );
+		$this->assertEquals( 1, substr_count( $nick_names, $author1->user_login ) );
+		$this->assertEquals( 1, substr_count( $nick_names, $editor1->user_login ) );
+
+		$nick_name = 'Test';
+		$user_id   = $this->factory->user->create( array(
+			'nickname' => $nick_name,
+		) );
+		$post_id   = $this->factory->post->create( array(
+			'post_author' => $user_id,
+		) );
+		$post      = get_post( $post_id );
+
+		$nick_names = coauthors_nicknames( null, null, null, null, false );
+
+		$this->assertEquals( $nick_name, $nick_names );
+		$this->assertEquals( 1, substr_count( $nick_names, $nick_name ) );
 
 		// Restore global post from backup.
 		$post = $post_backup;

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -190,4 +190,42 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Restore global post from backup.
 		$post = $post_backup;
 	}
+
+	/**
+	 * Tests for co-authors display names, without links to their posts.
+	 *
+	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/184
+	 *
+	 * @covers ::coauthors()
+	 **/
+	public function test_coauthors() {
+
+		global $post, $coauthors_plus;
+
+		// Backing up global post.
+		$post_backup = $post;
+
+		$post    = get_post( $this->post_id );
+		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
+
+		// Checks for single post author.
+		$coauthors = coauthors( null, null, null, null, false );
+
+		$this->assertEquals( $author1->display_name, $coauthors );
+		$this->assertEquals( 1, substr_count( $coauthors, $author1->display_name ) );
+		$this->assertEquals( 0, substr_count( $coauthors, $editor1->display_name ) );
+
+		// Checks for multiple post author.
+		$coauthors_plus->add_coauthors( $this->post_id, array( $editor1->user_login ), true );
+
+		$coauthors = coauthors( null, null, null, null, false );
+
+		$this->assertEquals( $author1->display_name . ' and ' . $editor1->display_name, $coauthors );
+		$this->assertEquals( 1, substr_count( $coauthors, $author1->display_name ) );
+		$this->assertEquals( 1, substr_count( $coauthors, $editor1->display_name ) );
+
+		// Restore global post from backup.
+		$post = $post_backup;
+	}
 }


### PR DESCRIPTION
## See #184 

**Added unit tests for below methods**:
- get_coauthors() 
- coauthors orders
- is_coauthor_for_post()
- coauthors()
- coauthors_posts_links_single()
- coauthors_firstnames()
- coauthors_lastnames()
- coauthors_nicknames()
- coauthors_emails()
- coauthors_links_single()
- coauthors_ids()
- get_the_coauthor_meta()
- coauthors_wp_list_authors()
- coauthors_get_avatar()

**Fixed undefined variable warnings**:
- Undefined variable: feed ( https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L545 )
- Undefined variable: alt ( https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L552 )
- Undefined variable: title ( https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L552 )

**Added `feed_type` for getting author feed link**:
- Should use `$args['feed_type']` at https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L540 to add support for `feed_type` in author's feed link same as in WP's `wp_list_authors()` method ( https://github.com/WordPress/WordPress/blob/master/wp-includes/author-template.php#L484 ).