### PR TITLE
Add the author taxonomy labels

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -220,7 +220,10 @@ class CoAuthors_Plus {
 		// Register new taxonomy so that we can store all of the relationships
 		$args = array(
 			'hierarchical' => false,
-			'label'        => false,
+			'labels' => array(
+				'name'			=> __( 'Authors' ),
+				'all_items' 	=> __( 'All Authors' ),
+			),
 			'query_var'    => false,
 			'rewrite'      => false,
 			'public'       => false,


### PR DESCRIPTION
When registering the author taxonomy, label being set to false breaks the Jetpack widget visibility option for Taxonomy. 
This Taxonomy option requires a label to form the first "all" option in the dropdown, otherwise the script errors out.
<img width="507" alt="Screen Shot 2022-07-21 at 3 30 20 pm" src="https://user-images.githubusercontent.com/2406820/180137096-83014f6e-4784-4373-8d6e-6cf6bd0d7b4c.png">

