### PR TITLE
get_co_author_by(): Only replace cap- prefix if no results found first

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -272,11 +272,12 @@ class CoAuthors_Plus {
 				if ( 'user_nicename' == $key ) {
 					$key = 'slug';
 				}
-				// Ensure we aren't doing the lookup by the prefixed value
-				if ( 'login' == $key || 'slug' == $key ) {
-					$value = preg_replace( '#^cap\-#', '', $value );
-				}
 				$user = get_user_by( $key, $value );
+				if ( ! $user && ( 'login' == $key || 'slug' == $key ) ) {
+					// Re-try lookup without prefixed value if no results found.
+					$value = preg_replace( '#^cap\-#', '', $value );
+					$user = get_user_by( $key, $value );
+				}
 				if ( ! $user ) {
 					return false;
 				}


### PR DESCRIPTION
Since CAP prefixes terms with `cap-`, we usually replace it to ensure a result is found. However, this breaks for WP_Users that have "Cap" in their name. For testing:

1) Create WP_User with first name "Cap" and last name "America". You should see that the new user has a nicename of `cap-america` now.
2) Using the below snippet to illustrate:
```
global $coauthors_plus;
$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', 'cap-america' );
var_dump( $coauthor );
```
One would see that `$coauthor` erroneously returns `false` due to it pre-emptively replacing the `cap-` prefix and therefore, not finding the user. 

We should only do the replacement if no result has been found first and then, try without the `cap-` prefix or else we risk missing nicenames with `cap-`.