### PR TITLE
Fix wrong avatar url getting returned when a users id matches a post id

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1722,7 +1722,7 @@ class CoAuthors_Plus {
 	 * @return string Avatar URL
 	 */
 	public function filter_get_avatar_url( $url, $id ) {
-		if ( has_post_thumbnail( $id ) ) {
+		if ( 'guest-author' === get_post_type( $id ) && has_post_thumbnail( $id ) ) {
 			$url = get_the_post_thumbnail_url( $id, $this->gravatar_size );
 		}
 		return $url;


### PR DESCRIPTION
This fixes a bug where the wrong image was getting returned for WordPress users that had the same ID as post ID. If the post had a featured image then it was getting returned as the user's avatar. This adds an additional check to make sure that the ID belongs to a post with a post type of `guest-author`.