### PR TITLE
🐛Only filter author template for title

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1610,13 +1610,22 @@ class CoAuthors_Plus {
 
 	/**
 	 * Filter of the header of author archive pages to correctly display author.
+	 *
+	 * @param $title
+	 *
+	 * @return string
 	 */
-	public function filter_author_archive_title() {
-		if ( is_author() ) {
-			$author_slug = sanitize_user( get_query_var( 'author_name' ) );
-			$author = $this->get_coauthor_by( 'user_nicename', $author_slug );
-			return sprintf( __( 'Author: %s' ), $author->display_name );
+	public function filter_author_archive_title( $title ) {
+		
+		// Bail if not an author archive template
+		if ( ! is_author() ) {
+			return $title;
 		}
+		
+		$author_slug = sanitize_user( get_query_var( 'author_name' ) );
+		$author = $this->get_coauthor_by( 'user_nicename', $author_slug );
+		
+		return sprintf( __( 'Author: %s' ), $author->display_name );
 	}
 }
 


### PR DESCRIPTION
Repro steps:
- in `archive.php`, use `the_archive_title()` method
- load a category archive page

Expected results:
"Category: category_name"

Actual results:
null

Notes:
The `filter_author_archive_title()` function is hooked to the `get_the_archive_title` filter, which can run in other archive templates such as `category` or `tag`. As a result, the function only returns a value when `is_author()` returns `true`, thereby resulting in `null` instead of `$title` for all other archive templates.