### PR TITLE
Allow `coauthors_wp_list_authors` to only query authors with posts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     include:
         # aliased to a recent 5.6.x version
         - php: "5.6"
-          env: WP_VERSION=4.6
+          env: WP_VERSION=4.8
 
         - php: '5.6'
           env:
@@ -20,13 +20,13 @@ matrix:
 
         # aliased to a recent 7.x version
         - php: '7.0'
-          env: WP_VERSION=4.6
+          env: WP_VERSION=4.8
 
         - php: '7.0'
           env: WP_VERSION=latest
 
         - php: '7.1'
-          env: WP_VERSION=4.6
+          env: WP_VERSION=4.8
 
         - php: '7.1'
           env: WP_VERSION=latest
@@ -53,7 +53,7 @@ before_script:
     - |
         if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
           composer global require "phpunit/phpunit=4.8.*"
-        elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." && ${WP_VERSION} == "4.6" ]]; then
+        elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." && ${WP_VERSION} == "4.8" ]]; then
           composer global require "phpunit/phpunit=5.7.*"
         fi
     - |

--- a/template-tags.php
+++ b/template-tags.php
@@ -527,6 +527,7 @@ function the_coauthor_meta( $field, $user_id = 0 ) {
  * feed (string) (''): If isn't empty, show links to author's feeds.
  * feed_image (string) (''): If isn't empty, use this image to link to feeds.
  * echo (boolean) (true): Set to false to return the output, instead of echoing.
+ * authors_with_posts_only (boolean) (false): If true, don't query for authors with no posts.
  * @param array $args The argument array.
  * @return null|string The output, if echo is set to false.
  */
@@ -544,7 +545,8 @@ function coauthors_wp_list_authors( $args = array() ) {
 		'style'              => 'list',
 		'html'               => true,
 		'number'           	 => 20, // A sane limit to start to avoid breaking all the things
-		'guest_authors_only' => false
+		'guest_authors_only' => false,
+		'authors_with_posts_only' => false,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -552,8 +554,12 @@ function coauthors_wp_list_authors( $args = array() ) {
 
 	$term_args = array(
 			'orderby'      => 'name',
-			'hide_empty'   => 0,
 			'number'       => (int) $args['number'],
+			/*
+			 * Historically, this was set to always be `0` ignoring `$args['hide_empty']` value
+			 * To avoid any backwards incompatibility, inventing `authors_with_posts_only` that defaults to false
+			 */
+			'hide_empty'   => (boolean) $args['authors_with_posts_only'],
 		);
 	$author_terms = get_terms( $coauthors_plus->coauthor_taxonomy, $term_args );
 


### PR DESCRIPTION
Fixes #193 by introducing `authors_with_posts_only` argument. 

The `$term_args` has been querying taxonomies with `hide_empty => 0` for the past years, ignoring the value of `$args['hide_empty']` that was passed to the `coauthors_wp_list_authors` function.

A simple fix would have been to just let the `coauthors_wp_list_authors` use the value of `$args['hide_empty']` but it defaults to true, and historically the term args defaulted to false, which is an inconsistency that's bound to cause trouble.

In the future, maybe this function could be deprecated and a new function used instead with better defaults.

**TL;DR**: I decided to introduce `authors_with_posts_only` for backward compatibility of the `hide_empty` argument. 