### PR TITLE
Use CSS to hide the Block Editor's Author label + select

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -109,3 +109,9 @@
 			margin-left: 30px;
 			font-size: 13px;
 		}
+
+/** Block Editor Hack for 5.0: Hide the core author input **/
+.block-editor label[for^="post-author-selector-"],
+.block-editor select[id^="post-author-selector-"] {
+	display: none;
+}


### PR DESCRIPTION
This is a pretty big hack :)

With 5.0, we end up with both Core's author input and the Co-Authors Plus metabox which is going to be cause for confusion (see #614).

It would be better to remove the inputs completely rather than hiding them (via javascript or hooking directly into Block Editor [1]) but this is a good start to help reduce that confusion.

[1] May need some new hooks in the editor to make this possible easily (i.e. without hacks :)).

