### PR TITLE
Check for $_POST['cap-linked_account'] before using it

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -790,7 +790,7 @@ class CoAuthors_Guest_Authors {
 			&& is_user_member_of_blog( $user->ID, get_current_blog_id() )
 			&& $user->user_login != get_post_meta( $original_args['ID'], $this->get_post_meta_key( 'linked_account' ), true ) ) {
 			// if user has selected to link account to matching user we don't have to bail
-			if ( (int)$_POST['cap-linked_account'] === (int)$user->ID ) {
+			if ( isset( $_POST['cap-linked_account'] ) && (int) $_POST['cap-linked_account'] === (int) $user->ID ) {
 				return $post_data;
 			}
 			wp_die( esc_html__( 'There is a WordPress user with the same username as this guest author, please go back and link them in order to update.', 'co-authors-plus' ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/Co-Authors-Plus/commit/fc8d78cec2a8d1bce98db756f45476ec8b2e5bc4

**Note**

Check for $_POST['cap-linked_account'] before using it

**Steps to test**

1. Run `composer cs` and see the following error:
```
FILE: /Users/nielslange/Development/plugins/Co-Authors-Plus/php/class-coauthors-guest-authors.php
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 793 | ERROR | Detected usage of a possibly undefined superglobal array index: $_POST['cap-linked_account']. Use isset() or empty() to check the index exists before using
     |       | it (WordPress.Security.ValidatedSanitizedInput.InputNotValidated)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
2. Check out this PR
3. Run `composer cs` again and see that no error is visible

Alternatively, verify that all checks of this PR are passing.