### PR TITLE
Fix failing tests

### DIFF
--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -361,7 +361,8 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		// Checks when search term is empty and any subscriber exists.
 		$subscriber1 = $this->factory->user->create_and_get( array(
-			'role' => 'subscriber',
+			'role'       => 'subscriber',
+			'user_login' => 'subscriber1'
 		) );
 
 		$authors = $coauthors_plus->search_authors();
@@ -371,7 +372,8 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		// Checks when search term is empty and any contributor exists.
 		$contributor1 = $this->factory->user->create_and_get( array(
-			'role' => 'contributor',
+			'role'       => 'contributor',
+			'user_login' => 'contributor1'
 		) );
 
 		$authors = $coauthors_plus->search_authors();
@@ -451,7 +453,8 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		// Checks when ignoring author1 but also exists one more author with similar kind of data.
 		$author2 = $this->factory->user->create_and_get( array(
-			'role' => 'author',
+			'role'       => 'author',
+			'user_login' => 'author2'
 		) );
 
 		$authors = $coauthors_plus->search_authors( '', $ignored_authors );

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -988,7 +988,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 	public function test_coauthors_get_avatar_default() {
 
 		$this->assertEmpty( coauthors_get_avatar( $this->author1->ID ) );
-		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*' />$|", coauthors_get_avatar( $this->author1 ) ), 1 );
+		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*' (loading='[^']*')?/>$|", coauthors_get_avatar( $this->author1 ) ), 1 );
 	}
 
 	/**
@@ -1007,7 +1007,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
 
-		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*' />$|", coauthors_get_avatar( $guest_author ) ), 1 );
+		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*' (loading='[^']*')?/>$|", coauthors_get_avatar( $guest_author ) ), 1 );
 
 		$filename = rand_str() . '.jpg';
 		$contents = rand_str();

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -988,7 +988,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 	public function test_coauthors_get_avatar_default() {
 
 		$this->assertEmpty( coauthors_get_avatar( $this->author1->ID ) );
-		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*' (loading='[^']*')?/>$|", coauthors_get_avatar( $this->author1 ) ), 1 );
+		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*'( loading='[^']*')?/>$|", coauthors_get_avatar( $this->author1 ) ), 1 );
 	}
 
 	/**
@@ -1007,7 +1007,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
 
-		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*' (loading='[^']*')?/>$|", coauthors_get_avatar( $guest_author ) ), 1 );
+		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*'( loading='[^']*')?/>$|", coauthors_get_avatar( $guest_author ) ), 1 );
 
 		$filename = rand_str() . '.jpg';
 		$contents = rand_str();


### PR DESCRIPTION
1) `test_search_authors_no_args` - The newly created user must have a valid `user_login` assigned or else they won't be properly populated as a key when `$authors` is retrieved from `search_coauthors()`: https://github.com/Automattic/Co-Authors-Plus/blob/525916a77a6e4379dfc5751f4782e95a776e6f4e/co-authors-plus.php#L1263
2) `test_search_authors_when_ignored_authors_provided` - same as 1)
3) `test_coauthors_get_avatar_default` - The regexp pattern does not account for lazy loading attribute
4) `test_coauthors_get_avatar_when_guest_author` - same as 3)
