### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .svn
 .idea/
 wpcom-helper.php
+/composer.lock
+/vendor


### PR DESCRIPTION
Fixes #786 

**Note**

Update `.gitignore` to ensure that `composer.lock` and `vendor` did not show up in local Git status after running `composer install` to run `PHPCS` and `PHPUnit` locally.

**Steps to test**

1. Check out this PR
2. Look up `.gitignore`
3. The file contains `composer.lock` and `vendor`