### PR TITLE
Search by term name rather than slug due

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1258,7 +1258,7 @@ class CoAuthors_Plus {
 		// Get the guest author objects
 		$found_users = array();
 		foreach ( $found_terms as $found_term ) {
-			$found_user = $this->get_coauthor_by( 'user_nicename', $found_term->slug );
+			$found_user = $this->get_coauthor_by( 'user_nicename', $found_term->name );
 			if ( ! empty( $found_user ) ) {
 				$found_users[ $found_user->user_login ] = $found_user;
 			}


### PR DESCRIPTION
Fixes #743.

Due to guest author terms being created with a prefix of `cap-`, we should search by the term name which is akin to the guest author "unique slug".  If we create a guest author called "Cap Underpants", the slug will be `cap-cap-underpants` and therefore, will not return any results from the query when `get_guest_author_by()` is called by `get_coauthor_by()`.

Testing Steps:
1) Create guest author with Display Name of "Cap Underpants".
2) Try to assign that guest author to a post by typing "cap" in the ajax box.
3) You will not see that the expected guest author pop up.
4) Apply patch.
5) Repeat step 2.