### PR TITLE
Change permission

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1270,7 +1270,7 @@ class CoAuthors_Plus {
 			// Make sure the user is contributor and above (or a custom cap)
 			if ( in_array( $found_user->user_nicename, $ignored_authors, true ) ) { // AJAX sends a list of already present *users_nicenames*
 				unset( $found_users[ $key ] );
-			} else if ( 'wpuser' === $found_user->type && false === $found_user->has_cap( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ) ) {
+			} else if ( 'wpuser' === $found_user->type && false === $found_user->has_cap( apply_filters( 'coauthors_edit_author_cap', 'read' ) ) ) {
 				unset( $found_users[ $key ] );
 			}
 		}


### PR DESCRIPTION
For many newsrooms, including ours, we have users that we don't want to have edit access. For example, our photographers have accounts because they use our backend to submit their photos. Sometimes though, we want to assign them as the author of a post. For example, if they make a photo essay.

I don't see any ready for why the user has to be able to edit posts. The guest author system is nice, but it's just not very convenient to have a custom post type that acts like a user.

It seems like users have had this issue before:
- [Bram Peerlings on WordPress.org](https://wordpress.org/support/topic/allow-subscribers-as-authors/)
- [strarsis on GitHub](https://github.com/Automattic/Co-Authors-Plus/issues/722)