### PR TITLE
posts_where_filter: adjust regex to exclude match of post_status

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -737,7 +737,7 @@ class CoAuthors_Plus {
 
 					$maybe_both_query = $maybe_both ? '$0 OR' : '';
 
-					$where = preg_replace( '/\s\b(?:' . $wpdb->posts . '\.)?post_author\s*IN\s*(.*' . $id . '(?:.*private\')?.)/', ' (' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
+					$where = preg_replace( '/\s\b(?:' . $wpdb->posts . '\.)?post_author\s*IN\s*\(' . $id . '\)/', ' (' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND
 
 				} else {
 					$where = preg_replace( '/(\b(?:' . $wpdb->posts . '\.)?post_author\s*=\s*(' . $id . '))/', '(' . $maybe_both_query . ' ' . $terms_implode . ')', $where, -1 ); #' . $wpdb->postmeta . '.meta_id IS NOT NULL AND


### PR DESCRIPTION
Fixes #662.

To reproduce:
a) Create Guest Author A "TestAdminGuest" and assign to User A ("admin")
b) Click on "Mine" link on an edit post view

Query before:

```
SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts 
LEFT JOIN wp_term_relationships AS tr1 ON (wp_posts.ID = tr1.object_id) 
LEFT JOIN wp_term_taxonomy ON ( tr1.term_taxonomy_id = wp_term_taxonomy.term_taxonomy_id ) 
WHERE 1=1 AND 
(wp_posts.post_author IN (1) AND wp_posts.post_type = 'post' AND 
(wp_posts.post_status = 'publish' OR wp_posts.post_status = 'password' OR wp_posts.post_status = 'logged_in' OR wp_posts.post_status = 'future' OR wp_posts.post_status = 'draft' OR wp_posts.post_status = 'pending' OR wp_posts.post_status = 'private')
 OR (wp_term_taxonomy.taxonomy = 'author' AND wp_term_taxonomy.term_id = '6')
 OR (wp_term_taxonomy.taxonomy = 'author' AND wp_term_taxonomy.term_id = '3')) 
GROUP BY wp_posts.ID 
HAVING MAX( IF ( wp_term_taxonomy.taxonomy = 'author', IF ( wp_term_taxonomy.term_id = '6' OR wp_term_taxonomy.term_id = '3',2,1 ),0 ) ) <> 1 
ORDER BY wp_posts.post_date DESC LIMIT 0, 20
```

<img width="1191" alt="Screen Shot 2019-03-20 at 11 36 38 AM" src="https://user-images.githubusercontent.com/16962021/54706756-466d5200-4b05-11e9-8f84-5b07c28b6db9.png">

As you can see, the `guest-author` CPT from CAP is showing in the edit post view.

After:

```
SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts 
LEFT JOIN wp_term_relationships AS tr1 ON (wp_posts.ID = tr1.object_id) 
LEFT JOIN wp_term_taxonomy ON ( tr1.term_taxonomy_id = wp_term_taxonomy.term_taxonomy_id ) 
WHERE 1=1 AND 
( wp_posts.post_author IN (1) OR 
(wp_term_taxonomy.taxonomy = 'author' AND wp_term_taxonomy.term_id = '6') OR (wp_term_taxonomy.taxonomy = 'author' AND wp_term_taxonomy.term_id = '3')
) AND wp_posts.post_type = 'post' 
AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'password' OR wp_posts.post_status = 'logged_in' OR wp_posts.post_status = 'future' OR wp_posts.post_status = 'draft' OR wp_posts.post_status = 'pending' OR wp_posts.post_status = 'private') 
GROUP BY wp_posts.ID 
HAVING MAX( IF ( wp_term_taxonomy.taxonomy = 'author', IF ( wp_term_taxonomy.term_id = '6' OR wp_term_taxonomy.term_id = '3',2,1 ),0 ) ) <> 1 
ORDER BY wp_posts.post_date DESC LIMIT 0, 20
```

<img width="1047" alt="Screen Shot 2019-03-20 at 11 39 49 AM" src="https://user-images.githubusercontent.com/16962021/54706761-4a00d900-4b05-11e9-82dc-f242caf14eab.png">

Now, not so much anymore.  