### PR TITLE
Changes to resolve issue #332 about missing coauthor meta 

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -422,43 +422,46 @@ function coauthors_ids( $between = null, $betweenLast = null, $before = null, $a
  *
  * @param string $field Required The user field to retrieve.[login, email, nicename, display_name, url, type]
  * @param string $user_id Optional The user ID for meta
+ *
+ * @return array $meta Value of the user field
  */
-function get_the_coauthor_meta( $field, $user_id = false ) { 
+function get_the_coauthor_meta( $field, $user_id = false ) {
 	global $coauthors_plus;
 
 	if ( ! $user_id ) {
 		$coauthors = get_coauthors();
-        } else {
-                $coauthor_data = $coauthors_plus->get_coauthor_by( 'id', $user_id );
-                $coauthors = array();
-                if ( ! empty( $coauthor_data ) ) {
-			$coauthors[] = $coauthor_data;
-		}
+    } else {
+        $coauthor_data = $coauthors_plus->get_coauthor_by( 'id', $user_id );
+        $coauthors = array();
+        if ( ! empty( $coauthor_data ) ) {
+            $coauthors[] = $coauthor_data;
         }
+    }
 
 	$meta = array();
-        
-        if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) )
-                $field = 'user_' . $field;
-        
-	foreach ( $coauthors as $coauthor ) {                
-		$user_id = $coauthor->ID;      
-                
-                if ( isset( $coauthor->type )  && 'user_url' === $field ) {
-                        if ( 'guest-author' === $coauthor->type) {
-                                $field = 'website';
-                        } 
-                } else if ( 'website' === $field ) {
-                        $field = 'user_url';
-                }
-                
-                if ( isset( $coauthor->$field ) ) {
-                        $meta[ $user_id ] = $coauthor->$field;
-                } else {
-                        $meta[ $user_id ] = '';
-                }                                
-	}        
-        
+
+    if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) ) {
+        $field = 'user_' . $field;
+    }
+
+	foreach ( $coauthors as $coauthor ) {
+		$user_id = $coauthor->ID;
+
+        if ( isset( $coauthor->type )  && 'user_url' === $field ) {
+            if ( 'guest-author' === $coauthor->type) {
+                $field = 'website';
+            }
+        } else if ( 'website' === $field ) {
+            $field = 'user_url';
+        }
+
+        if ( isset( $coauthor->$field ) ) {
+            $meta[ $user_id ] = $coauthor->$field;
+        } else {
+            $meta[ $user_id ] = '';
+        }
+	}
+
 	return $meta;
 }
 
