### PR TITLE
Remove accidental escaping

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -202,7 +202,7 @@ function coauthors__echo( $tag, $type = 'tag', $separators = array(), $tag_args 
 	$output .= $separators['after'];
 
 	if ( $echo ) {
-		echo esc_html( $output );
+		echo $output; // phpcs:ignore
 	}
 
 	return $output;


### PR DESCRIPTION
Fixes #796

** Changes**

In https://github.com/Automattic/Co-Authors-Plus/pull/784, I addressed various PHPCS errors. While addressing the PHPCS errors, I accidentally added HTML escaping to a function that returns an HTML link to the author profile. Due to escaping, the plain HTML code became visible. With this PR, I removed the escaping and adding an `// phpcs:ignore` statement instead.

**Steps to test**

1. Add the following code to the single.php file
```
<div class="post-preview__author"><span class="post-preview__author-prefix">by</span> <?php coauthors_posts_links(); ?></div>
```
2. Look up a random post to see the problem
3. Check out this PR
4. Look up the same post again to see the fix

<table>
<tr>
<td>Before:
<br><br>

![#796-before](https://user-images.githubusercontent.com/3323310/120192568-a0a4ea00-c21b-11eb-9b2f-f2ddee40326f.png)
</td>
<td>After:
<br><br>

![#796-after](https://user-images.githubusercontent.com/3323310/120192576-a26ead80-c21b-11eb-810b-e565755a759e.png)
</td>
</tr>
</table>
