### PR TITLE
fix typo that prevented addition of custom classes

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -970,13 +970,13 @@ class CoAuthors_Guest_Authors
 		}
 
 		$args = array(
-				'class' => "avatar avatar-{$size} photo",
-			);
+			'class' => "avatar avatar-{$size} photo",
+		);
 		if ( ! empty( $class ) ) {
 			if ( is_array( $class ) ) {
 				$class = implode( ' ', $class );
 			}
-			$args['class'] += " $class";
+			$args['class'] .= " $class";
 		}
 
 		$size = array( $size, $size );


### PR DESCRIPTION
accidental use of "+=" instead of ".=" for concatenating a string in `get_guest_author_thumbnail ` was causing the class name to come back as 0