### PR TITLE
Unexpected output of template tag 'coauthors_links' is resolved by updating conditions

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -420,14 +420,12 @@ function coauthors_emails( $between = null, $betweenLast = null, $before = null,
  * @return string
  */
 function coauthors_links_single( $author ) {
-	if ( 'guest-author' === $author->type ) {
-		if ( get_the_author_meta( 'website' ) ) {
-			return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
-				esc_url( get_the_author_meta( 'website' ) ),
-				esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
-				esc_html( get_the_author() )
-			);
-		} 
+	if ( 'guest-author' === $author->type && get_the_author_meta( 'website' ) ) {
+		return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
+			esc_url( get_the_author_meta( 'website' ) ),
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
+			esc_html( get_the_author() )
+		);
 	}
 	elseif ( get_the_author_meta( 'url' ) ) {
 		return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -593,11 +593,11 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$this->author1->type = 'guest-author';
 
-		$this->assertNull( coauthors_links_single( $this->author1 ) );
+		$this->assertEquals( get_the_author(), coauthors_links_single( $this->author1 ) );		
 
 		update_user_meta( $this->author1->ID, 'website', 'example.org' );
 
-		$this->assertNull( coauthors_links_single( $this->author1 ) );
+		$this->assertEquals( get_the_author(), coauthors_links_single( $this->author1 ) );
 
 		$authordata  = $this->author1;
 		$author_link = coauthors_links_single( $this->author1 );
@@ -676,7 +676,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$author_link = coauthors_links_single( $this->editor1 );
 
-		$this->assertEmpty( $author_link );
+		$this->assertEquals( get_the_author(), $author_link );
 
 		$authordata  = $this->author1;
 		$author_link = coauthors_links_single( $this->author1 );


### PR DESCRIPTION
Fixes #469 
The template tag was outputting usernames of guest authors when they do not have a website set in their profile. It will now output guest authors display names as expected.
Also made corrections to PHPUnit test cases to work with the updated code.