### PR TITLE
FIX: Handle display name with special chars

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1209,6 +1209,8 @@ class CoAuthors_Plus {
 				"%s ∣ %s ∣ %s ∣ %s ∣ %s ∣ %s \n",
 				esc_html( $author->ID ),
 				esc_html( $author->user_login ),
+				// Ensure that author names can contain a pipe character by replacing the pipe character with the
+				// divides character, which will now serve as a delimiter of the author parameters. (#370)
 				esc_html( str_replace( '∣', '|', $author->display_name ) ),
 				esc_html( $author->user_email ),
 				esc_html( rawurldecode( $author->user_nicename ) ),

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1205,8 +1205,15 @@ class CoAuthors_Plus {
 		}
 
 		foreach ( $authors as $author ) {
-			$avatar_url = get_avatar_url( $author->ID );
-			echo esc_html( $author->ID . ' | ' . $author->user_login . ' | ' . $author->display_name . ' | ' . $author->user_email . ' | ' . rawurldecode( $author->user_nicename ) ) . ' | ' . esc_url( $avatar_url ) . "\n";
+			printf(
+				"%s ∣ %s ∣ %s ∣ %s ∣ %s ∣ %s \n",
+				esc_html( $author->ID ),
+				esc_html( $author->user_login ),
+				esc_html( str_replace( '∣', '|', $author->display_name ) ),
+				esc_html( $author->user_email ),
+				esc_html( rawurldecode( $author->user_nicename ) ),
+				esc_url( get_avatar_url( $author->ID ) )
+			);
 		}
 
 		die();
@@ -1376,7 +1383,7 @@ class CoAuthors_Plus {
 		?>
 			<script type="text/javascript">
 				// AJAX link used for the autosuggest
-				var coAuthorsPlus_ajax_suggest_link = 
+				var coAuthorsPlus_ajax_suggest_link =
 				<?php
 				echo wp_json_encode(
 					add_query_arg(

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -193,7 +193,7 @@ jQuery( document ).ready(function () {
 	// Callback for when a user selects a co-author
 	function coauthors_autosuggest_select() {
 		$this = jQuery( this );
-		var vals = this.value.split( '|' );
+		var vals = this.value.split( '∣' );
 
 		var author = {}
 		author.id = jQuery.trim( vals[0] );
@@ -424,7 +424,7 @@ jQuery( document ).ready(function () {
 						avatar: jQuery( el ).data( 'avatar' ),
 					}
 				});
-				
+
 				coauthors_initialize( post_coauthors );
 
 			}


### PR DESCRIPTION
Fixes #370 

**Changes**

Allow users and guest users to use special characters in the display name.

**Steps to test**

1. Create a guest author with a special character in the display name, e.g. `Jane | Doe`
2. Open an existing post and add that guest author to it
3. Verify that the avatar/Gravatar is broken
4. Check out this PR
5. Refresh the post page
6. Add the guest author again
7. Verify that the avatar/Gravatar is visible

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

<img width="593" alt="Screenshot 2021-04-02 at 17 30 01" src="https://user-images.githubusercontent.com/3323310/113408291-47663900-93d9-11eb-848b-ccfa58a933ee.png">
</td>
<td>After:
<br><br>

<img width="593" alt="Screenshot 2021-04-02 at 17 27 45" src="https://user-images.githubusercontent.com/3323310/113408292-492ffc80-93d9-11eb-8559-bdd70bd52570.png">
</td>
</tr>
</table>