### PR TITLE
Removed Test_Author_Queried_Object setUp function

### DIFF
--- a/tests/test-author-queried-object.php
+++ b/tests/test-author-queried-object.php
@@ -6,20 +6,6 @@
 class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 
 	/**
-	 * Set up for test
-	 *
-	 * Don't create tables as 'temporary'.
-	 *
-	 * @see https://github.com/Automattic/Co-Authors-Plus/issues/398
-	 */
-	function setUp() {
-		parent::setUp();
-
-		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
-		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
-	}
-
-	/**
 	 * On author pages, the queried object should only be set
 	 * to a user that's not a member of the blog if they
 	 * have at least one published post. This matches core behavior.


### PR DESCRIPTION
This fixes #526 - `test__author_queried_object_fix()` fails when run twice.

![schermata del 2018-05-30 21-48-44](https://user-images.githubusercontent.com/7880569/40768690-5073f4ec-64b6-11e8-98dc-553cd8c3e353.png)

After tests are run, the database should be properly cleaned by the WP testcase itself, so I dug into the core tests handling to see why that was not happening. Apparently, all queries were being run as `TEMPORARY`, except the ones from this test. Thus, this statement (which is where the test hanged for me):

```php
$blog2 = $this->factory->blog->create( array( 'user_id' => $author1 ) );
```

failed, because the blog (and related db tables) were already present.

And indeed, it failed because of the filters in `test-author-queried-object.php` `setUp()` function, which prevented the default behavior of declaring the new site tables as `TEMPORARY`. **Commenting those two filters out, tests succeed AND can be run an arbitrary number of times (without throwing any errors)**.

```php
function setUp() {
	parent::setUp();

	//remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
	//remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
}
```

As a side note, `WP_UnitTestCase->tearDown()`, which executes `$wpdb->query( 'ROLLBACK' );` and thus deletes all temporary tables, is called at the _end of each plugin test_, so it shouldn't create any issues, and those filters are not needed.

I have thus deleted the whole function, since it was not doing anything besides setting up the filters. All tests still pass okay!