### PR TITLE
Making sure no coauthors are already assigned to a post before overwriting them with empty array

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -866,8 +866,13 @@ class CoAuthors_Plus {
 		}
 
 		// A co-author is always required
+		// If no coauthor is provided AND no coauthors are currently set, assign to current user - retain old ones otherwise.
 		if ( empty( $coauthors ) ) {
-			$coauthors = array( $current_user->user_login );
+			if( empty( $existing_coauthors ) ) {
+				$coauthors = array( $current_user->user_login );
+			} else {
+				$coauthors = $existing_coauthors;
+			}
 		}
 
 		// Set the co-authors


### PR DESCRIPTION
This fixes #492.

Currently, calling `add_coauthors()` with an empty array of coauthors to be added has the effect of setting the current user as coauthor. In particular, this is the problematic call: `add_coauthors( $post_id, array() )`. This will set the current author as **solo** co-author, **even if** other coauthors are already added to the post.

```php
// A co-author is always required
if ( empty( $coauthors ) ) {
	$coauthors = array( $current_user->user_login );
}
```

This is a safety measure to make sure that the function never runs without coauthors. However, it should not impact posts that are fine the way they are. If a post already has coauthors, and `add_coauthors` is called on it with an empty array, then the reasonable action is... no action, just leave the current coauthors as they are, and guess the call was a mistake. Expected behavior is by no means dropping the current list of coauthors and replace it with the current user. 

This commit only uses the current user if `add_coauthors` is called with an empty array **AND** no coauthors are already assigned to the post :)