### PR TITLE
Add CLI argument to assign-coauthors

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -121,7 +121,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @since 3.0
 	 *
 	 * @subcommand assign-coauthors
-	 * @synopsis [--meta_key=<key>] [--post_type=<ptype>] [--append_coauthors=<boolean>]
+	 * @synopsis [--meta_key=<key>] [--post_type=<ptype>] [--append_coauthors]
 	 */
 	public function assign_coauthors( $args, $assoc_args ) {
 		global $coauthors_plus;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -121,7 +121,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @since 3.0
 	 *
 	 * @subcommand assign-coauthors
-	 * @synopsis [--meta_key=<key>] [--post_type=<ptype>]
+	 * @synopsis [--meta_key=<key>] [--post_type=<ptype>] [--append_coauthors=<boolean>]
 	 */
 	public function assign_coauthors( $args, $assoc_args ) {
 		global $coauthors_plus;


### PR DESCRIPTION
This argument is used in the code already, but isn’t allowed to be passed down since it’s not in the synopsis.

It ends up being passed to `add_coauthors()` and determines if the co-author being added should replace all of the existing coauthors, or if it should be appended to the existing ones.