### PR TITLE
Fix CSS hack for hiding Gutenberg post author box

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -113,6 +113,7 @@
 /** Block Editor Hack for 5.0: Hide the core author input **/
 .block-editor label[for^="post-author-selector-"],
 .block-editor select[id^="post-author-selector-"],
+.block-editor .edit-post-sidebar .components-combobox-control,
 .block-editor .post-author-selector {
 	display: none;
 }


### PR DESCRIPTION
Expand the CSS hack to hide the Gutenberg post author selector combobox when over 25 authors exist on the site, as reported in [issue 825](https://github.com/Automattic/Co-Authors-Plus/issues/825).

Gutenberg in WordPress core changes the type of author select combobox when there are [25 or more authors](https://github.com/WordPress/gutenberg/blob/d8fa5000cb00c02b455124b0e34b8ac382fe31e4/packages/editor/src/components/post-author/index.js#L14), and this isn't being hidden by the previous CSS hide hack. 

So where the current CSS hack works, as soon as there are over 25 authors, the type of select box changes, and the hack no longer targets the CSS class.

To fix, this hack can be expanded to also hide this >25 author select combobox class that Gutenberg uses, however there isn't a precise ID or class that can be targeted, so there is a possibility that this will hide any similar combobox added to the same area of the edit page by any other plugin.