### PR TITLE
Whitelist approach in filtering for irrelevant capabilities

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1358,30 +1358,18 @@ class CoAuthors_Plus {
 		$user_id = isset( $args[1] ) ? $args[1] : 0;
 		$post_id = isset( $args[2] ) ? $args[2] : 0;
 
-		// Before we attempt to check the post type, we need to filter out caps
-		// that we know are totally irrelevant. Otherwise we end up passing non post
-		// ids to get_post_type()
-		$skipped_caps = array(
-			'delete_user',
-			'edit_users',
-			'edit_user',
+		//Bail on irrelevant caps
+		$caps_to_modify = array(
+			$obj->cap->edit_post,
+			'edit_post', // Need to filter this too, unfortunately: http://core.trac.wordpress.org/ticket/22415
+			$obj->cap->edit_others_posts, // This as well: http://core.trac.wordpress.org/ticket/22417
 		);
-
-		if ( in_array( $cap, $skipped_caps, true ) ) {
+		if ( ! in_array( $cap, $caps_to_modify ) ) {
 			return $allcaps;
 		}
 
 		$obj = get_post_type_object( get_post_type( $post_id ) );
 		if ( ! $obj || 'revision' == $obj->name ) {
-			return $allcaps;
-		}
-
-		$caps_to_modify = array(
-				$obj->cap->edit_post,
-				'edit_post', // Need to filter this too, unfortunately: http://core.trac.wordpress.org/ticket/22415
-				$obj->cap->edit_others_posts, // This as well: http://core.trac.wordpress.org/ticket/22417
-			);
-		if ( ! in_array( $cap, $caps_to_modify ) ) {
 			return $allcaps;
 		}
 


### PR DESCRIPTION
`_filter_user_has_cap()` was calling `get_post_type( $post_id )` before even knowing that the capability it was invoked with was a post-related one, thus possibly calling `get_post_type` with a non-`$post_id`.

PR #490 had implemented a small blacklist bail, avoiding the `get_post_type()` call on user-related capabilities. There was already a whitelist bail check, just after the `get_post_type()` call, that checked that the current capability was really a post-related one.

So I have removed the blacklist check introduced in #490 and moved upwards the whitelist check that was already in place (adding one line of comment and improving indentation, given the fact that I was already editing those lines anyway).

Fix #489, and makes #490 obsolete.