### PR TITLE
Add a method to fetch the guest author post count

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1649,22 +1649,29 @@ class CoAuthors_Plus {
 	/**
 	 * Get the post count for the guest author
 	 *
-	 * @global oebject $coauthors_plus
-	 * @param object $item guest-author object.
+	 * @param object $guest_author guest-author object.
 	 * @return int post count for the guest author
 	 */
-	public function get_guest_author_post_count( $item ) {
-		$term       = $this->get_author_term( $item );
-		$guest_term = get_term_by( 'slug', 'cap-' . $item->user_nicename, $this->coauthor_taxonomy );
-		if ( ! empty( $item->linked_account ) && $guest_term->count ) {
-			return count_user_posts( get_user_by( 'login', $item->linked_account )->ID );
+	public function get_guest_author_post_count( $guest_author ) {
+		if ( ! is_object( $guest_author ) ) {
+			return;
+		}
+
+		$term = $this->get_author_term( $guest_author );
+		$guest_term = get_term_by( 'slug', 'cap-' . $guest_author->user_nicename, $this->coauthor_taxonomy );
+
+		if ( ! $term || ! $guest_term ) {
+			return false;
+		}
+
+		if ( ! empty( $guest_author->linked_account ) && $guest_term->count ) {
+			return count_user_posts( get_user_by( 'login', $guest_author->linked_account )->ID );
 		} elseif ( $term ) {
 			return $term->count;
 		} else {
 			return 0;
 		}
 	}
-
 
 }
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1657,14 +1657,12 @@ class CoAuthors_Plus {
 			return;
 		}
 
-		$term = $this->get_author_term( $guest_author );
+		$term       = $this->get_author_term( $guest_author );
 		$guest_term = get_term_by( 'slug', 'cap-' . $guest_author->user_nicename, $this->coauthor_taxonomy );
 
-		if ( ! $term || ! $guest_term ) {
-			return false;
-		}
-
-		if ( ! empty( $guest_author->linked_account ) && $guest_term->count ) {
+		if ( is_object( $guest_term )
+			&& ! empty( $guest_author->linked_account )
+			&& $guest_term->count ) {
 			return count_user_posts( get_user_by( 'login', $guest_author->linked_account )->ID );
 		} elseif ( $term ) {
 			return $term->count;

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1644,7 +1644,27 @@ class CoAuthors_Plus {
 		$author = $this->get_coauthor_by( 'user_nicename', $author_slug );
 		
 		return sprintf( __( 'Author: %s' ), $author->display_name );
+	}	
+
+	/**
+	 * Get the post count for the guest author
+	 *
+	 * @global oebject $coauthors_plus
+	 * @param object $item guest-author object.
+	 * @return int post count for the guest author
+	 */
+	public function get_guest_author_post_count( $item ) {
+		$term       = $this->get_author_term( $item );
+		$guest_term = get_term_by( 'slug', 'cap-' . $item->user_nicename, $this->coauthor_taxonomy );
+		if ( ! empty( $item->linked_account ) && $guest_term->count ) {
+			return count_user_posts( get_user_by( 'login', $item->linked_account )->ID );
+		} elseif ( $term ) {
+			return $term->count;
+		} else {
+			return 0;
+		}
 	}
+
 
 }
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -469,7 +469,8 @@ class CoAuthors_Guest_Authors
 			}
 
 			// get post count
-			$count = $this->get_guest_author_post_count( $guest_author );
+			global $coauthors_plus;
+			$count = $coauthors_plus->get_guest_author_post_count( $guest_author );
 
 			echo '<div class="wrap">';
 			echo '<div class="icon32" id="icon-users"><br/></div>';
@@ -550,21 +551,6 @@ class CoAuthors_Guest_Authors
 			echo '</div>';
 		}
 
-	}
-
-	/**
-	 * Fetch the post count for a guest author
-	 *
-	 * @param object $guest_author guest-author object.
-	 * @return int post count.
-	 */
-	function get_guest_author_post_count( $guest_author ) {
-		if ( ! is_object( $guest_author ) ) {
-			return;
-		} else {
-			$cap_list_table = new CoAuthors_WP_List_Table();
-			return $cap_list_table->get_post_count( $guest_author );
-		}
 	}
 
 	/**

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -469,13 +469,7 @@ class CoAuthors_Guest_Authors
 			}
 
 			// get post count
-			global $coauthors_plus;
-			$term = $coauthors_plus->get_author_term( $guest_author );
-			if ( $term ) {
-				$count = $term->count;
-			} else {
-				$count = 0;
-			}
+			$count = $this->get_guest_author_post_count( $guest_author );
 
 			echo '<div class="wrap">';
 			echo '<div class="icon32" id="icon-users"><br/></div>';
@@ -556,6 +550,21 @@ class CoAuthors_Guest_Authors
 			echo '</div>';
 		}
 
+	}
+
+	/**
+	 * Fetch the post count for a guest author
+	 *
+	 * @param object $guest_author guest-author object.
+	 * @return int post count.
+	 */
+	function get_guest_author_post_count( $guest_author ) {
+		if ( ! is_object( $guest_author ) ) {
+			return;
+		} else {
+			$cap_list_table = new CoAuthors_WP_List_Table();
+			return $cap_list_table->get_post_count( $guest_author );
+		}
 	}
 
 	/**

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -249,28 +249,9 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 	 * Render the published post count column
 	 */
 	function column_posts( $item ) {
-		$count = $this->get_post_count( $item );
-		return '<a href="' . esc_url( add_query_arg( 'author_name', rawurlencode( $item->user_login ), admin_url( 'edit.php' ) ) ) . '">' . $count . '</a>';
-	}
-
-	/**
-	 * Get the post count for the guest author
-	 *
-	 * @global oebject $coauthors_plus
-	 * @param object $item guest-author object.
-	 * @return int post count for the guest author
-	 */
-	function get_post_count( $item ) {
 		global $coauthors_plus;
-		$term       = $coauthors_plus->get_author_term( $item );
-		$guest_term = get_term_by( 'slug', 'cap-' . $item->user_nicename, $coauthors_plus->coauthor_taxonomy );
-		if ( ! empty( $item->linked_account ) && $guest_term->count ) {
-			return count_user_posts( get_user_by( 'login', $item->linked_account )->ID );
-		} elseif ( $term ) {
-			return $term->count;
-		} else {
-			return 0;
-		}
+		$count = $coauthors_plus->get_guest_author_post_count( $item );
+		return '<a href="' . esc_url( add_query_arg( 'author_name', rawurlencode( $item->user_login ), admin_url( 'edit.php' ) ) ) . '">' . $count . '</a>';
 	}
 
 	/**

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -249,17 +249,28 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 	 * Render the published post count column
 	 */
 	function column_posts( $item ) {
+		$count = $this->get_post_count( $item );
+		return '<a href="' . esc_url( add_query_arg( 'author_name', rawurlencode( $item->user_login ), admin_url( 'edit.php' ) ) ) . '">' . $count . '</a>';
+	}
+
+	/**
+	 * Get the post count for the guest author
+	 *
+	 * @global oebject $coauthors_plus
+	 * @param object $item guest-author object.
+	 * @return int post count for the guest author
+	 */
+	function get_post_count( $item ) {
 		global $coauthors_plus;
-		$term = $coauthors_plus->get_author_term( $item );
+		$term       = $coauthors_plus->get_author_term( $item );
 		$guest_term = get_term_by( 'slug', 'cap-' . $item->user_nicename, $coauthors_plus->coauthor_taxonomy );
 		if ( ! empty( $item->linked_account ) && $guest_term->count ) {
-			$count = count_user_posts( get_user_by( 'login', $item->linked_account )->ID );
+			return count_user_posts( get_user_by( 'login', $item->linked_account )->ID );
 		} elseif ( $term ) {
-			$count = $term->count;
+			return $term->count;
 		} else {
-			$count = 0;
+			return 0;
 		}
-		return '<a href="' . esc_url( add_query_arg( 'author_name', rawurlencode( $item->user_login ), admin_url( 'edit.php' ) ) ) . '">' . $count . '</a>';
 	}
 
 	/**


### PR DESCRIPTION
Addresses #552 

Extracted the logic to get the post count from the `cloumn_posts` function of the `CoAuthors_WP_List_Table` class. 
Then added a wrapper for the newly created function in the class `CoAuthors_Guest_Authors` so that all guest author functionality remains in one class.
Made use of the new wrapper method in the `view_guest_authors_list` method.

Tested the changes with multiple guest authors with a varying number of posts. 