### PR TITLE
Fix for wrong title and description on author archive

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -134,6 +134,9 @@ class CoAuthors_Plus {
 		// Filter to correct author on author archive page
 		add_filter( 'get_the_archive_title', array( $this, 'filter_author_archive_title'), 10, 1 );
 
+		// Filter to correct author id on author archive page
+		add_filter( 'the_posts', array( $this, 'filter_author_archive_post_ids' ) );
+
 		// Filter to display author image if exists instead of avatar
 		add_filter( 'get_avatar_url', array( $this, 'filter_get_avatar_url' ), 10, 2 );
 	}
@@ -1688,6 +1691,31 @@ class CoAuthors_Plus {
 		$author = $this->get_coauthor_by( 'user_nicename', $author_slug );
 
 		return sprintf( __( 'Author: %s' ), $author->display_name );
+	}
+
+	/**
+	 * Filter the posts on author archive pages to correctly display author meta
+	 *
+	 * @param $posts array of post objects
+	 *
+	 * @return array Array of post objects either as they were passed or updated
+	 */
+	public function filter_author_archive_post_ids( $posts ) {
+		
+		// Bail if not an author archive template
+		if ( ! is_author() ) {
+			return $posts;
+		}
+
+		$author_slug = sanitize_user( get_query_var( 'author_name' ) );
+		$author = $this->get_coauthor_by( 'user_nicename', $author_slug );
+
+		// make post author id same as id from slug on author archive
+		foreach( $posts as $post ) {
+			$post->post_author = $author->ID;
+		}
+
+		return $posts;
 	}
 
 	/**


### PR DESCRIPTION
#693  and #643  identified the issue of incorrect author meta appearing when the author is a co-author but not the primary author on the first post on author archive pages. Suggestions for using filters like get_the_archive_description have been made, but I think it comes down to the incorrect author id being set in the loop. I've used the_posts filter below to resolve this. The post_author values in the posts array are changed to equal the id from the slug. That way the expected id is set, so the right description, title etc. are fetched. This is also a good alternative to having to run through all the author meta filters to output the right data.