### PR TITLE
Test test_coauthors_links_singe_guests_authors wrongly passing

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -421,14 +421,14 @@ function coauthors_emails( $between = null, $betweenLast = null, $before = null,
  */
 function coauthors_links_single( $author ) {
 	if ( 'guest-author' === $author->type && get_the_author_meta( 'website' ) ) {
-		return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
+		return sprintf( '<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'website' ) ),
 			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )
 		);
 	}
 	elseif ( get_the_author_meta( 'url' ) ) {
-		return sprintf( '<a href="%s" title="%s" rel="external" target="_blank">%s</a>',
+		return sprintf( '<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'url' ) ),
 			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -590,20 +590,23 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		// Backing up global author data.
 		$authordata_backup = $authordata;
+		$authordata = $this->author1;
 
+		// Shows that it's necessary to set $authordata to $this->author1
+		$this->assertEquals( $authordata, $this->author1, 'Global $authordata not matching expected $this->author1.' );
+		
 		$this->author1->type = 'guest-author';
 
-		$this->assertEquals( get_the_author(), coauthors_links_single( $this->author1 ) );		
+		$this->assertEquals( get_the_author_link(), coauthors_links_single( $this->author1 ), 'Co-Author link generation differs from Core author link one (without user_url)' );
+		
+		wp_update_user( array( 'ID' => $this->author1->ID, 'user_url' => 'example.org' ) );
+		$authordata = get_userdata( $this->author1->ID ); // Because wp_update_user flushes cache, but does not update global var
+		
+		$this->assertEquals( get_the_author_link(), coauthors_links_single( $this->author1 ), 'Co-Author link generation differs from Core author link one (with user_url)' );
 
-		update_user_meta( $this->author1->ID, 'website', 'example.org' );
-
-		$this->assertEquals( get_the_author(), coauthors_links_single( $this->author1 ) );
-
-		$authordata  = $this->author1;
 		$author_link = coauthors_links_single( $this->author1 );
-
-		$this->assertContains( get_the_author_meta( 'website' ), $author_link, 'Author link not found.' );
-		$this->assertContains( get_the_author(), $author_link, 'Author name not found.' );
+		$this->assertContains( get_the_author_meta( 'url' ), $author_link, 'Author url not found in link.' );
+		$this->assertContains( get_the_author(), $author_link, 'Author name not found in link.' );
 
 		// Here we are checking author name should not be more then one time.
 		// Asserting ">get_the_author()<" because "get_the_author()" can be multiple times like in href, title, etc.


### PR DESCRIPTION
This fixes #505. 

The test `test_coauthors_links_singe_guests_authors()` is meant to check that CAP correctly builds the link to a coauthor archive page. Also, it checks that it matches the structure WP Core author links have. However, there were just so many things not properly cared for.

This is the core of the test before my commits:

```php
$this->assertEquals( get_the_author(), coauthors_links_single( $this->author1 ) );		
update_user_meta( $this->author1->ID, 'website', 'example.org' );
$this->assertEquals( get_the_author(), coauthors_links_single( $this->author1 ) );
```

The (fine) idea is that of starting from a coauthor that does not have a website set, set it, and make sure the archive link CAP generates matches the one WP Core would generate for a normal author.
However,

- `get_the_author()` only returns the user name, never the link. `get_the_author_link()` should be used instead;
- the user_meta `website` is only used by CAP coauthors, but has no effect on WP Core users, so it's just ignored by `get_the_author_link()`;
- there is no guarantee that `global $authordata`, on which both `get_the_author()` and `coauthors_link_single()` rely, is not empty (and indeed, _it is empty_).

All these mistakes would in some way cancel out one another and let the test pass, although nothing was really being tested, since the user url was not updated in the first place.

So what I have done is (in the first commit):
- instead of the user_meta `website`, used `user_url`, which is actually stored in the wp_users record rather than a user_meta (but is accessed through `get_the_author_meta( 'url' )` anyway). Since CAP can handle both `website` and `user_url` (at least for guest authors), the latter should be used for the test. At this point the test fails somewhere at the bottom, but ignore that for now.
- made sure `global $authordata` contained the details of the current user. After this, the test would fail because `get_the_author()` would only output the username, while `coauthors_link_single()` would output the link;
- made sure `global $authordata` contained the _updated_ details of the user, after changing the url. This is not obvious since calling `wp_update_user` clears cache but does not update the global var, from which `get_the_author_meta()` takes its data;
- replaced `get_the_author()` with `get_the_author_link()`;

![failed](https://user-images.githubusercontent.com/7880569/40962805-e42bf894-68a6-11e8-98c0-c6f3db1bec83.png)

After all these edits, the test would fail in its main assertion: `coauthors_link_single()` did not match `get_the_author_link()`. The reason was simply that the link structure in CAP was a bit different than the one in WP Core. So in the second commit I changed CAP's link generation function so that its output matches expectation and has the same structure as Core's one :)

![passed](https://user-images.githubusercontent.com/7880569/40962810-e9fcd1bc-68a6-11e8-9110-a05c702a4f85.png)