@@ -466,9 +469,9 @@ function get_the_coauthor_meta( $field, $user_id = false ) {
 function the_coauthor_meta( $field, $user_id = 0 ) {
 	// TODO: need before after options
 	$coauthor_meta = get_the_coauthor_meta( $field, $user_id );
-        foreach ( $coauthor_meta as $meta ) {     
-                echo $meta; 
-        }
+    foreach ( $coauthor_meta as $meta ) {
+        echo $meta;
+    }
 }
 
 /**

--- a/template-tags.php
+++ b/template-tags.php
@@ -428,30 +428,26 @@ function get_the_coauthor_meta( $field ) {
 	$coauthors = get_coauthors();
 	$meta = array();
         
-	foreach ( $coauthors as $coauthor ) {
-                
-		$user_id = $coauthor->ID;
-                if ( isset($coauthor->data) ){
-                     $coauthor = $coauthor->data;
-                }
-                
-                if( $field == 'url' && isset ($coauthor->website) )
-                    $field = 'website';
-                
-                if( $field == 'website' && isset ($coauthor->user_url) )
-                    $field = 'user_url';
-                
-                if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) )
-                    $field = 'user_' . $field;
-
-                if ( isset( $coauthor->$field ) ){
-                    $meta[ $user_id ] = $coauthor->$field;
-                } else {
-                    $meta[ $user_id ] = '';
-                }
-                                
-	}
+        if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) )
+                $field = 'user_' . $field;
         
+	foreach ( $coauthors as $coauthor ) {                
+		$user_id = $coauthor->ID;
+                
+                if ( isset( $coauthor->type )  && 'user_url' === $field ) {
+                        if ( 'guest-author' === $coauthor->type) {
+                                $field = 'website';
+                        } 
+                } else if ( 'website' === $field ) {
+                        $field = 'user_url';
+                }
+                
+                if ( isset( $coauthor->$field ) ) {
+                        $meta[ $user_id ] = $coauthor->$field;
+                } else {
+                        $meta[ $user_id ] = '';
+                }                                
+	}        
 	return $meta;
 }
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -426,11 +426,12 @@ function coauthors_ids( $between = null, $betweenLast = null, $before = null, $a
  * @return array $meta Value of the user field
  */
 function get_the_coauthor_meta( $field, $user_id = false ) {
-	global $coauthors_plus;
+    global $coauthors_plus;
 
-	if ( ! $user_id ) {
-		$coauthors = get_coauthors();
-    } else {
+    if ( ! $user_id ) {
+        $coauthors = get_coauthors();
+    }
+    else {
         $coauthor_data = $coauthors_plus->get_coauthor_by( 'id', $user_id );
         $coauthors = array();
         if ( ! empty( $coauthor_data ) ) {
@@ -438,39 +439,41 @@ function get_the_coauthor_meta( $field, $user_id = false ) {
         }
     }
 
-	$meta = array();
+    $meta = array();
 
     if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) ) {
         $field = 'user_' . $field;
     }
 
-	foreach ( $coauthors as $coauthor ) {
-		$user_id = $coauthor->ID;
+    foreach ( $coauthors as $coauthor ) {
+        $user_id = $coauthor->ID;
 
-        if ( isset( $coauthor->type )  && 'user_url' === $field ) {
-            if ( 'guest-author' === $coauthor->type) {
+        if ( isset( $coauthor->type ) && 'user_url' === $field ) {
+            if ( 'guest-author' === $coauthor->type ) {
                 $field = 'website';
             }
-        } else if ( 'website' === $field ) {
+        }
+        else if ( 'website' === $field ) {
             $field = 'user_url';
         }
 
         if ( isset( $coauthor->$field ) ) {
             $meta[ $user_id ] = $coauthor->$field;
-        } else {
+        }
+        else {
             $meta[ $user_id ] = '';
         }
-	}
+    }
 
-	return $meta;
+    return $meta;
 }
 
 
 function the_coauthor_meta( $field, $user_id = 0 ) {
-	// TODO: need before after options
-	$coauthor_meta = get_the_coauthor_meta( $field, $user_id );
+    // TODO: need before after options
+    $coauthor_meta = get_the_coauthor_meta( $field, $user_id );
     foreach ( $coauthor_meta as $meta ) {
-        echo $meta;
+        echo esc_html( $meta );
     }
 }
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -424,7 +424,7 @@ function coauthors_ids( $between = null, $betweenLast = null, $before = null, $a
  * @param string $user_id Optional The user ID for meta
  */
 function get_the_coauthor_meta( $field, $user_id = false ) { 
-	global $wp_query, $post, $coauthors_plus;
+	global $coauthors_plus;
 
 	if ( ! $user_id ) {
 		$coauthors = get_coauthors();

--- a/template-tags.php
+++ b/template-tags.php
@@ -421,18 +421,28 @@ function coauthors_ids( $between = null, $betweenLast = null, $before = null, $a
  * Outputs the co-authors Meta Data
  *
  * @param string $field Required The user field to retrieve.[login, email, nicename, display_name, url, type]
+ * @param string $user_id Optional The user ID for meta
  */
-function get_the_coauthor_meta( $field ) { 
-	global $wp_query, $post;
+function get_the_coauthor_meta( $field, $user_id = false ) { 
+	global $wp_query, $post, $coauthors_plus;
 
-	$coauthors = get_coauthors();
+	if ( ! $user_id ) {
+		$coauthors = get_coauthors();
+        } else {
+                $coauthor_data = $coauthors_plus->get_coauthor_by( 'id', $user_id );
+                $coauthors = array();
+                if ( ! empty( $coauthor_data ) ) {
+			$coauthors[] = $coauthor_data;
+		}
+        }
+
 	$meta = array();
         
         if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) )
                 $field = 'user_' . $field;
         
 	foreach ( $coauthors as $coauthor ) {                
-		$user_id = $coauthor->ID;
+		$user_id = $coauthor->ID;      
                 
                 if ( isset( $coauthor->type )  && 'user_url' === $field ) {
                         if ( 'guest-author' === $coauthor->type) {
@@ -448,13 +458,17 @@ function get_the_coauthor_meta( $field ) {
                         $meta[ $user_id ] = '';
                 }                                
 	}        
+        
 	return $meta;
 }
 
 
 function the_coauthor_meta( $field, $user_id = 0 ) {
 	// TODO: need before after options
-	echo get_the_coauthor_meta( $field, $user_id );
+	$coauthor_meta = get_the_coauthor_meta( $field, $user_id );
+        foreach ( $coauthor_meta as $meta ) {     
+                echo $meta; 
+        }
 }
 
 /**

--- a/template-tags.php
+++ b/template-tags.php
@@ -422,35 +422,39 @@ function coauthors_ids( $between = null, $betweenLast = null, $before = null, $a
  *
  * @param string $field Required The user field to retrieve.[login, email, nicename, display_name, url, type]
  */
-function get_the_coauthor_meta( $field ) {
+function get_the_coauthor_meta( $field ) { 
 	global $wp_query, $post;
 
 	$coauthors = get_coauthors();
 	$meta = array();
         
 	foreach ( $coauthors as $coauthor ) {
+                
 		$user_id = $coauthor->ID;
-                if (isset( $coauthor->data) ){
-                    $coauthor_data = $coauthor->data;
-                } else {
-                    $coauthor_data = $coauthor;
+                if ( isset($coauthor->data) ){
+                     $coauthor = $coauthor->data;
                 }
                 
-                $coauthor_meta['login'] = $coauthor_data->user_login;
-                $coauthor_meta['email'] = $coauthor_data->user_email;
-                $coauthor_meta['nicename'] = $coauthor_data->user_nicename;
-                $coauthor_meta['display_name'] = $coauthor_data->display_name;  
-                if ( $coauthor_data->type == 'wpuser' ) {
-                    $coauthor_meta['url'] = $coauthor_data->user_url;
-                } else {
-                    $coauthor_meta['url'] = $coauthor_data->website;
-                }                
-                $coauthor_meta['type'] = $coauthor_data->type;   
+                if( $field == 'url' && isset ($coauthor->website) )
+                    $field = 'website';
                 
-                $meta[ $user_id ] = $coauthor_meta[$field];		
+                if( $field == 'website' && isset ($coauthor->user_url) )
+                    $field = 'user_url';
+                
+                if ( in_array( $field, array( 'login', 'pass', 'nicename', 'email', 'url', 'registered', 'activation_key', 'status' ) ) )
+                    $field = 'user_' . $field;
+
+                if ( isset( $coauthor->$field ) ){
+                    $meta[ $user_id ] = $coauthor->$field;
+                } else {
+                    $meta[ $user_id ] = '';
+                }
+                                
 	}
+        
 	return $meta;
 }
+
 
 function the_coauthor_meta( $field, $user_id = 0 ) {
 	// TODO: need before after options

--- a/template-tags.php
+++ b/template-tags.php
@@ -417,15 +417,37 @@ function coauthors_ids( $between = null, $betweenLast = null, $before = null, $a
 	), null, $echo );
 }
 
+/**
+ * Outputs the co-authors Meta Data
+ *
+ * @param string $field Required The user field to retrieve.[login, email, nicename, display_name, url, type]
+ */
 function get_the_coauthor_meta( $field ) {
 	global $wp_query, $post;
 
 	$coauthors = get_coauthors();
 	$meta = array();
-
+        
 	foreach ( $coauthors as $coauthor ) {
 		$user_id = $coauthor->ID;
-		$meta[ $user_id ] = get_the_author_meta( $field, $user_id );
+                if (isset( $coauthor->data) ){
+                    $coauthor_data = $coauthor->data;
+                } else {
+                    $coauthor_data = $coauthor;
+                }
+                
+                $coauthor_meta['login'] = $coauthor_data->user_login;
+                $coauthor_meta['email'] = $coauthor_data->user_email;
+                $coauthor_meta['nicename'] = $coauthor_data->user_nicename;
+                $coauthor_meta['display_name'] = $coauthor_data->display_name;  
+                if ( $coauthor_data->type == 'wpuser' ) {
+                    $coauthor_meta['url'] = $coauthor_data->user_url;
+                } else {
+                    $coauthor_meta['url'] = $coauthor_data->website;
+                }                
+                $coauthor_meta['type'] = $coauthor_data->type;   
+                
+                $meta[ $user_id ] = $coauthor_meta[$field];		
 	}
 	return $meta;
 }


### PR DESCRIPTION
I have made changes in the get_the_coauthor_meta function to resolve this issue #332 . The original function was not fetching meta data of the guest users. It was fetching data of only WP users from wp_users table. I have modified the function to fetch meta data of both WP users as well guest users associated with the post. 

Some of the meta fields associated with WP users are not available for guest users. So the function will return value for only those meta fields that are common for both type of users. 

Code 
```
while ( have_posts() ) : the_post();
     var_dump( get_the_coauthor_meta( 'email' ) ); 
endwhile;
```
Output for above code: 
 
For mapped guest user: Jeni
![mapped_guest_user](https://user-images.githubusercontent.com/32775865/35754725-819ea516-0832-11e8-8cd6-3c2920688202.JPG)

For guest user without any mapping : George
![not mapped guest user](https://user-images.githubusercontent.com/32775865/35754728-81b37a4a-0832-11e8-9305-d5f477687a6f.JPG)

For WP user: admin
![new_user](https://user-images.githubusercontent.com/32775865/35754727-81a90880-0832-11e8-8ba1-dd59d9be5666.JPG)