### PR TITLE
Limit users query in search_authors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1302,6 +1302,7 @@ class CoAuthors_Plus {
 				'user_email',
 				'user_login',
 			),
+			'capability'     => array( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ),
 			'fields'         => 'all_with_meta',
 		);
 		$found_users = get_users( $args );


### PR DESCRIPTION
When we call `search_authors`, CAP is also taking the opportunity to update the user terms.

In order to do that, it queries for all users in the database:

https://github.com/Automattic/Co-Authors-Plus/blob/e727fe75d432dda5e4ffea6799df85ff21a00531/co-authors-plus.php#L1296

When a site has too many users, this can be a problem, especially because this can be called with an empty search and would try to load all users of the site at once.

# Previous work

I saw that you tried to [fix this issue 4 years ago](https://github.com/Automattic/Co-Authors-Plus/pull/544), but it got [reverted](https://github.com/Automattic/Co-Authors-Plus/pull/590).

# This fix

This is an attempt to have a quick fix for this, without trying to replicate all the logic in the PR merged 4 years ago.

I saw that in that attempt, they were filtering out users who did not have the capability to edit posts. See:

https://github.com/Automattic/Co-Authors-Plus/pull/544/files#diff-a3596cc30542e2cf428e6b5c295e6d757efda1539e9b3d2b8aaea5e818e3753dR45

Also, in our current code, we never return users who don't have this capability:

https://github.com/Automattic/Co-Authors-Plus/blob/e727fe75d432dda5e4ffea6799df85ff21a00531/co-authors-plus.php#L1351

So what I propose in this PR is just to run this filter earlier, and only fix terms for users who have this capability.

Can someone have a look at it?

Known issue: This will filter out users who have rights to edit other post types, but not posts. But this is already a limitation of the plugin. If we had a `post_type` in that context we could check for the right cap.

Question: In the comments I see that this is addressing something for people who were running CAP < 2.7. If that's only for this purpose and is not required for newer versions, do you think it has been there for long enough and this could be removed altogether?