### PR TITLE
Remove pre_handle_404 filter

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1209,7 +1209,6 @@ class CoAuthors_Plus {
 		if ( is_object( $authordata ) || ! empty( $term ) ) {
 			$wp_query->queried_object    = $authordata;
 			$wp_query->queried_object_id = $authordata->ID;
-			add_filter( 'pre_handle_404', '__return_true' );
 		} else {
 			$wp_query->queried_object = $wp_query->queried_object_id = null;
 			$wp_query->is_author      = $wp_query->is_archive = false;


### PR DESCRIPTION
Problem: non-existent paged author archives are not throwing a 404. For example: /author/slug/page/100000. Will load and be indexed by crawlers.

Others are having this problem too: https://github.com/Automattic/Co-Authors-Plus/issues/703