### PR TITLE
WIP: Specify user by ID in assign-user-to-coauthor

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -225,7 +225,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$user_id = $assoc_args['user_id'];
 		if ( $assoc_args['user_login'] ) {
 			$user = get_user_by( 'login', $assoc_args['user_login'] );
-			$user_id = $user->ID;
+			if ($user) {
+				$user_id = $user->ID;
+			}
 		}
 
 		$coauthor = $coauthors_plus->get_coauthor_by( 'login', $assoc_args['coauthor'] );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -222,7 +222,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$user_id = $assoc_args['user_login'];
+		$user_id = $assoc_args['user_id'];
 		if ( $assoc_args['user_login'] ) {
 			$user = get_user_by( 'login', $assoc_args['user_login'] );
 			$user_id = $user->ID;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -222,7 +222,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$user_id = $assoc_args['user_id'];
+		$user_id = intval($assoc_args['user_id']);
 		if ( $assoc_args['user_login'] ) {
 			$user = get_user_by( 'login', $assoc_args['user_login'] );
 			if ($user) {


### PR DESCRIPTION
If a user has already been deleted, we need to specify just the user ID when assigning coauthors, instead of the login. This PR adds a second command-line option. One of either `--user_id` or `--user_login` is required. Existing behaviour should be unchanged.