### PR TITLE
Allow avatars to be imported by ID

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1263,6 +1263,11 @@ class CoAuthors_Guest_Authors
 			update_post_meta( $post_id, $pm_key, $args[ $key ] );
 		}
 
+		// Attach the avatar / featured image.
+		if ( ! empty( $args[ 'avatar' ] ) ) {
+			set_post_thumbnail( $post_id, $args[ 'avatar' ] );
+		}
+
 		// Make sure the author term exists and that we're assigning it to this post type
 		$author_term = $coauthors_plus->update_author_term( $this->get_guest_author_by( 'ID', $post_id ) );
 		wp_set_post_terms( $post_id, array( $author_term->slug ), $coauthors_plus->coauthor_taxonomy, false );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -824,7 +824,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'user_login' => sanitize_user( $author['user_login'] ),
 				'user_email' => sanitize_email( $author['user_email'] ),
 				'website' => esc_url_raw( $author['website'] ),
-				'description' => wp_filter_post_kses( $author['description'] )
+				'description' => wp_filter_post_kses( $author['description'] ),
+				'avatar' => absint( $author['avatar'] ),
 			);
 
 			$display_name_space_pos = strpos( $author['display_name'], ' ' );
@@ -864,7 +865,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'first_name' => $author['first_name'],
 				'last_name' => $author['last_name'],
 				'website' => $author['website'],
-				'description' => $author['description']
+				'description' => $author['description'],
+				'avatar' => $author['avatar'],
 			) );
 
 			if ( $guest_author_id ) {


### PR DESCRIPTION
Similar to https://github.com/Automattic/Co-Authors-Plus/pull/603

This will allow the CSV import to set a guest author's avatar by adding a column called `avatar` and listing the image's ID.

Future improvement:

#### 1) Allow listing the image's name rather than ID.

Will require a custom query to find the image ID based on the post name. WC does something similar here: https://github.com/woocommerce/woocommerce/blob/master/includes/import/abstract-wc-product-importer.php#L541-L567

#### 2) Allow listing an external URL that will then be imported and assigned as the featured image.

WC does this here: https://github.com/woocommerce/woocommerce/blob/master/includes/import/abstract-wc-product-importer.php#L589-L606

I was always thinking [we could use `WP_CLI::runcommand()`](https://make.wordpress.org/cli/handbook/internal-api/wp-cli-runcommand/) if available, and simply call:
`wp media import https://example.com/some-image.png`.