### PR TITLE
Remove the /wp/v2/coauthors endpoint

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -226,9 +226,7 @@ class CoAuthors_Plus {
 			'public'       => false,
 			'sort'         => true,
 			'args'         => array( 'orderby' => 'term_order' ),
-			'show_in_rest' => true,
 			'show_ui'      => false,
-			'rest_base'    => 'coauthors',
 		);
 
 		// If we use the nasty SQL query, we need our custom callback. Otherwise, we still need to flush cache.


### PR DESCRIPTION
Remove the `/wp/v2/coauthors` endpoint added in #790 that is not being used.