### PR TITLE
Add check for $id being passed into filter_get_avatar_url prior to filtering

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1727,7 +1727,7 @@ class CoAuthors_Plus {
 	 * @return string Avatar URL
 	 */
 	public function filter_get_avatar_url( $url, $id ) {
-		if ( ! $id || ! $this->is_guest_authors_enabled() ) {
+		if ( ! $id || ! $this->is_guest_authors_enabled() || ! is_numeric( $id ) ) {
 			return $url;
 		}
 		$coauthor = $this->get_coauthor_by( 'id', $id );


### PR DESCRIPTION
Fixes fatal: 

```
An error of type E_RECOVERABLE_ERROR was caused in line 1120 of the file /var/www/wp-content/plugins/co-authors-plus/php/class-coauthors-guest-authors.php. Error message: Object of class WP_Comment could not be converted to string
```

To reproduce, just load the main `wp-admin` dashboard on the current `master` version of CAP.  

Introduced by #706.  Since the second parameter of the filter `get_avatar_url` can be non-numeric (https://developer.wordpress.org/reference/hooks/get_avatar_url/), we should check it is a numeric value before running `get_coauthor_by()`. 