### PR TITLE
Adds the Yoast integration

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -34,12 +34,16 @@ Author - user with the role of author
 
 define( 'COAUTHORS_PLUS_VERSION', '3.5.3' );
 
+require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+
 require_once dirname( __FILE__ ) . '/template-tags.php';
 require_once dirname( __FILE__ ) . '/deprecated.php';
 
 require_once dirname( __FILE__ ) . '/php/class-coauthors-template-filters.php';
 require_once dirname( __FILE__ ) . '/php/class-coauthors-endpoint.php';
 require_once dirname( __FILE__ ) . '/php/integrations/amp.php';
+
+CoAuthors\Integrations\Yoast::init();
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once dirname( __FILE__ ) . '/php/class-wp-cli.php';
@@ -220,9 +224,9 @@ class CoAuthors_Plus {
 		// Register new taxonomy so that we can store all of the relationships
 		$args = array(
 			'hierarchical' => false,
-			'labels' => array(
-				'name'			=> __( 'Authors' ),
-				'all_items' 	=> __( 'All Authors' ),
+			'labels'       => array(
+				'name'      => __( 'Authors' ),
+				'all_items' => __( 'All Authors' ),
 			),
 			'query_var'    => false,
 			'rewrite'      => false,

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
     "wp-coding-standards/wpcs": "^2.3.0",
     "yoast/phpunit-polyfills": "^1.0.1"
   },
+  "autoload": {
+		"classmap": [
+			"php"
+		]
+	},
   "scripts": {
     "cs": [
       "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"WordPress-VIP-Go\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""

--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * The main file for the Yoast integration
+ */
+
+namespace CoAuthors\Integrations;
+
+use CoAuthors\Integrations\Yoast\CoAuthor;
+use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
+
+/**
+ * The main Yoast integration class
+ */
+class Yoast {
+
+	/**
+	 * This integration relies on the wpseo_schema_graph added in Yoast 18.7
+	 */
+	const YOAST_MIN_VERSION = '18.7';
+
+	/**
+	 * Public method to be used to initialize this integration
+	 *
+	 * It will register a callback to the init hook where the actual initializatino happens
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'plugins_loaded', [ __CLASS__, 'do_initialization' ] );
+	}
+
+	/**
+	 * Do the actual initialization. We don't want to do call before plugins_loaded to make sure we have everything in place to verify our conditions
+	 *
+	 * @return void
+	 */
+	public static function do_initialization() {
+		if ( self::should_initialize() ) {
+			self::register_hooks();
+		}
+	}
+
+	/**
+	 * Checks if we should initialize this integration
+	 *
+	 * @return boolean
+	 */
+	protected static function should_initialize() {
+		return self::is_yoast_active() && ! self::is_yoast_legacy_integration_enabled();
+	}
+
+	/**
+	 * Checks if the Yoast plugin is active and running the required version
+	 *
+	 * @return boolean
+	 */
+	protected static function is_yoast_active() {
+		return defined( 'WPSEO_VERSION' ) && version_compare( WPSEO_VERSION, self::YOAST_MIN_VERSION, '>=' );
+	}
+
+	/**
+	 * This integration was originally built in Yoast and left behind a feature flag
+	 *
+	 * Now that we are moving it to this plugin, lets make sure to not load it if the Yoast version is enabled to avoid conflicts
+	 *
+	 * @return boolean
+	 */
+	protected static function is_yoast_legacy_integration_enabled() {
+		return defined( 'YOAST_SEO_COAUTHORS_PLUS' ) && YOAST_SEO_COAUTHORS_PLUS;
+	}
+
+	/**
+	 * Register the hooks
+	 *
+	 * @return void
+	 */
+	public static function register_hooks() {
+		\add_filter( 'wpseo_schema_graph', [ __CLASS__, 'filter_graph' ], 11, 2 );
+		\add_filter( 'wpseo_schema_author', [ __CLASS__, 'filter_author_graph' ], 11, 4 );
+		\add_filter( 'wpseo_schema_profilepage', [ __CLASS__, 'filter_schema_profilepage' ], 11, 4 );
+		\add_filter( 'wpseo_meta_author', [ __CLASS__, 'filter_author_meta' ], 11, 2 );
+	}
+
+	/**
+	 * Filters the graph output of authors archive for guest authors.
+	 *
+	 * @param array                   $data                   The schema graph.
+	 * @param Meta_Tags_Context       $context                The context object.
+	 * @param Abstract_Schema_Piece   $graph_piece_generator  The graph piece generator.
+	 * @param Abstract_Schema_Piece[] $graph_piece_generators The graph piece generators.
+	 *
+	 * @return array The (potentially altered) schema graph.
+	 */
+	public static function filter_schema_profilepage( $data, $context, $graph_piece_generator, $graph_piece_generators ) {
+
+		if ( ! is_author() ) {
+			return $data;
+		}
+
+		$user = \get_queried_object();
+
+		if ( empty( $user->type ) || $user->type !== 'guest-author' ) {
+			return $data;
+		}
+
+		// Fix author URL.
+		$author_url                                     = \get_author_posts_url( $user->ID, $user->user_nicename );
+		$graph_piece_generator->context->canonical      = $author_url;
+		$graph_piece_generator->context->main_schema_id = $author_url;
+
+		return $graph_piece_generator->generate();
+	}
+
+	/**
+	 * Filters the graph output to add authors.
+	 *
+	 * @param array                   $data                   The schema graph.
+	 * @param Meta_Tags_Context       $context                The context object.
+	 * @param Abstract_Schema_Piece   $graph_piece_generator  The graph piece generator.
+	 * @param Abstract_Schema_Piece[] $graph_piece_generators The graph piece generators.
+	 *
+	 * @return array The (potentially altered) schema graph.
+	 */
+	public static function filter_author_graph( $data, $context, $graph_piece_generator, $graph_piece_generators ) {
+		if ( ! isset( $data['image']['url'] ) ) {
+			return $data;
+		}
+
+		if ( isset( $data['image']['@id'] ) ) {
+			$data['image']['@id'] .= \md5( $data['image']['url'] );
+		}
+
+		if ( isset( $data['logo']['@id'] ) ) {
+			$data['logo']['@id'] .= \md5( $data['image']['url'] );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Filters the graph output to add authors.
+	 *
+	 * @param array             $data    The schema graph.
+	 * @param Meta_Tags_Context $context Context object.
+	 *
+	 * @return array The (potentially altered) schema graph.
+	 */
+	public static function filter_graph( $data, $context ) {
+		if ( ! \is_singular() ) {
+			return $data;
+		}
+
+		if ( ! \function_exists( '\get_coauthors' ) ) {
+			return $data;
+		}
+
+		/**
+		 * Contains the authors from the CoAuthors Plus plugin.
+		 *
+		 * @var \WP_User[] $author_objects
+		 */
+		$author_objects = \get_coauthors( $context->post->ID );
+
+		$ids     = [];
+		$authors = [];
+
+		// Add the authors to the schema.
+		foreach ( $author_objects as $author ) {
+			$author_generator          = new CoAuthor();
+			$author_generator->context = $context;
+			$author_generator->helpers = \YoastSEO()->helpers;
+
+			if ( $author instanceof \WP_User ) {
+				$author_data = $author_generator->generate_from_user_id( $author->ID );
+			} elseif ( ! empty( $author->type ) && $author->type === 'guest-author' ) {
+				$author_data = $author_generator->generate_from_guest_author( $author );
+			}
+
+			if ( ! empty( $author_data ) ) {
+				$ids[]     = [ '@id' => $author_data['@id'] ];
+				$authors[] = $author_data;
+			}
+		}
+		$schema_types  = new Schema_Types();
+		$article_types = $schema_types->get_article_type_options_values();
+
+		// Change the author reference to reference our multiple authors.
+		$add_to_graph = false;
+		foreach ( $data as $key => $piece ) {
+			if ( \in_array( $piece['@type'], $article_types, true ) ) {
+				$data[ $key ]['author'] = $ids;
+				$add_to_graph           = true;
+				break;
+			}
+		}
+
+		if ( $add_to_graph ) {
+			// Clean all Persons from the schema, as the user stored as post owner might be incorrectly added if the post post has only guest authors as authors.
+			$data = \array_filter(
+				$data,
+				function( $piece ) {
+					return empty( $piece['@type'] ) || $piece['@type'] !== 'Person';
+				}
+			);
+
+			if ( ! empty( $author_data ) ) {
+				if ( $context->site_represents !== 'person' || $author->ID !== $context->site_user_id ) {
+					$data = \array_merge( $data, $authors );
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Filters the author meta tag
+	 *
+	 * @param string                 $author_name  The article author's display name. Return empty to disable the tag.
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 * @return string
+	 */
+	public static function filter_author_meta( $author_name, $presentation ) {
+		$author_objects = \get_coauthors( $presentation->context->post->id );
+
+		// Fallback in case of error.
+		if ( empty( $author_objects ) ) {
+			return $author_name;
+		}
+
+		$output = '';
+		foreach ( $author_objects as $i => $author ) {
+			$output .= $author->display_name;
+			if ( $i <= ( count( $author_objects ) - 2 ) ) {
+				$output .= ', ';
+			}
+		}
+		return $output;
+	}
+
+}

--- a/php/integrations/yoast/class-coauthor.php
+++ b/php/integrations/yoast/class-coauthor.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * The CoAuthor Schema class used by Yoast integration
+ */
+
+namespace CoAuthors\Integrations\Yoast;
+
+use Yoast\WP\SEO\Config\Schema_IDs;
+use Yoast\WP\SEO\Generators\Schema\Author;
+
+/**
+ * Returns schema Author data for the CoAuthor Plus assigned user on a post.
+ */
+class CoAuthor extends Author {
+
+	/**
+	 * The user ID of the author we're generating data for.
+	 *
+	 * @var int $user_id
+	 */
+	private $user_id;
+
+	/**
+	 * Determine whether we should return Person schema.
+	 *
+	 * @return bool
+	 */
+	public function is_needed() {
+		return true;
+	}
+
+	/**
+	 * Returns Person Schema data.
+	 *
+	 * @return bool|array Person data on success, false on failure.
+	 */
+	public function generate() {
+		$user_id = $this->determine_user_id();
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$data = $this->build_person_data( $user_id, true );
+
+		$data['@type'] = 'Person';
+		unset( $data['logo'] );
+
+		// If this is a post and the author archives are enabled, set the author archive url as the author url.
+		if ( $this->helpers->options->get( 'disable-author' ) !== true ) {
+			$data['url'] = $this->helpers->user->get_the_author_posts_url( $user_id );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Generate the Person data given a user ID.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return array|bool
+	 */
+	public function generate_from_user_id( $user_id ) {
+		$this->user_id = $user_id;
+
+		return $this->generate();
+	}
+
+	/**
+	 * Generate the Person data given a Guest Author object.
+	 *
+	 * @param object $guest_author The Guest Author object.
+	 *
+	 * @return array|bool
+	 */
+	public function generate_from_guest_author( $guest_author ) {
+		$data = $this->build_person_data_for_guest_author( $guest_author, true );
+
+		$data['@type'] = 'Person';
+		unset( $data['logo'] );
+
+		// If this is a post and the author archives are enabled, set the author archive url as the author url.
+		if ( $this->helpers->options->get( 'disable-author' ) !== true ) {
+			$data['url'] = \get_author_posts_url( $guest_author->ID, $guest_author->user_nicename );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Determines a User ID for the Person data.
+	 *
+	 * @return bool|int User ID or false upon return.
+	 */
+	protected function determine_user_id() {
+		return $this->user_id;
+	}
+
+	/**
+	 * Builds our array of Schema Person data for a given Guest Author.
+	 *
+	 * @param object $guest_author The Guest Author object.
+	 * @param bool   $add_hash Wether or not the person's image url hash should be added to the image id.
+	 *
+	 * @return array An array of Schema Person data.
+	 */
+	protected function build_person_data_for_guest_author( $guest_author, $add_hash = false ) {
+		$schema_id = $this->context->site_url . Schema_IDs::PERSON_LOGO_HASH;
+		$data      = [
+			'@type' => $this->type,
+			'@id'   => $schema_id . \wp_hash( $guest_author->user_login . $guest_author->ID . 'guest' ),
+		];
+
+		$data['name'] = $this->helpers->schema->html->smart_strip_tags( $guest_author->display_name );
+
+		$data = $this->set_image_from_avatar( $data, $guest_author, $schema_id, $add_hash );
+
+		// If local avatar is present, override.
+		$avatar_meta = \wp_get_attachment_image_src( \get_post_thumbnail_id( $guest_author->ID ) );
+		if ( $avatar_meta ) {
+			$avatar_meta   = [
+				'url'    => $avatar_meta[0],
+				'width'  => $avatar_meta[1],
+				'height' => $avatar_meta[2],
+			];
+			$data['image'] = $this->helpers->schema->image->generate_from_attachment_meta( $schema_id, $avatar_meta, $data['name'], $add_hash );
+		}
+
+		if ( ! empty( $guest_author->description ) ) {
+			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $guest_author->description );
+		}
+
+		$data = $this->add_guest_author_same_as_urls( $data, $guest_author );
+
+		return $data;
+	}
+
+	/**
+	 * Builds our SameAs array.
+	 *
+	 * @param array   $data         The Person schema data.
+	 * @param WP_User $guest_author The user data object.
+	 *
+	 * @return array The Person schema data.
+	 */
+	protected function add_guest_author_same_as_urls( $data, $guest_author ) {
+		$same_as_urls = [];
+
+		// Add the "Website" field from CoAuthors' contact info.
+		if ( ! empty( $guest_author->website ) ) {
+			$same_as_urls[] = $guest_author->website;
+		}
+
+		// When CAP adds it, add the social profiles here.
+
+		if ( ! empty( $same_as_urls ) ) {
+			$same_as_urls   = \array_values( \array_unique( $same_as_urls ) );
+			$data['sameAs'] = $same_as_urls;
+		}
+
+		return $data;
+	}
+}


### PR DESCRIPTION
This PR adds the Yoast integration.

This integration was initially developed as part of Yoast itself -> https://github.com/Yoast/wordpress-seo/pull/18331

I then added support to Guest Authors and did a couple of other improvements in -> https://github.com/Yoast/wordpress-seo/pull/19076

However, while chatting with @jdevalk, we agreed that it would be better if this integration lived in the CoAuthors plugin.

So this PR moves the whole integration, with my additions to the CoAuthors codebase.

Note: This only acts on Yoast filters so it should have no effect on sites not running Yoast.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

This PR can be acceptance tested by following these steps:

* Enable Yoast and CoAuthors Plus plugin
* Make sure you DO NOT have the `YOAST_SEO_COAUTHORS_PLUS` constant set
* Create a post

Now try different authorship states and check the resulting schema:

* Visit the post you created and look at the source code
* We want to look at the schema that is inserted in the `<script type="application/ld+json" class="yoast-schema-graph">` tag
* Make sure the "author" key has a list of IDs and they match the authors you have set up for the post:

```
"@graph": [
	        {
	            "@type": "Article",
	            "@id": "https://leogermani.jurassic.tube/2022/09/15/venenatis-dapibus-odio-sollicitudin-ultricies-magna-sem-hac-hendrerit-cursus-faucibus/#article",
	            "isPartOf": {
	                "@id": "https://leogermani.jurassic.tube/2022/09/15/venenatis-dapibus-odio-sollicitudin-ultricies-magna-sem-hac-hendrerit-cursus-faucibus/"
	            },
	            "author": [
	                {
	                    "@id": "https://leogermani.jurassic.tube/#/schema/person/743c49680386c3bcf517e1753cd46a25"
	                }
	            ],
 ...
```
* The example above shows a post with only one author
* At the end of the schema, look for the `Person` sections. There should be one section for each author you added to the post. Example:
```
	        {
	            "@type": "Person",
	            "@id": "https://leogermani.jurassic.tube/#/schema/person/743c49680386c3bcf517e1753cd46a25",
	            "name": "leo",
	            "image": {
	                "@type": "ImageObject",
	                "inLanguage": "en-US",
	                "@id": "https://leogermani.jurassic.tube/#/schema/person/image/00d99ee8603d99603d8c6be4dbc57016",
	                "url": "https://secure.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=96&d=mm&r=g",
	                "contentUrl": "https://secure.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=96&d=mm&r=g",
	                "caption": "leo"
	            },
	            "sameAs": [
	                "http://localhost"
	            ],
	            "mainEntityOfPage": {
	                "@id": "https://leogermani.jurassic.tube/author/leo/"
	            }
	        }
```
* The persons in the list must match the IDs in the author key we saw above. 
* Confirm that the `<meta name="author" ..` tag correctly displays the name of all authors
* Repeat the above steps changing the post authorship with different combinations:
  * only one regular author
  * 2 or more authors who are regular users
  * mix of regular users and guest authors as authors of the post
  * only one guest author as the post author
  * multiple guest authors as post authors
  * Also test guest authors with and without avatars, and with and without emails with gravatars. Check that the image tag is properly added in all cases.
 * Visit an author archive page for both a regular author and a guest author and make sure the schema for `profilePage` has the right links