### PR TITLE
🐛 FIX: Show Gravatar of guest user in editor

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -382,7 +382,11 @@ class CoAuthors_Plus {
 				<?php
 				foreach ( $coauthors as $coauthor ) :
 					$count++;
-					$avatar_url = get_avatar_url( $coauthor->ID );
+					if ( isset( $coauthor->type ) && 'guest-author' === $coauthor->type ) {
+					    $avatar_url = get_avatar_url( $coauthor->user_email );
+					} else {
+					    $avatar_url = get_avatar_url( $coauthor->ID );
+					}
 					?>
 					<li>
 						<?php echo get_avatar( $coauthor->ID, $this->gravatar_size ); ?>


### PR DESCRIPTION
Fixes #758 

**Change**

Show Gravatars of guest authors on in the editor.

**Steps to test**

1. Check out this PR
2. Go to /wp-admin/post-new.php?post_type=guest-author
3. Add a new guest author
4. Go to /wp-admin/users.php?page=view-guest-authors
5. Ensure that Gravatar for guest author is visible
6. Go to /wp-admin/post-new.php
7. Add new guest author
8. See that Gravatar is visible for both the author and the guest author

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

<img width="604" alt="Screenshot 2021-03-29 at 10 55 06" src="https://user-images.githubusercontent.com/3323310/112785060-54072c00-907d-11eb-90dd-fc85fa971e09.png">
</td>
<td>After:
<br><br>

<img width="604" alt="Screenshot 2021-03-29 at 10 54 44" src="https://user-images.githubusercontent.com/3323310/112785055-523d6880-907d-11eb-94bd-30da67b37fc4.png">
</td>
</tr>
</table>

