### PR TITLE
Fix possible discrepancy in author search with ignored authors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1212,7 +1212,7 @@ class CoAuthors_Plus {
 		$ignored_authors = apply_filters( 'coauthors_edit_ignored_authors', $ignored_authors );
 		foreach ( $found_users as $key => $found_user ) {
 			// Make sure the user is contributor and above (or a custom cap)
-			if ( in_array( $found_user->user_login, $ignored_authors ) ) {
+			if ( in_array( $found_user->user_nicename, $ignored_authors ) ) { //AJAX sends a list of already present *users_nicenames*
 				unset( $found_users[ $key ] );
 			} else if ( 'wpuser' === $found_user->type && false === $found_user->has_cap( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ) ) {
 				unset( $found_users[ $key ] );

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -367,7 +367,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$authors = $coauthors_plus->search_authors();
 
 		$this->assertNotEmpty( $authors );
-		$this->assertNotContains( $subscriber1->user_login, $authors );
+		$this->assertArrayNotHasKey( $subscriber1->user_login, $authors );
 
 		// Checks when search term is empty and any contributor exists.
 		$contributor1 = $this->factory->user->create_and_get( array(
@@ -397,32 +397,32 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		$this->assertNotEmpty( $authors );
 		$this->assertArrayHasKey( $this->author1->user_login, $authors );
-		$this->assertNotContains( $this->editor1->user_login, $authors );
-		$this->assertNotContains( 'admin', $authors );
+		$this->assertArrayNotHasKey( $this->editor1->user_login, $authors );
+		$this->assertArrayNotHasKey( 'admin', $authors );
 
 		// Checks when author searched using display_name.
 		$authors = $coauthors_plus->search_authors( $this->author1->display_name );
 
 		$this->assertNotEmpty( $authors );
 		$this->assertArrayHasKey( $this->author1->user_login, $authors );
-		$this->assertNotContains( $this->editor1->user_login, $authors );
-		$this->assertNotContains( 'admin', $authors );
+		$this->assertArrayNotHasKey( $this->editor1->user_login, $authors );
+		$this->assertArrayNotHasKey( 'admin', $authors );
 
 		// Checks when author searched using user_email.
 		$authors = $coauthors_plus->search_authors( $this->author1->user_email );
 
 		$this->assertNotEmpty( $authors );
 		$this->assertArrayHasKey( $this->author1->user_login, $authors );
-		$this->assertNotContains( $this->editor1->user_login, $authors );
-		$this->assertNotContains( 'admin', $authors );
+		$this->assertArrayNotHasKey( $this->editor1->user_login, $authors );
+		$this->assertArrayNotHasKey( 'admin', $authors );
 
 		// Checks when author searched using user_login.
 		$authors = $coauthors_plus->search_authors( $this->author1->user_login );
 
 		$this->assertNotEmpty( $authors );
 		$this->assertArrayHasKey( $this->author1->user_login, $authors );
-		$this->assertNotContains( $this->editor1->user_login, $authors );
-		$this->assertNotContains( 'admin', $authors );
+		$this->assertArrayNotHasKey( $this->editor1->user_login, $authors );
+		$this->assertArrayNotHasKey( 'admin', $authors );
 
 		// Checks when any subscriber exists using ID but not author.
 		$subscriber1 = $this->factory->user->create_and_get( array(
@@ -447,7 +447,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$authors = $coauthors_plus->search_authors( '', $ignored_authors );
 
 		$this->assertNotEmpty( $authors );
-		$this->assertNotContains( $this->author1->user_login, $authors );
+		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
 
 		// Checks when ignoring author1 but also exists one more author with similar kind of data.
 		$author2 = $this->factory->user->create_and_get( array(
@@ -457,15 +457,15 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$authors = $coauthors_plus->search_authors( '', $ignored_authors );
 
 		$this->assertNotEmpty( $authors );
-		$this->assertNotContains( $this->author1->user_login, $authors );
+		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
 		$this->assertArrayHasKey( $author2->user_login, $authors );
 
 		// Ignoring multiple authors.
 		$authors = $coauthors_plus->search_authors( '', array( $this->author1->user_login, $author2->user_login ) );
 
 		$this->assertNotEmpty( $authors );
-		$this->assertNotContains( $this->author1->user_login, $authors );
-		$this->assertNotContains( $author2->user_login, $authors );
+		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
+		$this->assertArrayNotHasKey( $author2->user_login, $authors );
 	}
 
 	/**
@@ -491,7 +491,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$authors = $coauthors_plus->search_authors( 'author', $ignored_authors );
 
 		$this->assertNotEmpty( $authors );
-		$this->assertNotContains( $this->author1->user_login, $authors );
+		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
 		$this->assertArrayHasKey( $author2->user_login, $authors );
 	}
 


### PR DESCRIPTION
This fixes #273.

The issue was that, in some cases, it was possible to add the same author more than once. Even though it was already a co-author of the post, it would still show up in search and be available for another addition - here, the last suggestion is the same user who is already an author of the post:

![before](https://user-images.githubusercontent.com/7880569/40963096-cc17d916-68a7-11e8-9101-fa2c5c02d5bb.png)

**_tl;dr - the issue was due to JS referencing existing authors by `user_nicename` while PHP by `user_login`._** 

Getting a peak at what happened when a post is saved, it was clear that there was some mismatch between the newly-added coauthors and the already present ones. It looked like some case issue:

![screenshot from 2018-06-05 09-20-20](https://user-images.githubusercontent.com/7880569/40963202-13875150-68a8-11e8-8757-646dd64e2763.png)

I expected this to be an issue with `search_authors()` - in particular, something to do with `$ignored_authors`. Indeed, diving into the JS and PHP, I found out it was an issue with how ignored authors are handled by the two sides. 

JS takes care of making the AJAX request to `ajax_suggest()`, which in turn calls `search_authors()`. It sends `existing_authors` as parameter, populating it with current authors `user_nicename`s.

```js
function coauthors_create_author_hidden_input ( author ) {
	var input = jQuery( '<input />' )
		.attr({
			'type': 'hidden',
			'id': 'coauthors_hidden_input',
			'name': 'coauthors[]',
			'value': decodeURIComponent( author.nicename )
		});
	return input;
}

jQuery( document ).ajaxSend(function( e, xhr, settings ) {
	var existing_authors = jQuery( 'input[name="coauthors[]"]' ).map(function(){return jQuery( this ).val();}).get();
```

But on the other side, PHP was deciding whether an author should be excluded from search comparing `user_login`s with the AJAX-supplied list of `user_nicename`s. This would work fine in several situations - basically, all the times `user_login` did not have any special chars or uppercase letters. But when `user_nicename` was different from `user_login`, this was clearly an issue.

```php
$found_users[ $found_user->user_login ] = $found_user;

foreach ( $found_users as $key => $found_user ) {
	if ( in_array( $found_user->user_login, $ignored_authors ) ) { 
		unset( $found_users[ $key ] );
	}
}
```

I thus changed `user_login` with `user_nicename` in the PHP bit. After this edit, the issue has gone! :)

![after](https://user-images.githubusercontent.com/7880569/40963389-a9b70742-68a8-11e8-82ea-5f1c27d2083e.png)

This edit does not affect anything else, as far as I am been able to check. All PHPUnit tests still succeed as they did before. Also, `search_authors()` is only called by `ajax_suggest()`, so it should really only affect its behavior (and that's what my tests have confirmed) :)