### PR TITLE
Update yoast/phpunit-polyfills version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
     "squizlabs/php_codesniffer": "^3.5",
     "wp-coding-standards/wpcs": "^2.3.0",
-    "yoast/phpunit-polyfills": "^0.2.0"
+    "yoast/phpunit-polyfills": "^1.0.1"
   },
   "scripts": {
     "cs": [


### PR DESCRIPTION
Updates to the PHPUnit tests in WordPress 5.9 now require the PHPUnit Polyfills library to be ^1.0.1. 

This PR updates the minimum version of yoast/phpunit-polyfills in the composer.json file from `^0.2.0` to `1.0.1`.

For reference about the unit test changes in WordPress 5.9, see 
[Changes to the WordPress Core PHP Test Suite](https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/)