### PR TITLE
Fix #620: Non-empty email entry and validation check added to CSV import function

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -805,7 +805,17 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					if ( empty( $field_keys[ $col_num ] ) ) {
 						continue;
 					}
+					//Verify if there is a valid email entry in the CSV, which is required for correct import.
+					if ( $col_num === 2 ) {
+						if ( $val === '' ) {
+						WP_CLI::error( 'Please verify that all row entries have email addresses assigned.' );
+						} else {
+							filter_var($val, FILTER_VALIDATE_EMAIL) ? ($author_data[ $field_keys[ $col_num ] ] = $val) :
+							WP_CLI::error( 'Please verify that all entries have valid email addresses assigned.' );
+						}
+					} else {
 					$author_data[ $field_keys[ $col_num ] ] = $val;
+					}
 				}
 
 				$authors[] = $author_data;


### PR DESCRIPTION
As a solution to the issue raised in #620 I've included verification if there is a valid email assigned in the CSV file in order to process it. The code verifies if the user_email is not empty and contains a valid email during the processing phase, giving a custom error notifying the user of the nature of the issue.Test

The original error happens as described in the issue#620 if we try to add a user with email, which is the same as another user without email:

After applying the fix to verify the existence of the email the importing quits with the an error message
(Image included for CSV missing email and resulting error message):

If we correct the CSV and add the missing email value the CSV import is successful: