### PR TITLE
Filters when assigning coauthors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -890,7 +890,8 @@ class CoAuthors_Plus {
 
 		// Best way to persist order
 		if ( $append ) {
-			$existing_coauthors = wp_list_pluck( get_coauthors( $post_id ), 'user_login' );
+			$field              = apply_filters( 'coauthors_post_list_pluck_field', 'user_login' );
+			$existing_coauthors = wp_list_pluck( get_coauthors( $post_id ), $field );
 		} else {
 			$existing_coauthors = array();
 		}
@@ -909,7 +910,7 @@ class CoAuthors_Plus {
 		$coauthors = array_unique( array_merge( $existing_coauthors, $coauthors ) );
 		$coauthor_objects = array();
 		foreach ( $coauthors as &$author_name ) {
-
+			$field  = apply_filters( 'coauthors_post_get_coauthor_by_field', 'user_nicename' );
 			$author = $this->get_coauthor_by( 'user_nicename', $author_name );
 			$coauthor_objects[] = $author;
 			$term = $this->update_author_term( $author );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -910,8 +910,9 @@ class CoAuthors_Plus {
 		$coauthors = array_unique( array_merge( $existing_coauthors, $coauthors ) );
 		$coauthor_objects = array();
 		foreach ( $coauthors as &$author_name ) {
+
 			$field  = apply_filters( 'coauthors_post_get_coauthor_by_field', 'user_nicename' );
-			$author = $this->get_coauthor_by( 'user_nicename', $author_name );
+			$author = $this->get_coauthor_by( $field, $author_name );
 			$coauthor_objects[] = $author;
 			$term = $this->update_author_term( $author );
 			$author_name = $term->slug;

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -911,7 +911,7 @@ class CoAuthors_Plus {
 		$coauthor_objects = array();
 		foreach ( $coauthors as &$author_name ) {
 
-			$field  = apply_filters( 'coauthors_post_get_coauthor_by_field', 'user_nicename' );
+			$field  = apply_filters( 'coauthors_post_get_coauthor_by_field', 'user_nicename', $author_name );
 			$author = $this->get_coauthor_by( $field, $author_name );
 			$coauthor_objects[] = $author;
 			$term = $this->update_author_term( $author );


### PR DESCRIPTION
Requesting Automatic to Approve this PR since we are facing issues on appending Co-authors.

We have Users Login through OKTA to our site, using `WP SIMPLE SAML` plugin.
When user login for the 1st times, This `WP SIMPLE SAML` plugin is creating user and users respective login is user `EMAIL` address.

So, when I am using `co-authors plus` plugin function
`global $coauthors_plus;
$coauthors_plus->add_coauthors( $post_id, [ $user_nicename ], $append_author );
`

In a loop, it is skipping the users which contain `user_login` as the email address.

So, if this plugin provides filters at the 2 respective places then, it will be easy for the users to modify the content based on their usage.
 