### PR TITLE
Stop handling wp_terms in search_authors, do it in install and profile update

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1172,26 +1172,6 @@ class CoAuthors_Plus {
 	 */
 	public function search_authors( $search = '', $ignored_authors = array() ) {
 		$args = array(
-				'count_total' => false,
-				'search' => sprintf( '*%s*', $search ),
-				'search_columns' => array(
-					'ID',
-					'display_name',
-					'user_email',
-					'user_login',
-				),
-				'fields' => 'all_with_meta',
-			);
-		$found_users = get_users( $args );
-
-		foreach ( $found_users as $found_user ) {
-			$term = $this->get_author_term( $found_user );
-			if ( empty( $term ) || empty( $term->description ) ) {
-				$this->update_author_term( $found_user );
-			}
-		}
-
-		$args = array(
 			'search' => $search,
 			'get' => 'all',
 			'number' => 10,

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1442,10 +1442,6 @@ class CoAuthors_Plus {
 	function action_user_profile_update( $userid ) {
 		global $coauthors_plus;
 
-		if( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
 		$user = get_userdata( $userid );
 
 		// Update author term only if user can be added as coauthor

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1466,7 +1466,7 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Update author term when user profile is updated.
+	 * Create guest author profile when WP user profile is updated.
 	 *
 	 * @param int $userid
 	 */
@@ -1475,10 +1475,17 @@ class CoAuthors_Plus {
 
 		$user = get_userdata( $userid );
 
-		// Update author term only if user can be added as coauthor
-		if( $user->has_cap( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ) ) {
-			$coauthors_plus->update_author_term( $user );
+		// Continue only if user can be added as coauthor
+		if ( $user->has_cap( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ) === false ) {
+			return;
 		}
+
+
+		if ( ( $guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'login', $user->user_login ) ) === false ) {
+			$coauthors_plus->guest_authors->create_guest_author_from_user_id( $userid );
+		}
+
+		$coauthors_plus->update_author_term( $user ); // when user is updated, we want to update its term so that the search results show up-to-date info
 	}
 
 	/**

--- a/php/coauthors-install.php
+++ b/php/coauthors-install.php
@@ -15,17 +15,17 @@ function cap_install_setup() {
 
 
 /**
- * Creates author terms for existing users.
+ * Creates guest author profiles for existing users.
  *
  * Since CAP 2.7, we're searching against the term description for the fields instead of the user details.
- * When CAP is first installed, terms are missing for all existing users.
- * This function take care of creating terms for all users who have permission to be added as coauthors.
+ * When CAP is first installed, guest authors are missing for all existing users.
+ * This function take care of creating them for all users who have permission to be added as coauthors.
  * Uses a WP-Cron event that gets rescheduled until all users have been processed.
  *
  * @param int $imported_count number of users already processed (used as `offset` in get_users)
  * @param int $number_to_update number of users to process per each cron event
  */ 
-function cap_create_author_terms( $imported_count = 0, $number_to_update = 100 ) {
+function cap_create_guest_authors( $imported_count = 0, $number_to_update = 100 ) {
 	global $coauthors_plus;
 
 	$args = array(
@@ -47,11 +47,11 @@ function cap_create_author_terms( $imported_count = 0, $number_to_update = 100 )
 			continue;
 		}
 		
-		$coauthors_plus->update_author_term( $found_user );
+		$coauthors_plus->guest_authors->create_guest_author_from_user_id( $found_user->ID );
 	}
 
 	$imported_count += $number_to_update;
 
 	wp_schedule_single_event( time(), 'cap_import_existing_users', array( $imported_count ) );
 }
-add_action( 'cap_import_existing_users', 'cap_create_author_terms' );
+add_action( 'cap_import_existing_users', 'cap_create_guest_authors' );

--- a/php/coauthors-install.php
+++ b/php/coauthors-install.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Install functions.
+ *
+ * @package Co-Authors Plus
+ */ 
+
+/**
+ * Runs on plugin activation.
+ */ 
+function cap_install_setup() {
+	wp_schedule_single_event( time(), 'cap_import_existing_users' );
+}
+
+
+/**
+ * Creates author terms for existing users.
+ *
+ * Since CAP 2.7, we're searching against the term description for the fields instead of the user details.
+ * When CAP is first installed, terms are missing for all existing users.
+ * This function take care of creating terms for all users who have permission to be added as coauthors.
+ * Uses a WP-Cron event that gets rescheduled until all users have been processed.
+ *
+ * @param int $imported_count number of users already processed (used as `offset` in get_users)
+ * @param int $number_to_update number of users to process per each cron event
+ */ 
+function cap_create_author_terms( $imported_count = 0, $number_to_update = 100 ) {
+	global $coauthors_plus;
+
+	$args = array(
+		'orderby' => 'registered',
+		'order' => 'ASC',
+		'offset' => $imported_count,
+		'number' => $number_to_update,
+		'fields' => 'all_with_meta',
+	);
+	$found_users = get_users( $args );
+
+	if ( empty( $found_users ) ) {
+		return;
+	}
+
+	foreach ( $found_users as $found_user ) {
+		//Check that user has permission to be added as coauthor
+		if( ! $found_user->has_cap( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ) ) {
+			continue;
+		}
+		
+		$coauthors_plus->update_author_term( $found_user );
+	}
+
+	$imported_count += $number_to_update;
+
+	wp_schedule_single_event( time(), 'cap_import_existing_users', array( $imported_count ) );
+}
+add_action( 'cap_import_existing_users', 'cap_create_author_terms' );

--- a/php/coauthors-install.php
+++ b/php/coauthors-install.php
@@ -29,7 +29,7 @@ function cap_create_author_terms( $imported_count = 0, $number_to_update = 100 )
 	global $coauthors_plus;
 
 	$args = array(
-		'orderby' => 'registered',
+		'orderby' => 'user_nicename',
 		'order' => 'ASC',
 		'offset' => $imported_count,
 		'number' => $number_to_update,

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -10,7 +10,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->author1 = $this->factory->user->create_and_get( array( 'role' => 'author', 'user_login' => 'author1' ) );
 		$this->editor1 = $this->factory->user->create_and_get( array( 'role' => 'editor', 'user_login' => 'editor1' ) );
 
-		cap_create_user_terms(); //users without terms don't exist for CAP
+		cap_create_author_terms(); //users without terms don't exist for CAP
 
 		$this->post = $this->factory->post->create_and_get( array(
 			'post_author'  => $this->author1->ID,
@@ -366,7 +366,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$subscriber1 = $this->factory->user->create_and_get( array(
 			'role' => 'subscriber',
 		) );
-		cap_create_user_terms();
+		cap_create_author_terms();
 
 		$authors = $coauthors_plus->search_authors();
 
@@ -377,7 +377,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$contributor1 = $this->factory->user->create_and_get( array(
 			'role' => 'contributor',
 		) );
-		cap_create_user_terms();
+		cap_create_author_terms();
 
 		$authors = $coauthors_plus->search_authors();
 
@@ -433,7 +433,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$subscriber1 = $this->factory->user->create_and_get( array(
 			'role' => 'subscriber',
 		) );
-		cap_create_user_terms();
+		cap_create_author_terms();
 
 		$this->assertEmpty( $coauthors_plus->search_authors( $subscriber1->ID ) );
 	}
@@ -459,7 +459,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$author2 = $this->factory->user->create_and_get( array(
 			'role' => 'author',
 		) );
-		cap_create_user_terms();
+		cap_create_author_terms();
 
 		$authors = $coauthors_plus->search_authors( '', $ignored_authors );
 
@@ -494,7 +494,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 			'role'       => 'author',
 			'user_login' => 'author2',
 		) );
-		cap_create_user_terms();
+		cap_create_author_terms();
 
 		$authors = $coauthors_plus->search_authors( 'author', $ignored_authors );
 

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -3,11 +3,14 @@
 class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 	public function setUp() {
+		global $coauthors_plus;
 
 		parent::setUp();
 
 		$this->author1 = $this->factory->user->create_and_get( array( 'role' => 'author', 'user_login' => 'author1' ) );
 		$this->editor1 = $this->factory->user->create_and_get( array( 'role' => 'editor', 'user_login' => 'editor1' ) );
+
+		cap_create_user_terms(); //users without terms don't exist for CAP
 
 		$this->post = $this->factory->post->create_and_get( array(
 			'post_author'  => $this->author1->ID,
@@ -363,6 +366,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$subscriber1 = $this->factory->user->create_and_get( array(
 			'role' => 'subscriber',
 		) );
+		cap_create_user_terms();
 
 		$authors = $coauthors_plus->search_authors();
 
@@ -373,6 +377,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$contributor1 = $this->factory->user->create_and_get( array(
 			'role' => 'contributor',
 		) );
+		cap_create_user_terms();
 
 		$authors = $coauthors_plus->search_authors();
 
@@ -428,6 +433,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$subscriber1 = $this->factory->user->create_and_get( array(
 			'role' => 'subscriber',
 		) );
+		cap_create_user_terms();
 
 		$this->assertEmpty( $coauthors_plus->search_authors( $subscriber1->ID ) );
 	}
@@ -453,6 +459,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$author2 = $this->factory->user->create_and_get( array(
 			'role' => 'author',
 		) );
+		cap_create_user_terms();
 
 		$authors = $coauthors_plus->search_authors( '', $ignored_authors );
 
@@ -487,6 +494,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 			'role'       => 'author',
 			'user_login' => 'author2',
 		) );
+		cap_create_user_terms();
 
 		$authors = $coauthors_plus->search_authors( 'author', $ignored_authors );
 


### PR DESCRIPTION
This fixes #486. The issue was that the plugin created `wp_terms` for all users upon each call to `search_authors()`, regardless of whether they could be added as coauthors. This ended up flooding the database with tons of unneeded entries, in particular on sites with many subscribers.

_**tl;dr the fix is: stop creating/updating wp_terms on search; instead, do it in bulk on plugin install and in profile updating.**_

What I have done is:

1. **Set up a cron job on plugin activation** 

It selects WP users sorting by _registration time ASC_ and creates the needed author term for each of them, provided they have the capability of being added as coauthors. This is also a 80% fix for #235, because users that should never show up in search do not get a `wp_term`. 

At the end, the cron job just re-spawns itself as a new one, keeping track of how many users have already been processed. The process automatically stops (leaving no cron jobs behind) when the existing users import is complete. It updates 100 users every time. It may be _just a little bit_ heavy, but keep in mind that **until this runs, no authors are found in the Co-Authors search box!**

(Side note: sorting by registration time ASC ensures that, even on sites that get new users every few seconds, the import works fine. Indeed, the import deals first with non-changing data and tackles recent data at the end. It is guaranteed to cover all users. In truth, this is just an extra-safety measure, because all users created after CAP installation would have their term created as per 2. ).

2. **Create/Update author terms when a user profile is updated**

This is what makes sure terms are kept updated after plugin installation.

3. **Lighten the `search_authors()` function** 

Before, it used to the following:
- query for WP users and update author term for selected users
- query for terms. These would be where the _real_ search results would come from
- foreach the selected users and exclude the ones that did not have permission to be added as coauthors.

Now, it
- queries for terms (search results)
- foreaches the selected users and exclude the ones that do not have permission to be added as coauthors. However, when a user is found not to have enough permissions BUT has the CAP wp_term, the wp_term is deleted so that the user will not be selected in future searches. **This will gradually de-pollute the database!** (We could not just strip this check because current CAP installations have subscribers with CAP term.)

4. **Updated PHPUnit tests to work**

When testing `search_authors()`, the tests created some users and then immediately called `search_authors()`, relying on the fact that it would create the missing wp_term for the new users. This is no longer the case, so we need to call `cap_create_author_terms()` after creating the users. It defaults to updating 100 users, so if ever we will test creating more than 100 users, will need to call it like `cap_create_author_terms(0, 1000)`.

All tests succeed now after the last commit.