### PR TITLE
Removed function action_pre_user_query and its hooks

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1174,9 +1174,7 @@ class CoAuthors_Plus {
 				),
 				'fields' => 'all_with_meta',
 			);
-		add_action( 'pre_user_query', array( $this, 'action_pre_user_query' ) );
 		$found_users = get_users( $args );
-		remove_action( 'pre_user_query', array( $this, 'action_pre_user_query' ) );
 
 		foreach ( $found_users as $found_user ) {
 			$term = $this->get_author_term( $found_user );
@@ -1219,17 +1217,6 @@ class CoAuthors_Plus {
 			}
 		}
 		return (array) $found_users;
-	}
-
-	/**
-	 * Modify get_users() to search display_name instead of user_nicename
-	 */
-	function action_pre_user_query( $user_query ) {
-
-		if ( is_object( $user_query ) ) {
-			$user_query->query_where = str_replace( 'user_nicename LIKE', 'display_name LIKE', $user_query->query_where );
-		}
-
 	}
 
 	/**


### PR DESCRIPTION
Fix for #530.

`action_pre_user_query()` had the purpose of tweaking `get_users()` behavior to search for `display_name` instead of `user_nicename`. It was added and removed as a filter when calling `get_users()` in `search_authors()` - and nowhere else.

However, this was only needed before PR #519, when no argument `search_columns` was provided to the `get_users()` call. In that case, the default WP behavior was to search in a bunch of fields that included `user_nicename` but not `display_name`. PR #519 provides the argument `search_columns` correctly and with that, `user_nicename` is not among the search fields anymore, while `display_name` is. The action has thus become obsolete and was just slowing every search query down.

**Note**: depends on #519 (already merged, at the time of writing).