### PR TITLE
Fix incorrect post count for linked accounts

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1048,25 +1048,23 @@ class CoAuthors_Plus {
 	 * @return int Post count
 	 */
 	function filter_count_user_posts( $count, $user_id ) {
-		$user = get_userdata( $user_id );
+		$user     = get_userdata( $user_id );
+		$coauthor = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
+
+		// Return $count, if no coauthor exists.
+		if ( ! is_object( $coauthor ) ) {
+			return $count;
+		}
 
 		// Return combined post count, if account is linked.
-		$coauthor = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
-		if ( is_object( $coauthor ) && strlen( $coauthor->linked_account ) > 2 ) {
+		if ( strlen( $coauthor->linked_account ) > 2 ) {
 			return $this->get_combined_post_count( $coauthor );
 		}
 
-		// Return term count, if account is not linked and term count is available.
-		if ( $this->has_author_terms( $user ) ) {
-			$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
-
-			if ( ! is_object( $user ) ) {
-				return $count;
-			}
-
-			if ( $this->get_author_term( $user ) ) {
-				return $term->count;
-			}
+		// Return term count, if term count is available.
+		$term = $this->get_author_term( $coauthor );
+		if ( is_int( $term->count ) ) {
+			return $term->count;
 		}
 
 		// Return $count as fallback.

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1054,6 +1054,10 @@ class CoAuthors_Plus {
 			$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
 			$term = $this->get_author_term( $user );
 
+			if ( false === $term ) {
+				return $count;
+			}
+
 			if ( ! $user->linked_account ) {
 				$count = $term->count;
 			} else {

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1124,7 +1124,7 @@ class CoAuthors_Plus {
 				{$wpdb->prefix}posts.ID
 			",
 			$user->linked_account,
-			$user->user_nicename,
+			$user->user_nicename
 		);
 
 		return count( $wpdb->get_results( $query ) );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1058,13 +1058,13 @@ class CoAuthors_Plus {
 
 		$term = $this->get_author_term( $coauthor );
 
-		// Return combined post count, if account is linked.
-		if ( is_object( $term ) && strlen( $coauthor->linked_account ) > 2 ) {
-			return $count + $term->count;
-		}
-
-		// Return term count, if term count is available.
 		if ( is_object( $term ) ) {
+			// Return combined post count, if account is linked.
+			if ( strlen( $coauthor->linked_account ) > 2 ) {
+				return $count + $term->count;
+			}
+
+			// Otherwise, return the term count.
 			return $term->count;
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1051,8 +1051,9 @@ class CoAuthors_Plus {
 		$user = get_userdata( $user_id );
 
 		// Return combined post count, if account is linked.
-		if ( $this->has_linked_account( $user ) ) {
-			return $this->get_combined_post_count( $this->get_coauthor_by( 'user_nicename', $user->user_nicename ) );
+		$coauthor = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
+		if ( is_object( $coauthor ) && strlen( $coauthor->linked_account ) > 2 ) {
+			return $this->get_combined_post_count( $coauthor );
 		}
 
 		// Return term count, if account is not linked and term count is available.
@@ -1070,18 +1071,6 @@ class CoAuthors_Plus {
 
 		// Return $count as fallback.
 		return $count;
-	}
-
-	/**
-	 * Check if user is linked to another account.
-	 *
-	 * @param WP_User $user The WP_User object.
-	 *
-	 * @return bool True on success, false on failure.
-	 */
-	function has_linked_account( $user ) {
-		$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
-		return (bool) $user->linked_account;
 	}
 
 	/**

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1059,12 +1059,12 @@ class CoAuthors_Plus {
 		$term = $this->get_author_term( $coauthor );
 
 		// Return combined post count, if account is linked.
-		if ( is_int( $term->count ) && strlen( $coauthor->linked_account ) > 2 ) {
+		if ( is_object( $term->count ) && strlen( $coauthor->linked_account ) > 2 ) {
 			return $count + $term->count;
 		}
 
 		// Return term count, if term count is available.
-		if ( is_int( $term->count ) ) {
+		if ( is_object( $term->count ) ) {
 			return $term->count;
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1058,7 +1058,7 @@ class CoAuthors_Plus {
 				return $this->get_linked_post_count( $user->user_nicename, $user->linked_account );
 			}
 
-			if ( null !== $term->count ) {
+			if ( isset( $term->count ) && null !== $term->count ) {
 				return $term->count;
 			}
 		}

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1131,32 +1131,6 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Get the post IDs by author name.
-	 *
-	 * @param string $author_name The name of the corresponding user.
-	 *
-	 * @return array The IDs of all matching posts.
-	 */
-	function get_post_ids_by_author_name( $author_name ) {
-		$results = array();
-		$args    = array(
-			'author_name' => $author_name,
-			'post_type'   => 'post',
-		);
-		$query   = new WP_Query( $args );
-
-		if ( ! $query->post_count ) {
-			return $results;
-		}
-
-		foreach ( $query->posts as $post ) {
-			$results[] = $post->ID;
-		}
-
-		return $results;
-	}
-
-	/**
 	 * Checks to see if the current user can set co-authors or not
 	 */
 	function current_user_can_set_authors( $post = null ) {

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1094,7 +1094,8 @@ class CoAuthors_Plus {
 	function get_combined_post_count( $user ) {
 		global $wpdb;
 
-		$query = $wpdb->prepare( "
+		$query = $wpdb->prepare(
+			"
 			SELECT
 				COUNT( {$wpdb->prefix}posts.ID ) as post_count
 			FROM

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1054,14 +1054,12 @@ class CoAuthors_Plus {
 			$user = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
 			$term = $this->get_author_term( $user );
 
-			if ( false === $term ) {
-				return $count;
+			if ( strlen( $user->linked_account ) > 1 ) {
+				return $this->get_linked_post_count( $user->user_nicename, $user->linked_account );
 			}
 
-			if ( ! $user->linked_account ) {
-				$count = $term->count;
-			} else {
-				$count = $this->get_linked_post_count( $user->user_nicename, $user->linked_account );
+			if ( null !== $term->count ) {
+				return $term->count;
 			}
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1056,65 +1056,20 @@ class CoAuthors_Plus {
 			return $count;
 		}
 
+		$term = $this->get_author_term( $coauthor );
+
 		// Return combined post count, if account is linked.
-		if ( strlen( $coauthor->linked_account ) > 2 ) {
-			return $this->get_combined_post_count( $coauthor );
+		if ( is_int( $term->count ) && strlen( $coauthor->linked_account ) > 2 ) {
+			return $count + $term->count;
 		}
 
 		// Return term count, if term count is available.
-		$term = $this->get_author_term( $coauthor );
 		if ( is_int( $term->count ) ) {
 			return $term->count;
 		}
 
 		// Return $count as fallback.
 		return $count;
-	}
-
-	/**
-	 * Get the combined post count of the user and its linked coauthor account.
-	 *
-	 * @param WP_User $user The WP_User object.
-	 *
-	 * @return int The combined post count.
-	 */
-	function get_combined_post_count( $user ) {
-		global $wpdb;
-
-		$query = $wpdb->prepare(
-			"
-			SELECT
-				COUNT( {$wpdb->prefix}posts.ID ) as post_count
-			FROM
-				{$wpdb->prefix}posts
-			INNER JOIN
-				{$wpdb->prefix}term_relationships
-			ON
-				{$wpdb->prefix}posts.ID = {$wpdb->prefix}term_relationships.object_id
-			INNER JOIN
-				{$wpdb->prefix}terms
-			ON
-				{$wpdb->prefix}term_relationships.term_taxonomy_id = {$wpdb->prefix}terms.term_id
-			INNER JOIN
-				{$wpdb->prefix}users
-			ON
-				{$wpdb->prefix}posts.post_author = {$wpdb->prefix}users.ID
-			WHERE
-				{$wpdb->prefix}posts.post_type = 'post'
-			AND
-				(
-					{$wpdb->prefix}users.user_login = %s
-				OR
-					{$wpdb->prefix}terms.name = %s
-				)
-			GROUP BY
-				{$wpdb->prefix}posts.ID
-			",
-			$user->linked_account,
-			$user->user_nicename
-		);
-
-		return count( $wpdb->get_results( $query ) );
 	}
 
 	/**

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1059,12 +1059,12 @@ class CoAuthors_Plus {
 		$term = $this->get_author_term( $coauthor );
 
 		// Return combined post count, if account is linked.
-		if ( is_object( $term->count ) && strlen( $coauthor->linked_account ) > 2 ) {
+		if ( is_object( $term ) && strlen( $coauthor->linked_account ) > 2 ) {
 			return $count + $term->count;
 		}
 
 		// Return term count, if term count is available.
-		if ( is_object( $term->count ) ) {
+		if ( is_object( $term ) ) {
 			return $term->count;
 		}
 

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -272,14 +272,6 @@ class CoAuthors_WP_List_Table extends WP_List_Table {
 		global $coauthors_plus;
 		$count = $coauthors_plus->get_guest_author_post_count( $item );
 
-		if ( ! empty( $item->linked_account ) ) {
-			global $coauthors_plus;
-			// Add user term count to guest author term count.
-			$term = get_term_by( 'slug', 'cap-' . $item->linked_account, $coauthors_plus->coauthor_taxonomy );
-			if ( is_object( $term ) ) {
-				$count = $count + $term->count;
-			}
-		}
 		return '<a href="' . esc_url( add_query_arg( 'author_name', rawurlencode( $item->user_login ), admin_url( 'edit.php' ) ) ) . '">' . $count . '</a>';
 	}
 


### PR DESCRIPTION
Fixes #460 

**Changes**

Fix incorrect post count for linked accounts

**Steps to test**

1. Check out this PR
2. Create the following three test cases.

---

**Test case**

1. Create an editor account (editor-460)
2. Create two posts (#460-1 & #460-2) as editor
3. Create a guest account (guest-460)
4. Create one post (#460-3) as guest
5. Check post count for editor and guest
6. Link guest account (guest-460) with editor account (editor-460)
7. Check post count for editor and guest

Expected count before linking:

- ✅ Editor: 2 posts
- ✅ Guest: 1 post 

Expected count after linking:

- ✅ Editor: 3 posts
- ✅ Guest: 3 posts