### PR TITLE
Add checks to ensure that 'blank' get_avatar() calls nor WP_Users with same IDs as posts with featured images aren't improperly returning

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1727,7 +1727,11 @@ class CoAuthors_Plus {
 	 * @return string Avatar URL
 	 */
 	public function filter_get_avatar_url( $url, $id ) {
-		if ( has_post_thumbnail( $id ) ) {
+		if ( ! $id || ! $this->is_guest_authors_enabled() ) {
+			return $url;
+		}
+		$coauthor = $this->get_coauthor_by( 'id', $id );
+		if ( false !== $coauthor && isset( $coauthor->type ) && 'guest-author' === $coauthor->type && has_post_thumbnail( $id ) ) {
 			$url = get_the_post_thumbnail_url( $id, $this->gravatar_size );
 		}
 		return $url;


### PR DESCRIPTION
Fixes #676.