### PR TITLE
Hide deprecated social media links

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1063,21 +1063,6 @@ class CoAuthors_Guest_Authors {
 				'input' => 'url',
 			),
 			array(
-				'key'   => 'aim',
-				'label' => __( 'AIM', 'co-authors-plus' ),
-				'group' => 'contact-info',
-			),
-			array(
-				'key'   => 'yahooim',
-				'label' => __( 'Yahoo IM', 'co-authors-plus' ),
-				'group' => 'contact-info',
-			),
-			array(
-				'key'   => 'jabber',
-				'label' => __( 'Jabber / Google Talk', 'co-authors-plus' ),
-				'group' => 'contact-info',
-			),
-			array(
 				'key'               => 'description',
 				'label'             => __( 'Biographical Info', 'co-authors-plus' ),
 				'group'             => 'about',

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -190,9 +190,6 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 			'user_email',
 			'linked_account',
 			'website',
-			'aim',
-			'yahooim',
-			'jabber',
 			'description',
 		);
 
@@ -219,7 +216,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 		$fields = $guest_author_obj->get_guest_author_fields( 'contact-info' );
 		$keys   = wp_list_pluck( $fields, 'key' );
 
-		$this->assertEquals( array( 'user_email', 'website', 'aim', 'yahooim', 'jabber' ), $keys );
+		$this->assertEquals( array( 'user_email', 'website' ), $keys );
 
 		// Checks all the meta fields with group "about".
 		$fields = $guest_author_obj->get_guest_author_fields( 'about' );


### PR DESCRIPTION
Checks the WordPress database version and hides the fields for Jabber, AIM, and Google Talk on newer sites. Closes https://github.com/Automattic/Co-Authors-Plus/issues/827.