### PR TITLE
Bulk edit issue

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1,4 +1,6 @@
 <?php
+die(__FILE__);
+
 /*
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
@@ -1015,6 +1017,9 @@ class CoAuthors_Plus {
 						break;
 					case 'tt_ids' :
 						$terms[] = $author->term_taxonomy_id;
+						break;
+					case 'ids':
+						$terms[] = (int) $author->term_id;
 						break;
 					case 'all' :
 					default :

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1,6 +1,4 @@
 <?php
-die(__FILE__);
-
 /*
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/


### PR DESCRIPTION
There is a case in bulk edit that CAP fails when adding terms. This will pass the appropriate term.