### PR TITLE
Replace deprecated GitHub-hosted runner ubuntu-16.04 with ubuntu-18.04

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     continue-on-error: ${{ matrix.allowed_failure }}
     
     env:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,15 +12,21 @@ jobs:
       WP_VERSION: ${{ matrix.wordpress }}
       
     strategy:
-      fail-fast: false
       matrix:
         php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
         wordpress: [ '5.5', '5.6', '5.7'  ]
         allowed_failure: [ false ]
-        # https://make.wordpress.org/core/2020/11/23/wordpress-and-php-8-0/
+        include:
+          - php: "8.0"
+            # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
+            composer-options: "--ignore-platform-reqs"
+            extensions: pcov
+            ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
+            coverage: pcov
         exclude: 
           - php: '8.0'
             wordpress: '5.5'
+      fail-fast: false
 
     steps:
       - name: Checkout code
@@ -30,10 +36,15 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: pcov
-          # https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions
-          extensions: curl, dom, exif, fileinfo, hash, json, mbstring, mysqli, libsodium, openssl, pcre, imagick, xml, zip
+          extensions: ${{ matrix.extensions }}
+          ini-values: ${{ matrix.ini-values }}
+          coverage: ${{ matrix.coverage }}
 
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "${{ matrix.composer-options }}"
+          
       - name: Install Composer dependencies (PHP < 8.0 )
         if: ${{ matrix.php < 8.0 }}
         uses: ramsey/composer-install@v1

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -45,16 +45,6 @@ jobs:
         with:
           composer-options: "${{ matrix.composer-options }}"
           
-      - name: Install Composer dependencies (PHP < 8.0 )
-        if: ${{ matrix.php < 8.0 }}
-        uses: ramsey/composer-install@v1
-
-      - name: Install Composer dependencies (PHP >= 8.0)
-        if: ${{ matrix.php >= 8.0 }}
-        uses: ramsey/composer-install@v1
-        with:
-          composer-options: --ignore-platform-reqs
-
       - name: Setup Problem Matchers for PHPUnit
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 


### PR DESCRIPTION
Fixes #807 

**Note**

Replace deprecated GitHub-hosted runner ubuntu-16.04 with ubuntu-18.04. See also https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners.

**Steps to test**

1. Head over to https://github.com/Automattic/Co-Authors-Plus/actions/runs/1008419320, which is a check before this PR
2. See that deprecation warnings appear
3. Head over to https://github.com/Automattic/Co-Authors-Plus/actions/runs/1011697542, which is a check of this PR
4. See that no deprecation warnings appear

<table>
<tr>
<td>Before:
<br><br>

![#807-before](https://user-images.githubusercontent.com/3323310/124925933-460e6300-dffd-11eb-9934-df28174d741a.png)
</td>
<td>After:
<br><br>

![#807-after](https://user-images.githubusercontent.com/3323310/124925939-49095380-dffd-11eb-88b7-e9797ad23121.png)
</td>
</tr>
</table>
