### PR TITLE
Issue with cache key `id` not being deleted.

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1222,7 +1222,7 @@ class CoAuthors_Guest_Authors {
 				$value_key = 'user_nicename';
 			} elseif ( 'login' == $key ) {
 				$value_key = 'user_login';
-			} else if ( 'id' == $key ) {
+			} elseif ( 'id' == $key ) {
 				$value_key = 'ID';
 			}
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1214,7 +1214,7 @@ class CoAuthors_Guest_Authors {
 
 		// Delete the lookup cache associated with each old co-author value
 		$keys = wp_list_pluck( $this->get_guest_author_fields(), 'key' );
-		$keys = array_merge( $keys, array( 'login', 'post_name', 'user_nicename', 'ID' ) );
+		$keys = array_merge( $keys, array( 'login', 'post_name', 'user_nicename', 'ID', 'id' ) );
 		foreach ( $keys as $key ) {
 			$value_key = $key;
 
@@ -1222,6 +1222,8 @@ class CoAuthors_Guest_Authors {
 				$value_key = 'user_nicename';
 			} elseif ( 'login' == $key ) {
 				$value_key = 'user_login';
+			} else if ( 'id' == $key ) {
+				$value_key = 'ID';
 			}
 
 			$cache_key = $this->get_cache_key( $key, $guest_author->$value_key );


### PR DESCRIPTION
`get_guest_author_by` method in `CoAuthors_Guest_Authors` allows the key `id`. It caches the result using the key as park of the cache key. The only problem is that the `delete_guest_author_cache` method does not recognize `id` as a valid key, so that cache remains indefinitely. This PR fixes the issue with `id` cache not being deleted.