### PR TITLE
Modified query filter regex.

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -712,7 +712,7 @@ class CoAuthors_Plus {
 
 					$maybe_both_query = $maybe_both ? '$0 OR' : '';
 
-					$where = preg_replace( '/\s\b(?:' . $wpdb->posts . '\.)?post_author\s*IN\s*(.*private\'.)/', ' (' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+					$where = preg_replace( '/\s\b(?:' . $wpdb->posts . '\.)?post_author\s*IN\s*(.*' . $id . '(?:.*private\')?.)/', ' (' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
 
 				} else {
 					$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . $id . '))/', '(' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -712,7 +712,7 @@ class CoAuthors_Plus {
 
 					$maybe_both_query = $maybe_both ? '$0 OR' : '';
 
-					$where = preg_replace( '/\s\b(?:' . $wpdb->posts . '\.)?post_author\s*IN\s*(.*' . $id . '.)/', ' (' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+					$where = preg_replace( '/\s\b(?:' . $wpdb->posts . '\.)?post_author\s*IN\s*(.*private\'.)/', ' (' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
 
 				} else {
 					$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . $id . '))/', '(' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND

--- a/tests/test-author-queries.php
+++ b/tests/test-author-queries.php
@@ -12,6 +12,8 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 		) );
 		$this->_cap->add_coauthors( $post_id, array( $author->user_login ) );
 
+		wp_set_current_user( $author_id );
+
 		$query = new WP_Query( array(
 			'author' => $author_id,
 		) );

--- a/tests/test-author-queries.php
+++ b/tests/test-author-queries.php
@@ -2,7 +2,7 @@
 
 class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 
-	public function test__author_arg__user_is_post_author() {
+	public function test__author_arg__user_is_post_author_query_as_post_author() {
 		$author_id = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'batman' ) );
 		$author = get_userdata( $author_id );
 		$post_id = $this->factory->post->create( array(
@@ -13,6 +13,24 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 		$this->_cap->add_coauthors( $post_id, array( $author->user_login ) );
 
 		wp_set_current_user( $author_id );
+
+		$query = new WP_Query( array(
+			'author' => $author_id,
+		) );
+
+		$this->assertEquals( 1, count( $query->posts ) );
+		$this->assertEquals( $post_id, $query->posts[ 0 ]->ID );
+	}
+
+	public function test__author_arg__user_is_post_author() {
+		$author_id = $this->factory->user->create( array( 'role' => 'author', 'user_login' => 'batman' ) );
+		$author = get_userdata( $author_id );
+		$post_id = $this->factory->post->create( array(
+			'post_author'     => $author_id,
+			'post_status'     => 'publish',
+			'post_type'       => 'post',
+		) );
+		$this->_cap->add_coauthors( $post_id, array( $author->user_login ) );
 
 		$query = new WP_Query( array(
 			'author' => $author_id,


### PR DESCRIPTION
This code is meant to append a conditional statement to the WHERE clause of a query.

But because the regex mistakenly believed that the statement should be appended after a user ID, and not after 'private', we ended up with queries like this:

```
OR wp_posts.post_author = 3
OR (
    wp_term_taxonomy.taxonomy = 'author'
    AND wp_term_taxonomy.term_id = '8'
)
AND wp_posts.post_status = 'private'
```

instead of this:

```
OR wp_posts.post_author = 3 AND wp_posts.post_status = 'private'
OR (
    wp_term_taxonomy.taxonomy = 'author'
    AND wp_term_taxonomy.term_id = '8'
)
```

Those are two very different queries: One returns posts including those private posts that belong to user 3, the other excludes all posts that are not private posts belonging to user 3.

The modified regex now allows the query to be constructed appropriately.

I've run unit tests on the code and no regressions were reported.

You can also review my process of solving the problem here: https://github.com/Automattic/Co-Authors-Plus/issues/508