### PR TITLE
Users Menu: add new column listing the linked guest author.

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -286,7 +286,7 @@ class CoAuthors_Plus {
 		// Add quick-edit co-author select field
 		add_action( 'quick_edit_custom_box', array( $this, '_action_quick_edit_custom_box' ), 10, 2 );
 
-		// Hooks to modify the published post number count on the Users WP List Table
+		// Hooks to modify the published post count and surface the linked guest author on the Users WP List Table.
 		add_filter( 'manage_users_columns', array( $this, '_filter_manage_users_columns' ) );
 		add_filter( 'manage_users_custom_column', array( $this, '_filter_manage_users_custom_column' ), 10, 3 );
 
@@ -659,15 +659,24 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Unset the post count column because it's going to be inaccurate and provide our own
+	 * Create custom columns in the Users table:
+	 *
+	 * - A column listing the linked guest author, when one is set.
+	 * - A custom post count column to replace the inaccurate default.
+	 *
+	 * @since 2.6.1
+	 * @since 4.1.0 Added column to display the linked guest author.
+	 *
+	 * @param array $columns An array of column name => label.
 	 */
 	public function _filter_manage_users_columns( $columns ): array {
 
 		$new_columns = array();
-		// Unset and add our column while retaining the order of the columns
+		// Unset the default post count column and add our own while retaining the order of the columns.
 		foreach ( $columns as $column_name => $column_title ) {
 			if ( 'posts' === $column_name ) {
-				$new_columns['coauthors_post_count'] = __( 'Posts', 'co-authors-plus' );
+				$new_columns['coauthors_linked_author'] = __( 'Linked Guest Author', 'co-authors-plus' );
+				$new_columns['coauthors_post_count']    = __( 'Posts', 'co-authors-plus' );
 			} else {
 				$new_columns[ $column_name ] = $column_title;
 			}
@@ -676,23 +685,69 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Provide an accurate count when looking up the number of published posts for a user
+	 * Render the custom Users table columns:
+	 *
+	 * - `coauthors_post_count` shows an accurate count of published posts for the user.
+	 * - `coauthors_linked_author` shows the linked guest author's name, linking to its edit screen.
+	 *
+	 * @since 2.6.1
+	 * @since 4.1.0 Added column to display the linked guest author.
+	 *
+	 * @param string $value       Custom column output. Default empty.
+	 * @param string $column_name Column name.
+	 * @param int    $user_id     ID of the currently-listed user.
 	 */
 	public function _filter_manage_users_custom_column( $value, $column_name, $user_id ) {
-		if ( 'coauthors_post_count' !== $column_name ) {
-			return $value;
+		if ( 'coauthors_post_count' === $column_name ) {
+			return $value . $this->render_users_post_count_column( $user_id );
 		}
-		// We filter count_user_posts() so it provides an accurate number
-		$numposts = count_user_posts( $user_id ); // phpcs:ignore
-		$user     = get_user_by( 'id', $user_id );
-		if ( $numposts > 0 ) {
-			$value .= "<a href='edit.php?author_name=$user->user_nicename' title='" . esc_attr__( 'View posts by this author', 'co-authors-plus' ) . "' class='edit'>";
-			$value .= $numposts;
-			$value .= '</a>';
-		} else {
-			$value .= 0;
+
+		if ( 'coauthors_linked_author' === $column_name ) {
+			return $value . $this->render_users_linked_author_column( $user_id );
 		}
+
 		return $value;
+	}
+
+	/**
+	 * Render the post count column for a user, linking to their filtered posts view.
+	 *
+	 * @param int $user_id ID of the currently-listed user.
+	 */
+	private function render_users_post_count_column( $user_id ): string {
+		// We filter count_user_posts() so it provides an accurate number.
+		$numposts = count_user_posts( $user_id ); // phpcs:ignore
+		if ( $numposts <= 0 ) {
+			return '0';
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		return sprintf(
+			'<a href="edit.php?author_name=%1$s" title="%2$s" class="edit">%3$d</a>',
+			esc_attr( $user->user_nicename ),
+			esc_attr__( 'View posts by this author', 'co-authors-plus' ),
+			absint( $numposts )
+		);
+	}
+
+	/**
+	 * Render the linked guest author column for a user, linking to the guest author's edit screen.
+	 *
+	 * @param int $user_id ID of the currently-listed user.
+	 */
+	private function render_users_linked_author_column( $user_id ): string {
+		$author_info = $this->get_coauthor_by( 'id', $user_id, false );
+		if ( ! $author_info || 'guest-author' !== $author_info->type ) {
+			return '';
+		}
+
+		return sprintf(
+			'<a href="post.php?post=%1$d&action=edit" title="%2$s" class="edit">%3$s</a>',
+			absint( $author_info->ID ),
+			esc_attr__( 'Edit Guest Author', 'co-authors-plus' ),
+			esc_html( $author_info->display_name )
+		);
 	}
 
 	/**

--- a/tests/Integration/UsersListTableColumnsTest.php
+++ b/tests/Integration/UsersListTableColumnsTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Tests for the custom Users list table columns.
+ *
+ * @package CoAuthors
+ */
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Tests for {@see \CoAuthors_Plus::_filter_manage_users_columns()} and
+ * {@see \CoAuthors_Plus::_filter_manage_users_custom_column()}.
+ *
+ * The Users screen replaces the core "Posts" column with a CAP-aware count and
+ * also surfaces the linked guest author (when one exists) so administrators
+ * can see at a glance why a user's post count differs from the default.
+ */
+class UsersListTableColumnsTest extends TestCase {
+
+	/**
+	 * The Posts column should be removed and replaced by the linked-author
+	 * column followed by the CAP post-count column, with all other columns
+	 * left in their original position.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_columns
+	 */
+	public function test_columns_replaces_posts_with_linked_author_then_post_count(): void {
+		$columns = array(
+			'cb'       => '<input type="checkbox" />',
+			'username' => 'Username',
+			'name'     => 'Name',
+			'email'    => 'Email',
+			'role'     => 'Role',
+			'posts'    => 'Posts',
+		);
+
+		$filtered = $this->_cap->_filter_manage_users_columns( $columns );
+
+		$this->assertSame(
+			array( 'cb', 'username', 'name', 'email', 'role', 'coauthors_linked_author', 'coauthors_post_count' ),
+			array_keys( $filtered ),
+			'The Posts column is replaced by linked author then post count, preserving column order.'
+		);
+		$this->assertArrayNotHasKey( 'posts', $filtered, 'The original Posts column is removed.' );
+		$this->assertSame( 'Linked Guest Author', $filtered['coauthors_linked_author'] );
+		$this->assertSame( 'Posts', $filtered['coauthors_post_count'] );
+	}
+
+	/**
+	 * If a site has already removed the core Posts column (for example via a
+	 * different plugin), the filter should be a no-op rather than appending
+	 * stray columns.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_columns
+	 */
+	public function test_columns_filter_is_noop_when_posts_column_absent(): void {
+		$columns = array(
+			'cb'       => '',
+			'username' => 'Username',
+		);
+
+		$filtered = $this->_cap->_filter_manage_users_columns( $columns );
+
+		$this->assertSame( $columns, $filtered, 'No CAP columns are added when the Posts column is not present.' );
+	}
+
+	/**
+	 * The post-count column should render a link to the user's filtered posts
+	 * view, with the user_nicename safely escaped into the href.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_custom_column
+	 */
+	public function test_post_count_column_renders_link_for_user_with_posts(): void {
+		$author = $this->create_author( 'columns-author' );
+
+		$this->factory()->post->create_many(
+			2,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$value = $this->_cap->_filter_manage_users_custom_column( '', 'coauthors_post_count', $author->ID );
+
+		$this->assertStringContainsString( 'edit.php?author_name=' . $author->user_nicename, $value );
+		$this->assertStringContainsString( 'class="edit"', $value );
+		$this->assertStringContainsString( '>2</a>', $value, 'The post count is rendered inside the link.' );
+	}
+
+	/**
+	 * A user with no posts should render a literal `0` rather than an empty
+	 * link, matching the prior behaviour.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_custom_column
+	 */
+	public function test_post_count_column_renders_zero_for_user_without_posts(): void {
+		$author = $this->create_author( 'columns-empty' );
+
+		$value = $this->_cap->_filter_manage_users_custom_column( '', 'coauthors_post_count', $author->ID );
+
+		$this->assertSame( '0', $value, 'A user with no posts is rendered as 0 with no anchor.' );
+	}
+
+	/**
+	 * The linked-author column should render a link to the guest author's
+	 * edit screen when the user has a linked guest author, with the
+	 * display_name safely escaped.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_custom_column
+	 */
+	public function test_linked_author_column_renders_link_when_guest_author_is_linked(): void {
+		$user = $this->create_author( 'columns-linked' );
+
+		$guest_id = $this->_cap->guest_authors->create_guest_author_from_user_id( $user->ID );
+		$this->assertIsInt( $guest_id, 'The guest author was created from the user.' );
+
+		$value = $this->_cap->_filter_manage_users_custom_column( '', 'coauthors_linked_author', $user->ID );
+
+		$this->assertStringContainsString( 'post.php?post=' . $guest_id . '&action=edit', $value );
+		$this->assertStringContainsString( 'class="edit"', $value );
+		$this->assertStringContainsString( '>columns-linked</a>', $value, 'The guest author display name is rendered as the link text.' );
+	}
+
+	/**
+	 * A user with no linked guest author should leave the column value
+	 * untouched so other plugins can populate it.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_custom_column
+	 */
+	public function test_linked_author_column_is_empty_for_user_with_no_linked_guest_author(): void {
+		$user = $this->create_author( 'columns-unlinked' );
+
+		$value = $this->_cap->_filter_manage_users_custom_column( '', 'coauthors_linked_author', $user->ID );
+
+		$this->assertSame( '', $value, 'No markup is appended when the user has no linked guest author.' );
+	}
+
+	/**
+	 * Columns the filter does not recognise must pass through unchanged so
+	 * other plugins relying on the same hook keep working.
+	 *
+	 * @covers \CoAuthors_Plus::_filter_manage_users_custom_column
+	 */
+	public function test_unknown_column_passes_value_through_unchanged(): void {
+		$author = $this->create_author( 'columns-passthrough' );
+
+		$value = $this->_cap->_filter_manage_users_custom_column( 'untouched', 'some_other_column', $author->ID );
+
+		$this->assertSame( 'untouched', $value );
+	}
+}


### PR DESCRIPTION
Fixes #494

The post count in the Users Menu changes when you've linked an account to a guest author. That is not always clear to everyone, as explained in #494. 

If we add a new column to the menu that shows that guest author, right before the post count, I think it makes things a bit clearer.

**Before**

<img width="1119" alt="screenshot 2018-04-11 at 22 01 36" src="https://user-images.githubusercontent.com/426388/38640255-16cab22a-3dd4-11e8-803e-8d92af1f52d9.png">


**After**

<img width="1126" alt="screenshot 2018-04-11 at 22 00 54" src="https://user-images.githubusercontent.com/426388/38640247-11ea1660-3dd4-11e8-9de8-63dc92134229.png">

What do you think?

**Testing**

To test, go to Users > Guest Authors, create a few guest authors and link them to existing accounts on your site like so:

<img width="340" alt="screenshot 2018-04-11 at 22 06 41" src="https://user-images.githubusercontent.com/426388/38640460-a1b9c402-3dd4-11e8-9fba-743f8ef647b9.png">

Then visit the Users menu and make sure the information and links displayed there are correct.
