### PR TITLE
Allow bulk edit of coauthors

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -6,6 +6,16 @@
 	margin-left: 5em;
 }
 
+#bulk-edit label.bulk-edit-group {
+	clear: both;
+	padding: 0 .5em;
+	margin-top: .5em;
+}
+
+#bulk-edit label.bulk-edit-group #coauthors-list {
+	margin-left: 5.6em;
+}
+
 #coauthors-list {
 	width: 100%;
 	padding: 0 5px;

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -393,6 +393,7 @@ jQuery( document ).ready(function () {
 	}
 	else if ( 'edit-php' == adminpage ) {
 
+		// 'Inline edit'
 		var wpInlineEdit = inlineEditPost.edit;
 
 		inlineEditPost.edit = function( id ) {
@@ -424,9 +425,32 @@ jQuery( document ).ready(function () {
 						avatar: jQuery( el ).data( 'avatar' ),
 					}
 				});
-				
+
 				coauthors_initialize( post_coauthors );
 
+			}
+		}
+
+		// 'Bulk edit'
+		var coauthors_initialized_on_bulk_edit = false;
+		var wpBulkEdit = inlineEditPost.setBulk;
+
+		inlineEditPost.setBulk = function() {
+
+			wpBulkEdit.apply( this, arguments );
+
+			// Initialize co-authors, but only on the first 'Bulk edit' interaction.
+			if ( ! coauthors_initialized_on_bulk_edit ) {
+				var bulk_right_column = jQuery( '#bulk-edit .inline-edit-col-right' );
+
+				// Move the Authors section in the right column of the Bulk section.
+				jQuery( '#bulk-edit .bulk-edit-coauthors' ).appendTo( bulk_right_column );
+				// Quick fix to give the last column its 'real' height because
+				// the float:left; for the Post Format dropdown does not help positioning the Authors section we just added
+				bulk_right_column.find( 'div.inline-edit-col' ).addClass( 'wp-clearfix' );
+
+				coauthors_initialize( [] );
+				coauthors_initialized_on_bulk_edit = true;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #551.

Bulk edit of coauthors has been disabled for a long time. This PR finishes work initiated by https://github.com/psaikali/Co-Authors-Plus/commit/2ac1afbacaec965bbd35bbdd569b8eeb3c160c03 and makes it fully working, by actually updating the coauthors on bulk edit actions. 

![Screenshot from 2020-10-03 21-29-06](https://user-images.githubusercontent.com/7880569/95000265-8d277d80-05bf-11eb-9988-94eb4315fdb4.png)
