### PR TITLE
column_posts() should use user_login when querying for linked_account

### DIFF
--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -253,7 +253,7 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 		$term = $coauthors_plus->get_author_term( $item );
 		$guest_term = get_term_by( 'slug', 'cap-' . $item->user_nicename, $coauthors_plus->coauthor_taxonomy );
 		if ( ! empty( $item->linked_account ) && $guest_term->count ) {
-			$count = count_user_posts( get_user_by( 'slug', $item->linked_account )->ID );
+			$count = count_user_posts( get_user_by( 'login', $item->linked_account )->ID );
 		} elseif ( $term ) {
 			$count = $term->count;
 		} else {


### PR DESCRIPTION
This fixes #554.

In the Guest Authors view, some authors would have a wrong post count. This would happen for users with a `user_login` different than the `user_nicename`. 

Up to now, due to [this Core issue](https://core.trac.wordpress.org/ticket/44510), `count_user_posts()` would return the total site posts count for those users. When that bug will be fixed, it will return 0. In any case, it is not the correct count.

The issue lies in this part of the code:

```php
if ( ! empty( $item->linked_account ) && $guest_term->count ) {
	$count = count_user_posts( get_user_by( 'slug', $item->linked_account )->ID );
```

because `$item->linked_account` contains the user login rather than the slug (which would be the nicename). Besides returning a wrong count, it would also generate a bunch of PHP Notices because `get_user_by` would return `false` and we would thus be fetching property of non-object.

![screenshot from 2018-07-04 11-10-27](https://user-images.githubusercontent.com/7880569/42268187-2b5598de-7f7b-11e8-87a3-d1457905094a.png)