### PR TITLE
Avoid PHP Fatal in calling guest_authors->get_guest_author_by

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -940,15 +940,17 @@ class CoAuthors_Plus {
 			wp_delete_term( $delete_user->user_login, $this->coauthor_taxonomy );
 		}
 
-		// Get the deleted user data by user id.
-		$user_data = get_user_by( 'id', $delete_id );
+		if ( $this->is_guest_authors_enabled() ) {
+			// Get the deleted user data by user id.
+			$user_data = get_user_by( 'id', $delete_id );
+		
+			// Get the associated user.
+			$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $user_data->data->user_login );
 
-		// Get the associated user.
-		$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $user_data->data->user_login );
-
-		if ( isset( $associated_user->ID ) ) {
-			// Delete associated guest user.
-			$this->guest_authors->delete( $associated_user->ID );
+			if ( isset( $associated_user->ID ) ) {
+				// Delete associated guest user.
+				$this->guest_authors->delete( $associated_user->ID );
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes #601.

The issue was that `guest_authors->get_guest_author_by()` was being called without prior checking that guest author functions were enabled, and thus resulting in a PHP Fatal because `guest_authors` was `null`.