### PR TITLE
Delete user term correctly

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -981,7 +981,8 @@ class CoAuthors_Plus {
 		$delete_user = get_user_by( 'id', $delete_id );
 		if ( is_object( $delete_user ) ) {
 			// Delete term
-			wp_delete_term( $delete_user->user_login, $this->coauthor_taxonomy );
+			$term = $this->get_author_term( $delete_user );
+			wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
 		}
 
 		if ( $this->is_guest_authors_enabled() ) {


### PR DESCRIPTION
The `delete_user_action` doesn't delete the author term as it passes the `user_login` to `wp_delete_term` rather than the term ID.

I found this bug when trying to convert users to guest authors. I wanted the new guest author to have the same slug as the old user, so I used a script to do the following:

1. Create new guest author with user_login "tmpuser"
2. `wp coauthors-plus swap-coauthor --from=user --to=tmpuser`
3. `wp_delete_user($user)`
4. `wp coauthors-plus rename-coauthor --from=tmpuser --to=user`

The final step (rename-coauthor) assigns the old user's term_taxonomy_id to the post rather than the new guest author's one. I'm guessing this is because when it looks up `cap-user` it finds the old term instead of the new one.

This bug has been raised before here:
https://github.com/Automattic/Co-Authors-Plus/issues/268, https://github.com/Automattic/Co-Authors-Plus/pull/313