### PR TITLE
Replacing search_fields with search_columns in get_users()

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1166,7 +1166,7 @@ class CoAuthors_Plus {
 		$args = array(
 				'count_total' => false,
 				'search' => sprintf( '*%s*', $search ),
-				'search_fields' => array(
+				'search_columns' => array(
 					'ID',
 					'display_name',
 					'user_email',


### PR DESCRIPTION
As reported in #513, the `CoAuthors_Plus::search_authors` was using `search_fields` as an argument to `get_users()`, which [simply does not exist](https://codex.wordpress.org/Class_Reference/WP_User_Query#Search_Parameters). Replaced that with the correct argument `search_columns`.

Anyway, the old search was not really buggy (not that I have been able to find, at least), since fallbacking on the default `search_columns` when not explicitly provided resulted in a wider search.