### PR TITLE
Fixes Issue #578 - cannot update guest author

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -783,7 +783,7 @@ class CoAuthors_Guest_Authors
 			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] !== (int)$user->ID ) ) {
 				wp_die( esc_html__( 'Please map the guest author to the user with the same username', 'co-authors-plus' ) );
 			}
-			wp_die( esc_html__( 'Guest authors cannot be created with the same user_login value as a user. Try creating a profile from the user on the Manage Users listing instead.', 'co-authors-plus' ) );
+			wp_die( esc_html__( 'There is a WordPress user with the same username as this guest author, please go back and link them in order to update.', 'co-authors-plus' ) );
 		}
 
 		// Guest authors can't have the same post_name value

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -775,6 +775,14 @@ class CoAuthors_Guest_Authors
 		if ( $user
 			&& is_user_member_of_blog( $user->ID, get_current_blog_id() )
 			&& $user->user_login != get_post_meta( $original_args['ID'], $this->get_post_meta_key( 'linked_account' ), true ) ) {
+			// if user has selected to link account to matching user we don't have to bail
+			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] === (int)$user->ID ) ) {
+				return $post_data;
+			}
+			// if user has selected to link account NOT matching user, bail with custom message
+			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] !== (int)$user->ID ) ) {
+				wp_die( esc_html__( 'Please map the guest author to the user with the same username', 'co-authors-plus' ) );
+			}
 			wp_die( esc_html__( 'Guest authors cannot be created with the same user_login value as a user. Try creating a profile from the user on the Manage Users listing instead.', 'co-authors-plus' ) );
 		}
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -779,10 +779,6 @@ class CoAuthors_Guest_Authors
 			if ( (int)$_POST['cap-linked_account'] === (int)$user->ID ) {
 				return $post_data;
 			}
-			// if user has selected to link account NOT matching user, bail with custom message
-			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] !== (int)$user->ID ) ) {
-				wp_die( esc_html__( 'Please map the guest author to the user with the same username', 'co-authors-plus' ) );
-			}
 			wp_die( esc_html__( 'There is a WordPress user with the same username as this guest author, please go back and link them in order to update.', 'co-authors-plus' ) );
 		}
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -776,7 +776,7 @@ class CoAuthors_Guest_Authors
 			&& is_user_member_of_blog( $user->ID, get_current_blog_id() )
 			&& $user->user_login != get_post_meta( $original_args['ID'], $this->get_post_meta_key( 'linked_account' ), true ) ) {
 			// if user has selected to link account to matching user we don't have to bail
-			if ( $_POST['cap-linked_account'] > 0 && ( (int)$_POST['cap-linked_account'] === (int)$user->ID ) ) {
+			if ( (int)$_POST['cap-linked_account'] === (int)$user->ID ) {
 				return $post_data;
 			}
 			// if user has selected to link account NOT matching user, bail with custom message


### PR DESCRIPTION
Fixes Issue #578 - Currently backend user is able to create a guest author and wp user with the same username if the guest author is created first. Unfortunately, if an attempt to update the guest author is made, an error is thrown and guest author cannot be updated. This PR provides additional messaging to coerce the user to link the guest author with the wp user with the same username.