### PR TITLE
Hide author section in editor for WP 5.6 and higher

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -112,6 +112,7 @@
 
 /** Block Editor Hack for 5.0: Hide the core author input **/
 .block-editor label[for^="post-author-selector-"],
-.block-editor select[id^="post-author-selector-"] {
+.block-editor select[id^="post-author-selector-"],
+.block-editor .post-author-selector {
 	display: none;
 }


### PR DESCRIPTION
Fixes #791 

**Note**

Hide the author section from the editor for WordPress >= 5.6.

**Steps to test**

1. Check out this PR
2. Ensure to test this PR against WordPress 5.6 or higher
3. Go to `/wp-admin/post-new.php` and `/wp-admin/post-new.php?post_type=page`
4. See that the author section is no longer visible in the sidebar

<table>
<tr>
<td>Before:
<br><br>

![#791-before](https://user-images.githubusercontent.com/3323310/119385035-dbf86380-bcc5-11eb-898e-4777cb004a4e.png)
</td>
<td>After:
<br><br>

![#791-after](https://user-images.githubusercontent.com/3323310/119385038-dd299080-bcc5-11eb-932a-fa393799d4dc.png)
</td>
</tr>
</table>