### PR TITLE
Changed posts_selection from filter to action

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -110,7 +110,7 @@ class CoAuthors_Plus {
 		add_filter( 'wp_get_object_terms', array( $this, 'filter_wp_get_object_terms' ), 10, 4 );
 
 		// Make sure we've correctly set data on guest author pages
-		add_filter( 'posts_selection', array( $this, 'fix_author_page' ) ); // use posts_selection since it's after WP_Query has built the request and before it's queried any posts
+		add_action( 'posts_selection', array( $this, 'fix_author_page' ) ); // use posts_selection since it's after WP_Query has built the request and before it's queried any posts
 		add_action( 'the_post', array( $this, 'fix_author_page' ) );
 
 		// Support for Edit Flow's calendar and story budget
@@ -1071,8 +1071,11 @@ class CoAuthors_Plus {
 	 * the query_var is changed.
 	 *
 	 * Also, we have to do some hacky WP_Query modification for guest authors
+	 *
+	 * @param string $selection The assembled selection query
+	 * @void
 	 */
-	public function fix_author_page() {
+	public function fix_author_page( $selection ) {
 
 		if ( ! is_author() ) {
 			return;


### PR DESCRIPTION
This fixes #562.

The issue was that `posts_selection` was being used as a WP filter rather than an action, as it should have been. This was wrong, but did not impact the plugin behavior because `add_action()` is actually [just a wrapper](https://developer.wordpress.org/reference/functions/add_action/#source) of `add_filter()`. The other way around, it would have not worked, but this way... it works, even if it is wrong.

I have also taken the chance to add the apt argument to the callback (since the hook is passing it) and to update the inline doc.