### PR TITLE
Add `coauthors_get_users` template tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,5 +58,11 @@
       "@putenv WP_MULTISITE=1",
       "@composer integration"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
Factor the coauthor/user data retrieval logic out of the `coauthors_wp_list_authors` template tag
and into a separate template tag akin to WordPress' own `get_users` function.

Allow theme developers to use raw coauthor/user data to create custom-tailored widgets and not be restricted by the output of the `coauthors_wp_list_authors` template tag.