### PR TITLE
Fix `_update_users_posts_count` function to recount Guest Author's shadow taxonomy term count.

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -546,7 +546,7 @@ class CoAuthors_Plus {
 		global $wpdb;
 
 		$tt_ids   = implode( ', ', array_map( 'intval', $tt_ids ) );
-		$term_ids = $wpdb->get_results( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN (%s)", $tt_ids ) );
+		$term_ids = $wpdb->get_results( "SELECT term_id FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN ($tt_ids)" ); // phpcs:ignore
 
 
 		foreach ( (array) $term_ids as $term_id_result ) {


### PR DESCRIPTION
When you run a recount for `author` taxonomy from CLI, it doesn't update post count.

> wp term recount author

---

The query for getting all term id from term taxonomy id in `_update_users_posts_count` is:
> $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE term_taxonomy_id IN (%s)", $tt_ids ) 

Which runs as
>  SELECT term_id FROM wp_term_taxonomy WHERE term_taxonomy_id IN ('1, 2')

Where as, it should be
> SELECT term_id FROM wp_term_taxonomy WHERE term_taxonomy_id IN (1, 2)

Looks like this was introduced while some phpcs error fixes: https://github.com/Automattic/Co-Authors-Plus/commit/c51143e9d332d3818e4641c5dd6de79fd314a308
