### PR TITLE
Add the ability to add additional classes to coauthors_get_avatar()

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -958,11 +958,12 @@ class CoAuthors_Guest_Authors
 	/**
 	 * Get an thumbnail for a Guest Author object
 	 *
-	 * @param 	object 	The Guest Author object for which to retrieve the thumbnail
-	 * @param 	int 	The desired image size
-	 * @return 	string 	The thumbnail image tag, or null if one doesn't exist
+	 * @param 	object 	The Guest Author object for which to retrieve the thumbnail.
+	 * @param 	int 	The desired image size.
+	 * @param   string  String of additional classes. Default null.
+	 * @return 	string 	The thumbnail image tag, or null if one doesn't exist.
 	 */
-	function get_guest_author_thumbnail( $guest_author, $size ) {
+	function get_guest_author_thumbnail( $guest_author, $size, $class = null ) {
 		// See if the guest author has an avatar
 		if ( ! has_post_thumbnail( $guest_author->ID ) ) {
 			return null;
@@ -971,6 +972,9 @@ class CoAuthors_Guest_Authors
 		$args = array(
 				'class' => "avatar avatar-{$size} photo",
 			);
+		if ( ! empty( $class ) ) {
+			$args['class'] += " $class";
+		}
 
 		$size = array( $size, $size );
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -676,19 +676,31 @@ function coauthors_wp_list_authors( $args = array() ) {
  * This is a replacement for using get_avatar(), which only operates on email addresses and cannot differentiate
  * between Guest Authors (who may share an email) and regular user accounts
  *
- * @param  object   $coauthor The Co Author or Guest Author object
- * @param  int      $size     The desired size
- * @return string             The image tag for the avatar, or an empty string if none could be determined
+ * @param  object        $coauthor The Co Author or Guest Author object.
+ * @param  int           $size     The desired size.
+ * @param  string        $default  Optional. URL for the default image or a default type. Accepts '404'
+ *                                 (return a 404 instead of a default image), 'retro' (8bit), 'monsterid'
+ *                                 (monster), 'wavatar' (cartoon face), 'indenticon' (the "quilt"),
+ *                                 'mystery', 'mm', or 'mysteryman' (The Oyster Man), 'blank' (transparent GIF),
+ *                                 or 'gravatar_default' (the Gravatar logo). Default is the value of the
+ *                                 'avatar_default' option, with a fallback of 'mystery'.
+ * @param  string        $alt      Optional. Alternative text to use in &lt;img&gt; tag. Default false.
+ * @param  array|string  $class    Array or string of additional classes to add to the &lt;img&gt; element. Default null.
+ * @return string                  The image tag for the avatar, or an empty string if none could be determined.
  */
-function coauthors_get_avatar( $coauthor, $size = 32, $default = '', $alt = false ) {
+function coauthors_get_avatar( $coauthor, $size = 32, $default = '', $alt = false, $class = null ) {
 	global $coauthors_plus;
 
 	if ( ! is_object( $coauthor ) ) {
 		return '';
 	}
 
+	if ( ! empty( $class ) && is_array( $class ) ) {
+			$class = implode( ' ', $class );
+	}
+
 	if ( isset( $coauthor->type ) && 'guest-author' == $coauthor->type ) {
-		$guest_author_thumbnail = $coauthors_plus->guest_authors->get_guest_author_thumbnail( $coauthor, $size );
+		$guest_author_thumbnail = $coauthors_plus->guest_authors->get_guest_author_thumbnail( $coauthor, $size, $class );
 
 		if ( $guest_author_thumbnail ) {
 			return $guest_author_thumbnail;
@@ -697,7 +709,7 @@ function coauthors_get_avatar( $coauthor, $size = 32, $default = '', $alt = fals
 
 	// Make sure we're dealing with an object for which we can retrieve an email
 	if ( isset( $coauthor->user_email ) ) {
-		return get_avatar( $coauthor->user_email, $size, $default, $alt );
+		return get_avatar( $coauthor->user_email, $size, $default, $alt, array( 'class' => $class ) );
 	}
 
 	// Nothing matched, an invalid object was passed.


### PR DESCRIPTION
Addresses #266.

Based on the type of co-author, `coauthors_get_avatar()` calls either `get_guest_author_thumbnail()` or `get_avatar()`.

[`get_avatar()`](https://github.com/WordPress/WordPress/blob/master/wp-includes/pluggable.php#L2533) accepts an `args` array, an element of which is an `array|string` of additional classes.

A similar modification is required for [`get_guest_author_thumbnail()`](https://github.com/Automattic/Co-Authors-Plus/blob/master/php/class-coauthors-guest-authors.php#L965) which will also accept an additional parameter `$class`; a string of additional classes. 

[`coauthors_get_avatar()`](https://github.com/Automattic/Co-Authors-Plus/blob/master/template-tags.php#L683) now accepts an optional param `$class` which will be either an array or string of additional classes, the default value of which will be `null`. If it is an array of classes, it will be converted to a space delimited string using `implode()` and passed to either `get_guest_author_thumbnail()` or `get_avatar()`.