### PR TITLE
Revert PHPCS fix that lead to an AJAX problem

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -547,7 +547,7 @@ class CoAuthors_Plus {
 
 		$tt_ids   = implode( ', ', array_map( 'intval', $tt_ids ) );
 		$term_ids = $wpdb->get_results( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN (%s)", $tt_ids ) );
-		
+
 
 		foreach ( (array) $term_ids as $term_id_result ) {
 			$term = get_term_by( 'id', $term_id_result->term_id, $this->coauthor_taxonomy );
@@ -1197,12 +1197,12 @@ class CoAuthors_Plus {
 			die();
 		}
 
-		if ( empty( $_REQUEST['q'] ) || empty( $_REQUEST['existing_authors'] ) ) {
+		if ( empty( $_REQUEST['q'] ) ) {
 			die();
 		}
 
 		$search = sanitize_text_field( strtolower( $_REQUEST['q'] ) );
-		$ignore = array_map( 'sanitize_text_field', explode( ',', $_REQUEST['existing_authors'] ) );
+		$ignore = array_map( 'sanitize_text_field', explode( ',', $_REQUEST['existing_authors'] ) ); // phpcs:ignore
 
 		$authors = $this->search_authors( $search, $ignore );
 


### PR DESCRIPTION
Fixes #799 

**Notes**

In #784, I changed `if ( empty( $_REQUEST['q'] ) ) { ... }` to `if ( empty( $_REQUEST['q'] ) || empty( $_REQUEST['existing_authors'] ) ) { ... }`, which prevents adding a co-author in case a page or post does not (longer) have an author (yet). 

This PR reverts this particular change.

**Steps to test**

1. Try to add an author to a page or post that does not have an author, to see the error.
2. Check out this PR.
3. Try to add an author again, to verify that an author can be added then.