### PR TITLE
Account for guest author terms that begin with "cap-"

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1259,6 +1259,12 @@ class CoAuthors_Plus {
 		$found_users = array();
 		foreach ( $found_terms as $found_term ) {
 			$found_user = $this->get_coauthor_by( 'user_nicename', $found_term->slug );
+			if ( ! $found_user && 0 === strpos( $found_term->slug, 'cap-cap-' ) ) {
+				// Account for guest author terms that start with 'cap-'.
+				// e.g. "Cap Ri" -> "cap-cap-ri".
+				$cap_slug = substr( $found_term->slug, 4, strlen( $found_term->slug ) );
+				$found_user = $this->get_coauthor_by( 'user_nicename', $cap_slug );
+			}
 			if ( ! empty( $found_user ) ) {
 				$found_users[ $found_user->user_login ] = $found_user;
 			}


### PR DESCRIPTION
#744 introduced the bug #761.

This should fix #743, which was what #744 was intended to do.