### PR TITLE
Handle WP_Error on failed guest author creation for method create_guest_author()

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1239,9 +1239,12 @@ class CoAuthors_Guest_Authors {
 
 
 	/**
-	 * Create a guest author
+	 * Create a guest author.
+	 *
+	 * @param $args array Author args. Required keys to create author: 'display_name' and 'user_email'.
 	 *
 	 * @since 3.0
+	 * @return int|WP_Error The ID of the created guest author, or a WP_Error object if the author could not be created.
 	 */
 	function create( $args ) {
 		global $coauthors_plus;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -889,14 +889,14 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			return WP_CLI::warning( sprintf( esc_html__( '-- Failed to create guest author: %s', 'co-authors-plus' ), $guest_author_id->get_error_message() ) );
 		}
 
-		// translators: Guest Author ID.
-		WP_CLI::success( sprintf( esc_html__( '-- Created as guest author #%s', 'co-authors-plus' ), $guest_author_id ) );
-
 		if ( isset( $author['author_id'] ) ) {
 			update_post_meta( $guest_author_id, '_original_author_id', $author['ID'] );
 		}
 
 		update_post_meta( $guest_author_id, '_original_author_login', $author['user_login'] );
+
+		// translators: Guest Author ID.
+		WP_CLI::success( sprintf( esc_html__( '-- Created as guest author #%s', 'co-authors-plus' ), $guest_author_id ) );
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -850,6 +850,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		WP_CLI::line( 'All done!' );
 	}
 
+	/**
+	 * Helper function to create a guest author.
+	 *
+	 * @param $author array author args. Required: display_name, user_login
+	 * @return void
+	 */
 	private function create_guest_author( $author ) {
 		global $coauthors_plus;
 		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_email', $author['user_email'], true );
@@ -858,36 +864,39 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', $author['user_login'], true );
 		}
 
-		if ( ! $guest_author ) {
-			WP_CLI::line( '-- Not found; creating profile.' );
-
-			$guest_author_id = $coauthors_plus->guest_authors->create(
-				array(
-					'display_name' => $author['display_name'],
-					'user_login'   => $author['user_login'],
-					'user_email'   => $author['user_email'],
-					'first_name'   => $author['first_name'],
-					'last_name'    => $author['last_name'],
-					'website'      => $author['website'],
-					'description'  => $author['description'],
-					'avatar'       => $author['avatar'],
-				)
-			);
-
-			if ( $guest_author_id ) {
-				WP_CLI::line( sprintf( '-- Created as guest author #%s', $guest_author_id ) );
-
-				if ( isset( $author['author_id'] ) ) {
-					update_post_meta( $guest_author_id, '_original_author_id', $author['ID'] );
-				}
-
-				update_post_meta( $guest_author_id, '_original_author_login', $author['user_login'] );
-			} else {
-				WP_CLI::warning( '-- Failed to create guest author.' );
-			}
-		} else {
-			WP_CLI::line( sprintf( '-- Author already exists (ID #%s); skipping.', $guest_author->ID ) );
+		if ( $guest_author ) {
+			// translators: Guest Author ID.
+			return WP_CLI::warning( sprintf( esc_html__( '-- Author already exists (ID #%s); skipping.', 'co-authors-plus' ), $guest_author->ID ) );
 		}
+
+		WP_CLI::line( esc_html__( '-- Not found; creating profile.', 'co-authors-plus' ) );
+
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => $author['display_name'],
+				'user_login'   => $author['user_login'],
+				'user_email'   => $author['user_email'],
+				'first_name'   => $author['first_name'],
+				'last_name'    => $author['last_name'],
+				'website'      => $author['website'],
+				'description'  => $author['description'],
+				'avatar'       => $author['avatar'],
+			)
+		);
+
+		if ( is_wp_error( $guest_author_id ) ) {
+			// translators: The error message.
+			return WP_CLI::warning( sprintf( esc_html__( '-- Failed to create guest author: %s', 'co-authors-plus' ), $guest_author_id->get_error_message() ) );
+		}
+
+		// translators: Guest Author ID.
+		WP_CLI::success( sprintf( esc_html__( '-- Created as guest author #%s', 'co-authors-plus' ), $guest_author_id ) );
+
+		if ( isset( $author['author_id'] ) ) {
+			update_post_meta( $guest_author_id, '_original_author_id', $author['ID'] );
+		}
+
+		update_post_meta( $guest_author_id, '_original_author_login', $author['user_login'] );
 	}
 
 	/**


### PR DESCRIPTION
Hi there,

This PR checks if `create()` returns a WP_Error and displays a warning with the error message https://github.com/Automattic/Co-Authors-Plus/compare/master...oscarssanchez:fix/error-handling-create-guest-author-cli?expand=1#diff-a52979a3ff3a75e65a5166f5fc4a259ef7e243368b5953e587054bbfbada9865R887

Fixes #878 

It also changes a couple things I think could make the command more readable (both in code and output in the terminal)

* Changed output from a single line to display `success` when creating an author, or `warning` when there's an issue. This could help readability in the terminal in my opinion
* Adds i18n
* Adds documentation to create_guest_author() and create()
* A bit of refactoring to reduce if statements

This could also help with development for #875 

Thanks for your feedback!
