### PR TITLE
Remove CSS hack that hides the add author box from core in the block editor

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -109,10 +109,3 @@
 			margin-left: 30px;
 			font-size: 13px;
 		}
-
-/** Block Editor Hack for 5.0: Hide the core author input **/
-.block-editor label[for^="post-author-selector-"],
-.block-editor select[id^="post-author-selector-"],
-.block-editor .post-author-selector {
-	display: none;
-}


### PR DESCRIPTION
This CSS hack is no longer needed. 

As of #790, the authors box in the core block editor is prevented from showing [here](https://github.com/Automattic/Co-Authors-Plus/blob/cf8bc5ab87cd463cb985301078af0be5fd75b320/php/class-coauthors-endpoint.php#L284) and a 
 Co-Authors Plus specific author [combobox](https://github.com/Automattic/Co-Authors-Plus/blob/master/src/components/AuthorsSelection.js) has been added. 