### PR TITLE
Fix issue 754: rest_forbidden as an second author

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1406,12 +1406,14 @@ class CoAuthors_Plus {
 	public function get_to_be_filtered_caps() {
 		if( ! empty( $this->supported_post_types ) && empty( $this->to_be_filtered_caps ) ) {
 			$this->to_be_filtered_caps[] = 'edit_post'; // Need to filter this too, unfortunately: http://core.trac.wordpress.org/ticket/22415
+			$this->to_be_filtered_caps[] = 'read_post';
 
 			foreach( $this->supported_post_types as $single ) {
 				$obj = get_post_type_object( $single );
 
 				$this->to_be_filtered_caps[] = $obj->cap->edit_post;
 				$this->to_be_filtered_caps[] = $obj->cap->edit_others_posts; // This as well: http://core.trac.wordpress.org/ticket/22417
+				$this->to_be_filtered_caps[] = $obj->cap->read_post;
 			}
 
 			$this->to_be_filtered_caps = array_unique( $this->to_be_filtered_caps );
@@ -1443,6 +1445,8 @@ class CoAuthors_Plus {
 				$obj->cap->edit_post,
 				'edit_post', // Need to filter this too, unfortunately: http://core.trac.wordpress.org/ticket/22415
 				$obj->cap->edit_others_posts, // This as well: http://core.trac.wordpress.org/ticket/22417
+				'read_post',
+				$obj->cap->read_post,
 			);
 		if ( ! in_array( $cap, $caps_to_modify ) ) {
 			return $allcaps;


### PR DESCRIPTION
Fix #754 

## Description 

The explanation for this fix is here https://github.com/Automattic/Co-Authors-Plus/issues/754#issuecomment-803546624

## Test 

1) Create author user
2) Create draft with admin user and add author user to draft
3) Attempt to access draft from author user
4) The co-author can edit the draft normally 
5) There is no `403` XHR request in the browser console 