### PR TITLE
Fixing double posts counts for users with linked accounts

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -994,23 +994,19 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Filter the count_users_posts() core function to include our correct count
+	 * Filter the count_users_posts() core function to include our correct count.
+	 *
+	 * @param int $count Post count
+	 * @param int $user_id WP user ID
+	 * @return int Post count
 	 */
 	function filter_count_user_posts( $count, $user_id ) {
 		$user = get_userdata( $user_id );
-
 		$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
 
 		$term = $this->get_author_term( $user );
-		$guest_term = get_term_by( 'slug', 'cap-' . $user->user_nicename, $this->coauthor_taxonomy );
-		// Only modify the count if it has a linked account with posts or the author exists as a term
-		if ( $user->linked_account && $guest_term->count ) {
-			if ( $term && ! is_wp_error( $term )) {
-				$count = $guest_term->count + $term->count;
-			} else {
-				$count = $guest_term->count;
-			}
-		} elseif ( $term && ! is_wp_error( $term ) ) {
+		
+		if ( $term && ! is_wp_error( $term ) ) {
 			$count = $term->count;
 		}
 


### PR DESCRIPTION
This fixes #561.

On a correct, up-to-date CAP installation, posts counts for authors with guest authors profile are absolutely off - basically, they are double what they should.

This is an example with CAP enabled - clearly off since the `Mine` posts is more than the total:
![w cap](https://user-images.githubusercontent.com/7880569/42560878-0f11328c-84f8-11e8-94d5-bc1dab1faef5.png)

With CAP disabled:
![wo cap](https://user-images.githubusercontent.com/7880569/42560879-0f3b15ca-84f8-11e8-8e9e-70af57becc4c.png)

Prior to this PR, the code which filtered the WP posts count was this:
```php
$term = $this->get_author_term( $user );
$guest_term = get_term_by( 'slug', 'cap-' . $user->user_nicename, $this->coauthor_taxonomy );

// Only modify the count if it has a linked account with posts or the author exists as a term
if ( $user->linked_account && $guest_term->count ) {
	if ( $term && ! is_wp_error( $term )) {
		$count = $guest_term->count + $term->count;
	} else {
		$count = $guest_term->count;
	}
} elseif ( $term && ! is_wp_error( $term ) ) {
	$count = $term->count;
}
```
Both `$term` and `$guest_term` are considered, guessing that `$term` would hold the non-prefixed version of the CAP author term, while `$guest_term` the prefixed `cap-` one. The counts are later summed under the assumption that they are complementary. The flaw is that [`$this->get_author_term()`](https://github.com/TheCrowned/Co-Authors-Plus/blob/master/co-authors-plus.php#L1424) already fetches the one term that exists, giving priority to the prefixed `cap-` version of it. So what happens is that, **if `cap-$username` exists, both `$term` and `$guest_term` will contain its content, and `$count` will then be doubled.**

The fix is thus to get rid of the `$guest_term` var and only retain the final conditional:
```php
if ( $term && ! is_wp_error( $term ) ) {
	$count = $term->count;
}
```
But aren't we losing some counts on the way? Aren't we discarding the non-prefixed version of the term? Is it just useless? No, we don't lose counts; No, we are discarding it, and no, it is not useless. The pivot is [`$this->update_author_term()`](https://github.com/TheCrowned/Co-Authors-Plus/blob/master/co-authors-plus.php#L1452): it will update any of the terms that exist, also suggesting that it should never happen that they co-exist: either there is the prefixed `cap-` term, _or_ the non-prefixed one. In any case, `get_author_term()` will fetch the one that exists for the author, which will already contain the total count, and we don't need to sum anything to it. 

(I think we should also think about migrating terms to all having the `cap-` prefix, but this is another issue #566)