### PR TITLE
Remove PHP notice when viewing guest author archive

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1037,14 +1037,15 @@ class CoAuthors_Plus {
 	 */
 	function filter_count_user_posts( $count, $user_id ) {
 		$user = get_userdata( $user_id );
-		$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
+		if ( $user ) {
+			$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
 
-		$term = $this->get_author_term( $user );
+			$term = $this->get_author_term( $user );
 
-		if ( $term && ! is_wp_error( $term ) ) {
-			$count = $term->count;
+			if ( $term && ! is_wp_error( $term ) ) {
+				$count = $term->count;
+			}
 		}
-
 		return $count;
 	}
 


### PR DESCRIPTION
When viewing an author archive that is not tied to an actual Wordpress user (i.e.: a guest author), PHP throws a Notice in filter_count_user_posts().  The $user object doesn't exist but the function tries to retrieve data from the object anyway.

This change checks for a user before continuing.