### PR TITLE
Added filter to count_user_posts

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -91,6 +91,8 @@ class CoAuthors_Plus {
 		// Action to reassign posts when a guest author is deleted
 		add_action( 'delete_user',  array( $this, 'delete_user_action' ) );
 
+		//Filter to return our correct post count
+		add_filter( 'count_user_posts', array( $this, 'filter_count_user_posts' ), 10, 2 );
 		add_filter( 'get_usernumposts', array( $this, 'filter_count_user_posts' ), 10, 2 );
 
 		// Action to set up co-author auto-suggest


### PR DESCRIPTION
Only the get_usernumposts() function was being filtered in order to return the correct user posts count. That function is deprecated and count_user_posts() is the correct one. A filter to that function has been added.