### PR TITLE
Added FAQ to readme on how to disable Guest Authors

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,11 @@ To create new guest author profiles, a WordPress will need the 'list_users' capa
 
 Yep! There's a template tag called `coauthors_wp_list_authors()` that accepts many of the same arguments as `wp_list_authors()`. Look in template-tags.php for more details.
 
+= Can I disable Guest Authors?
+
+Yep! Guest authors can be disabled entirely through an apt filter. Having the following line load on `init` will do the trick:
+`add_filter( 'coauthors_guest_authors_enabled', '__return_false' )`
+
 == Upgrade Notice ==
 
 = 3.1 =


### PR DESCRIPTION
Fix #122, where it was proposed to mention how to disable Guest Authors in a readme FAQ. 

I hope I have not been too short in the FAQ Answer, but I think that 

1. a lengthy explanation such as 
_there exists filter `name` that can handle a boolean value 
blabla
blabla_
was quite unneeded. I think a developer would be pissed off by that.

2. it is not the place to put a mini-tutorial on how to disable Guest Authors expecting virtually zero knowledge on the reader's part, such as
_put the following code in your theme functions.php -- 10 lines of code provided, with functions and `init` hooks._
If you don't know how to have a filter loaded on `init`, then a) you probably would not be reading a readme on github; b) you shouldn't be tweaking code in the first place.