### PR TITLE
Change coauthors metabox context from `normal` to `side`

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -334,7 +334,7 @@ class CoAuthors_Plus {
 	public function add_coauthors_box() {
 
 		if ( $this->is_post_type_enabled() && $this->current_user_can_set_authors() ) {
-			add_meta_box( $this->coauthors_meta_box_name, apply_filters( 'coauthors_meta_box_title', __( 'Authors', 'co-authors-plus' ) ), array( $this, 'coauthors_meta_box' ), get_post_type(), apply_filters( 'coauthors_meta_box_context', 'normal' ), apply_filters( 'coauthors_meta_box_priority', 'high' ) );
+			add_meta_box( $this->coauthors_meta_box_name, apply_filters( 'coauthors_meta_box_title', __( 'Authors', 'co-authors-plus' ) ), array( $this, 'coauthors_meta_box' ), get_post_type(), apply_filters( 'coauthors_meta_box_context', 'side' ), apply_filters( 'coauthors_meta_box_priority', 'high' ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #705.

Default metabox location is now in the sidebar, instead of below the editor. This is also in line with default Gutenberg behavior.

(Notice that Travis tests failing are **not** due to this PR)