### PR TITLE
Fix broken image on coauthor's avatar on quick edit

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -475,6 +475,7 @@ class CoAuthors_Plus {
 				data-user_email="<?php echo esc_attr( $author->user_email ) ?>"
 				data-display_name="<?php echo esc_attr( $author->display_name ) ?>"
 				data-user_login="<?php echo esc_attr( $author->user_login ) ?>"
+				data-avatar="<?php echo esc_attr( get_avatar_url( $author->ID, [ 'default' => 'gravatar_default' ] ) ) ?>"
 				><?php echo esc_html( $author->display_name ); ?></a><?php echo ( $count < count( $authors ) ) ? ',' : ''; ?>
 				<?php
 				$count++;

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -420,9 +420,11 @@ jQuery( document ).ready(function () {
 						login: jQuery( el ).data( 'user_login' ),
 						name: jQuery( el ).data( 'display_name' ),
 						email: jQuery( el ).data( 'user_email' ),
-						nicename: jQuery( el ).data( 'user_nicename' )
+						nicename: jQuery( el ).data( 'user_nicename' ),
+						avatar: jQuery( el ).data( 'avatar' ),
 					}
-				})
+				});
+				
 				coauthors_initialize( post_coauthors );
 
 			}


### PR DESCRIPTION
Fixes #726, as we need the `data-avatar` attribute for jQuery.