### PR TITLE
Performance improvements for assign_coauthors command

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -53,6 +53,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	public function create_terms_for_posts() {
 		global $coauthors_plus, $wp_post_types;
 
+		add_filter( 'posts_groupby', function( $groupby ) { return ''; } );
+
 		// Cache these to prevent repeated lookups
 		$authors = array();
 		$author_terms = array();
@@ -63,6 +65,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'post_type'         => $coauthors_plus->supported_post_types,
 				'posts_per_page'    => 100,
 				'paged'             => 1,
+				'no_found_rows'	   => true,
 				'update_meta_cache' => false,
 			);
 
@@ -72,6 +75,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$total_posts = $posts->found_posts;
 		WP_CLI::line( "Now inspecting or updating {$posts->found_posts} total posts." );
 		while ( $posts->post_count ) {
+
+			wp_defer_term_counting(true);
 
 			foreach ( $posts->posts as $single_post ) {
 
@@ -103,6 +108,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				sleep( 1 );
 			}
 
+			wp_defer_term_counting(false);
 			$args['paged']++;
 			$posts = new WP_Query( $args );
 		}


### PR DESCRIPTION
We’re doing a few things here to improve the performance of assign_coauthors:

`'no_found_rows'	=> true,` Since we don’t care about pagination here, we can dramatically speed up the query by adding this argument. This removes the intensive `SQL SQL_CALC_FOUND_ROWS`` query modifier.

We also are removing the `posts_groupby` argument because we don’t need to actually group by Post ID. You should only need to group by Post ID when you have multiple results that could have the same Post ID (like if you had multiple meta keys with the same Post ID).

We’re doing some deferring of term counting here too, and basically deferring the coutning until AFTER each foreach runs, so that we’re not doing term counting on each individual item in the loop.

In some use cases, this sped up the command from taking a few weeks of time to a few hours.