### PR TITLE
Bail out early if $wp_query does not exist

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1135,7 +1135,7 @@ class CoAuthors_Plus {
 
 		global $wp_query, $authordata;
  
-		if ( ! did_action( 'wp' ) ) {
+		if ( ! isset( $wp_query ) ) {
 			return;
 		}
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1147,7 +1147,7 @@ class CoAuthors_Plus {
 		}
 
 		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
-		
+
 		global $wp_query, $authordata;
 
 		if ( is_object( $author ) ) {

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1133,6 +1133,12 @@ class CoAuthors_Plus {
 	 */
 	public function fix_author_page( $selection ) {
 
+		global $wp_query, $authordata;
+ 
+		if ( ! isset( $wp_query ) ) {
+			return;
+		}
+
 		if ( ! is_author() ) {
 			return;
 		}
@@ -1143,8 +1149,6 @@ class CoAuthors_Plus {
 		}
 
 		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
-
-		global $wp_query, $authordata;
 
 		if ( is_object( $author ) ) {
 			$authordata = $author; //phpcs:ignore

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1133,6 +1133,8 @@ class CoAuthors_Plus {
 	 */
 	public function fix_author_page( $selection ) {
 
+		global $wp_query, $authordata;
+
 		if ( ! isset( $wp_query ) ) {
 			return;
 		}
@@ -1147,9 +1149,6 @@ class CoAuthors_Plus {
 		}
 
 		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
-
-		global $wp_query, $authordata;
-
 		if ( is_object( $author ) ) {
 			$authordata = $author; //phpcs:ignore
 			$term       = $this->get_author_term( $authordata );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1133,8 +1133,6 @@ class CoAuthors_Plus {
 	 */
 	public function fix_author_page( $selection ) {
 
-		global $wp_query, $authordata;
- 
 		if ( ! isset( $wp_query ) ) {
 			return;
 		}
@@ -1149,6 +1147,8 @@ class CoAuthors_Plus {
 		}
 
 		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
+		
+		global $wp_query, $authordata;
 
 		if ( is_object( $author ) ) {
 			$authordata = $author; //phpcs:ignore

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1135,7 +1135,7 @@ class CoAuthors_Plus {
 
 		global $wp_query, $authordata;
  
-		if ( ! isset( $wp_query ) ) {
+		if ( ! did_action( 'wp' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #615 

**Note**

Add defensive programming to avoid that functions are called to early.

**Steps to test**

1. Install and activate [WooCommerce](https://wordpress.org/plugins/woocommerce/) and [WooCommerce Memberships](https://woocommerce.com/products/woocommerce-memberships/).
2. Create a simple product (a membership is not needed)
3. Look up the product page to see the warning (wp_debug must be active)
4. Check out this PR
5. Look up the product page again and see that warning is gone

**Screenshots**

<table>
<tr>
<td>Before:
<br><br>

![#615-before](https://user-images.githubusercontent.com/3323310/121011982-888f1680-c797-11eb-8c02-a9d23b2256e4.png)
</td>
<td valign="top">After:
<br><br>

![#615-after](https://user-images.githubusercontent.com/3323310/121011964-84fb8f80-c797-11eb-8a6c-79b1115452cd.png)
</td>
</tr>
</table>