### PR TITLE
Re-enable disabled Test_Author_Queries tests

### DIFF
--- a/tests/test-author-queries.php
+++ b/tests/test-author-queries.php
@@ -101,8 +101,6 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function tests__author_name_arg_plus_tax_query__is_coauthor() {
-		return; // TODO: re-enable; fails currently because our posts_join_filter doesn't add an exclusive JOIN on relationships + taxonomy to match the query mods we make. We'd need aliased JOINs on relationships + taxonomy on top of the JOIN that the tax query already adds.
-
 		$author1_id = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'batman' ) );
 		$author1 = get_userdata( $author1_id );
 		$author2_id = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'superman' ) );

--- a/tests/test-author-queries.php
+++ b/tests/test-author-queries.php
@@ -60,8 +60,6 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test__author_arg__user_is_coauthor__author_arg() {
-		return; // TODO: re-enable; fails currently because WordPress generates query as `post_author IN (id)` which doesn't match our regex in the posts_where filter.
-
 		$author1_id = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'batman' ) );
 		$author1 = get_userdata( $author1_id );
 		$author2_id = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'superman' ) );


### PR DESCRIPTION
This fixes #538.

`Test_Author_Queries->test__author_arg__user_is_coauthor__author_arg()` and `Test_Author_Queries->tests__author_name_arg_plus_tax_query__is_coauthor()` had been deactivated because failed. I was looking at the reason why that should be the case (even before trying to execute them), and I couldn't find any - it all looked okay! Then I simply re-activated them without changing anything, and it looks like they work fine!

The issues in the code that prevented them from working were fixed in #388 (in particular, https://github.com/Automattic/Co-Authors-Plus/pull/476/commits/fd08f52a97fe63dbc6b7a25dd7be1b94c25b4b53) for the first test, and #376 (in particular, https://github.com/Automattic/Co-Authors-Plus/commit/786777a38bde89c84852794e05a844f932b7f596) for the second test, I believe.

I tried to run PHPUnit after re-enabling both, and it just went through smoothly!

![screenshot from 2018-06-15 15-54-15](https://user-images.githubusercontent.com/7880569/41471596-6347a5e6-70b4-11e8-8f1f-63f79835a566.png)
