### PR TITLE
Use pre_get_avatar_data instead of get_avatar_url for shortcircuiting uncached user lookup queries

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1738,7 +1738,7 @@ class CoAuthors_Plus {
 	 * @return string Avatar URL
 	 */
 	public function filter_pre_get_avatar_data_url( $args, $id ) {
-		if ( ! $id || ! $this->is_guest_authors_enabled() || ! is_numeric( $id ) ) {
+		if ( ! $id || ! $this->is_guest_authors_enabled() || ! is_numeric( $id ) || isset( $args['url'] ) ) {
 			return $args;
 		}
 		$coauthor = $this->get_coauthor_by( 'id', $id );


### PR DESCRIPTION
Fixes #723.

Reduces the call amount to efficiently one query, as `get_avatar_url` and `get_avatar` are both used in `coauthors_meta_box()`.  
Also removes the default hardcoded no-avatar avatar, as it defaults to the default option.

