### PR TITLE
$ignored_authors in search should use user_nicename, not login.

### DIFF
--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -442,7 +442,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		global $coauthors_plus;
 
 		// Ignoring single author.
-		$ignored_authors = array( $this->author1->user_login );
+		$ignored_authors = array( $this->author1->user_nicename );
 
 		$authors = $coauthors_plus->search_authors( '', $ignored_authors );
 
@@ -461,7 +461,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertArrayHasKey( $author2->user_login, $authors );
 
 		// Ignoring multiple authors.
-		$authors = $coauthors_plus->search_authors( '', array( $this->author1->user_login, $author2->user_login ) );
+		$authors = $coauthors_plus->search_authors( '', array( $this->author1->user_nicename, $author2->user_nicename ) );
 
 		$this->assertNotEmpty( $authors );
 		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
@@ -478,7 +478,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		global $coauthors_plus;
 
 		// Checks when ignoring author1.
-		$ignored_authors = array( $this->author1->user_login );
+		$ignored_authors = array( $this->author1->user_nicename );
 
 		$this->assertEmpty( $coauthors_plus->search_authors( $this->author1->ID, $ignored_authors ) );
 


### PR DESCRIPTION
This fixes #568.

As per #532, the `$ignored_authors` arg to `search_authors()` should take an array of `user_nicename`s, not `user_login`s. The second test in `test_search_authors_when_ignored_authors_provided()` would fail because of this, while `test_search_authors_when_search_keyword_and_ignored_authors_provided()` could fail. I addressed them both. They all succeed now.