### PR TITLE
check for coauthor terms before using them in query: addressing issue #511

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -722,15 +722,15 @@ class CoAuthors_Plus {
 					is_author() &&
 					get_queried_object_id() != get_current_user_id()
 				) {
-				    $current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
-				    $current_coauthor_term = $this->get_author_term( $current_coauthor );
+					$current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
+					$current_coauthor_term = $this->get_author_term( $current_coauthor );
 
-				    if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
-					    $current_user_query = $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\' AND ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\'';
-					    $this->having_terms .= ' ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\' OR ';
+					if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
+						$current_user_query = $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\' AND ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\'';
+						$this->having_terms .= ' ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\' OR ';
+					}
 
-					    $where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, - 1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
-				    }
+					$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, - 1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND}
 				}
 
 				$this->having_terms = rtrim( $this->having_terms, ' OR' );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -725,11 +725,11 @@ class CoAuthors_Plus {
 					$current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
 					$current_coauthor_term = $this->get_author_term( $current_coauthor );
 
-					if ( $current_coauthor_term ) {
-                        $current_user_query  = $wpdb->term_taxonomy . '.taxonomy = \''. $this->coauthor_taxonomy.'\' AND '. $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\'';
-                        $this->having_terms .= ' ' . $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\' OR ';
+					if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
+					    $current_user_query  = $wpdb->term_taxonomy . '.taxonomy = \''. $this->coauthor_taxonomy.'\' AND '. $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\'';
+					    $this->having_terms .= ' ' . $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\' OR ';
 
-                        $where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+					    $where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
                     }
 				}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1,4 +1,4 @@
-<?php /** @noinspection PhpCSValidationInspection */
+<?php
 /*
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -725,12 +725,12 @@ class CoAuthors_Plus {
 					$current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
 					$current_coauthor_term = $this->get_author_term( $current_coauthor );
 
-					if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
+					if ( is_a( $current_coauthor_term, 'WP_Term' ) ) {
 						$current_user_query = $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\' AND ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\'';
 						$this->having_terms .= ' ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\' OR ';
-					}
 
-					$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, - 1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND}
+						$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, - 1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND}
+					}
 				}
 
 				$this->having_terms = rtrim( $this->having_terms, ' OR' );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -726,10 +726,10 @@ class CoAuthors_Plus {
 					$current_coauthor_term = $this->get_author_term( $current_coauthor );
 
 					if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
-					    $current_user_query  = $wpdb->term_taxonomy . '.taxonomy = \''. $this->coauthor_taxonomy.'\' AND '. $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\'';
-					    $this->having_terms .= ' ' . $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\' OR ';
+                        $current_user_query = $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\' AND ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\'';
+                        $this->having_terms .= ' ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\' OR ';
 
-					    $where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+                        $where = preg_replace('/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
                     }
 				}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -725,10 +725,12 @@ class CoAuthors_Plus {
 					$current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
 					$current_coauthor_term = $this->get_author_term( $current_coauthor );
 
-					$current_user_query  = $wpdb->term_taxonomy . '.taxonomy = \''. $this->coauthor_taxonomy.'\' AND '. $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\'';
-					$this->having_terms .= ' ' . $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\' OR ';
+					if ( $current_coauthor_term ) {
+                        $current_user_query  = $wpdb->term_taxonomy . '.taxonomy = \''. $this->coauthor_taxonomy.'\' AND '. $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\'';
+                        $this->having_terms .= ' ' . $wpdb->term_taxonomy .'.term_id = \''. $current_coauthor_term->term_id .'\' OR ';
 
-					$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+                        $where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+                    }
 				}
 
 				$this->having_terms = rtrim( $this->having_terms, ' OR' );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpCSValidationInspection */
 /*
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
@@ -722,15 +722,15 @@ class CoAuthors_Plus {
 					is_author() &&
 					get_queried_object_id() != get_current_user_id()
 				) {
-					$current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
-					$current_coauthor_term = $this->get_author_term( $current_coauthor );
+				    $current_coauthor      = $this->get_coauthor_by( 'user_nicename', wp_get_current_user()->user_nicename );
+				    $current_coauthor_term = $this->get_author_term( $current_coauthor );
 
-					if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
-                        $current_user_query = $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\' AND ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\'';
-                        $this->having_terms .= ' ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\' OR ';
+				    if ( is_object( $current_coauthor_term ) && wpcom_vip_term_exists( $current_coauthor_term->term_id ) ) {
+					    $current_user_query = $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\' AND ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\'';
+					    $this->having_terms .= ' ' . $wpdb->term_taxonomy . '.term_id = \'' . $current_coauthor_term->term_id . '\' OR ';
 
-                        $where = preg_replace('/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, -1); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
-                    }
+					    $where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . get_current_user_id() . '))/', $current_user_query, $where, - 1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+				    }
 				}
 
 				$this->having_terms = rtrim( $this->having_terms, ' OR' );


### PR DESCRIPTION
This is addressing issue #511 to check if a user has terms before building a query with the terms.

To test, I went to an author archive page as a user (Subscriber) that didn't have any posts. I saw the following warnings:
Notice: Trying to get property of non-object in /srv/www/example/public_html/wp-content/plugins/co-authors-plus/co-authors-plus.php on line 728

Notice: Trying to get property of non-object in /srv/www/example/public_html/wp-content/plugins/co-authors-plus/co-authors-plus.php on line 729

With this fix, I don't see the warnings. I'm not certain if this is the right fix, or if the change in the where filter is needed for users that don't have terms. The fix looks to work with all my examples, but I may have missed an example to test.
