### PR TITLE
Update and improve Travis build for default Xenial dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
+services: mysql
 
 matrix:
     include:
         # aliased to a recent 5.6.x version
         - php: "5.6"
-          env: WP_VERSION=5.2.2
+          env: WP_VERSION=5.6.1
 
         - php: '5.6'
           env:
@@ -20,13 +21,13 @@ matrix:
 
         # aliased to a recent 7.x version
         - php: '7.0'
-          env: WP_VERSION=5.2.2
+          env: WP_VERSION=5.6.1
 
         - php: '7.0'
           env: WP_VERSION=latest
 
         - php: '7.1'
-          env: WP_VERSION=5.2.2
+          env: WP_VERSION=5.6.1
 
         - php: '7.1'
           env: WP_VERSION=latest
@@ -39,6 +40,8 @@ before_script:
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    # Install VIP Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/Automattic/VIP-Coding-Standards.git $SNIFFS_DIR; fi    
     # Install PHP Compatibility sniffs.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
     # Set install path for PHPCS sniffs.
@@ -48,24 +51,10 @@ before_script:
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
     # Set up unit tests
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-    # Properly handle PHPUnit versions
-    - export PATH="$HOME/.composer/vendor/bin:$PATH"
-    - |
-        if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then
-          composer global require "phpunit/phpunit=4.8.*"
-        elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." && ${WP_VERSION} == "5.2.2" ]]; then
-          composer global require "phpunit/phpunit=5.7.*"
-        fi
-    - |
-        if [[ -n $COMPOSER_BIN_DIR && -x $COMPOSER_BIN_DIR/phpunit ]]; then
-          $COMPOSER_BIN_DIR/phpunit --version
-        else
-          phpunit --version
-        fi
+    # Properly handle versions since the pre-installed PHPUnit is incompatible on some builds
+    - composer require --dev "phpunit/phpunit":"^5"
 
 script:
-    # Search for PHP syntax errors.
-    - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
     # WordPress Coding Standards.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
     # @link http://pear.php.net/package/PHP_CodeSniffer/
@@ -75,11 +64,6 @@ script:
     # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
     # --standard: Use WordPress as the standard.
     # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard="WordPress-VIP" --extensions=php; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard="WordPress-VIP-Go" --extensions=php; fi
     # Run unit tests
-    - |
-        if [[ -n $COMPOSER_BIN_DIR && -x $COMPOSER_BIN_DIR/phpunit ]]; then
-          $COMPOSER_BIN_DIR/phpunit
-        else
-          phpunit
-        fi
+    - ./vendor/bin/phpunit


### PR DESCRIPTION
[Prior to switching to Xenial](https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide) by default, TravisCI was using Trusty builds, which were working as expected. This fixes the Travis build file by:
- enabling mysql as a service
- bumping WP version to recent
- installing VIPCS sniffs and using `WordPress-VIP-Go` ruleset
- requiring PHPUnit of 5.7 since there are incompatibilities with PHP and the default PHPUnit versions
- removing inaccurate PHP syntax error check