### PR TITLE
Added i18n support and corrected author display name for author archive: addressing issue #515

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1612,7 +1612,7 @@ class CoAuthors_Plus {
 	public function filter_author_archive_title() {
 		if ( is_author() ) {
 			$author = sanitize_user( get_query_var( 'author_name' ) );
-			return "Author: ". $author;
+			return sprintf( __( 'Author: %s'), $author);
 		}
 	}
 }

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1611,8 +1611,9 @@ class CoAuthors_Plus {
 	 */
 	public function filter_author_archive_title() {
 		if ( is_author() ) {
-			$author = sanitize_user( get_query_var( 'author_name' ) );
-			return sprintf( __( 'Author: %s'), $author);
+			$author_slug = sanitize_user( get_query_var( 'author_name' ) );
+			$author = $this->get_coauthor_by( 'user_nicename', $author_slug );
+			return sprintf( __( 'Author: %s' ), $author->display_name );
 		}
 	}
 }


### PR DESCRIPTION
I reproduced issue #515 locally by creating a few posts with the guest author Test Guest Author assigned to them. Then, I changed the language to Spanish and navigated to /?author_name=test-guest-author. Before the fix, the top of the page read: "Author: Test-Guest-Author" and after the fix, it reads "Autor: Test Guest Author"

The fix addresses both the translation issue and the author display name issue on the author archive page.
