### PR TITLE
🐛 FIX: Fix behaviour of filter button on guest author page

### DIFF
--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -276,8 +276,8 @@ if ( 'top' == $which ) {
 			echo '<option value="' . esc_attr( $key ) . '" ' . selected( $this->active_filter, $key, false ) . '>' . esc_attr( $value ) . '</option>';
 		}
 		echo '</select>';
+	    submit_button( __( 'Filter', 'co-authors-plus' ), 'secondary', false, false );
 	}
-	submit_button( __( 'Filter', 'co-authors-plus' ), 'secondary', false, false );
 }
 		?></div><?php
 	}

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -100,8 +100,6 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
         switch ( $this->active_filter ) {
             case 'with-linked-account':
                 $args['meta_query'] = array(
-                    'relation' => 'AND',
-                    array( 'key' => $key, 'compare' => 'EXISTS' ),
                     array( 'key' => $key, 'compare' => '!=', 'value' => '' ),
                 );
                 break;

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -10,6 +10,8 @@ require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
 class CoAuthors_WP_List_Table extends WP_List_Table {
 
 	var $is_search = false;
+    var $filters = array();
+    var $active_filter = '';
 
 	function __construct() {
 		if ( ! empty( $_REQUEST['s'] ) ) {

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -96,39 +96,23 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 			$this->active_filter = 'show-all';
 		}
 
-		switch ( $this->active_filter ) {
-			case 'with-linked-account':
-			case 'without-linked-account':
-				$key = $coauthors_plus->guest_authors->get_post_meta_key( 'linked_account' );
-				if ( 'with-linked-account' == $this->active_filter ) {
-                    $args['meta_query'] = array(
-                        'relation' => 'AND',
-                        array(
-                            'key'     => $key,
-                            'compare' => 'EXISTS',
-                        ),
-                        array(
-                            'key'     => $key,
-                            'value'   => '',
-                            'compare' => '!=',
-                        ),
-                    );
-				} else {
-                    $args['meta_query'] = array(
-                        'relation' => 'OR',
-                        array(
-                            'key'     => $key,
-                            'compare' => 'NOT EXISTS',
-                        ),
-                        array(
-                            'key'     => $key,
-                            'value'   => '',
-                            'compare' => '=',
-                        ),
-                    );
-				}
+        $key = $coauthors_plus->guest_authors->get_post_meta_key( 'linked_account' );
+        switch ( $this->active_filter ) {
+            case 'with-linked-account':
+                $args['meta_query'] = array(
+                    'relation' => 'AND',
+                    array( 'key' => $key, 'compare' => 'EXISTS' ),
+                    array( 'key' => $key, 'compare' => '!=', 'value' => '' ),
+                );
                 break;
-		}
+            case 'without-linked-account':
+                $args['meta_query'] = array(
+                    'relation' => 'OR',
+                    array( 'key' => $key, 'compare' => 'NOT EXISTS' ),
+                    array( 'key' => $key, 'compare' => '=', 'value' => '' ),
+                );
+                break;
+        }
 
 		if ( $this->is_search ) {
 			add_filter( 'posts_where', array( $this, 'filter_query_for_search' ) );

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -99,14 +99,35 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 		switch ( $this->active_filter ) {
 			case 'with-linked-account':
 			case 'without-linked-account':
-				$args['meta_key'] = $coauthors_plus->guest_authors->get_post_meta_key( 'linked_account' );
+				$key = $coauthors_plus->guest_authors->get_post_meta_key( 'linked_account' );
 				if ( 'with-linked-account' == $this->active_filter ) {
-					$args['meta_compare'] = '!=';
+                    $args['meta_query'] = array(
+                        'relation' => 'AND',
+                        array(
+                            'key'     => $key,
+                            'compare' => 'EXISTS',
+                        ),
+                        array(
+                            'key'     => $key,
+                            'value'   => '',
+                            'compare' => '!=',
+                        ),
+                    );
 				} else {
-					$args['meta_compare'] = '=';
+                    $args['meta_query'] = array(
+                        'relation' => 'OR',
+                        array(
+                            'key'     => $key,
+                            'compare' => 'NOT EXISTS',
+                        ),
+                        array(
+                            'key'     => $key,
+                            'value'   => '',
+                            'compare' => '=',
+                        ),
+                    );
 				}
-				$args['meta_value'] = '0';
-				break;
+                break;
 		}
 
 		if ( $this->is_search ) {


### PR DESCRIPTION
Fixes #715

**Change**

Fix behaviour of filter button on guest author page

**Steps to test**

1. Check out this PR
2. Head over to `/wp-admin/users.php?page=view-guest-authors`
3. Ensure that the filter button is working as expected and that filter options are visible

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

![#715-before](https://user-images.githubusercontent.com/3323310/112854079-ad03ae00-90d7-11eb-9ddf-56ac13880441.png)
</td>
<td>After:
<br><br>

![#715-after-1](https://user-images.githubusercontent.com/3323310/112854068-aaa15400-90d7-11eb-8caa-e9db4b4aca01.png)
</td>
</tr>
</table>