### PR TITLE
Don't search and replace with co-author post_id

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -715,6 +715,12 @@ class CoAuthors_Plus {
 
 				$id = is_author() ? get_queried_object_id() : '\d+';
 
+				//If we have an ID but it's not a "real" ID that means that this isn't the first time the filter has fired and the object_id has already been replaced by a previous run of this filter. We therefore need to replace the 0
+				// This happens when wp_query::get_posts() is run multiple times.
+				if ( false === get_user_by( 'id', $id ) ){
+					$id = 0;
+				}
+				
 				// When WordPress generates query as 'post_author IN (id)'.
 				if ( false !== strpos( $where, "{$wpdb->posts}.post_author IN " ) ) {
 


### PR DESCRIPTION
If the posts_where_filter has already been run (For example is wp_query::get_posts() is run twice). The second time around it will try to replace the co-author's post id inside the query, leading it to not replace the 'wp_posts.post_author = 0' part of the query.

This fixes a compatability issue with Yoast wp-seo

Internal ticket id:85217