### PR TITLE
Add command documentation

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -770,6 +770,25 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Create a single guest author.
+	 *
+	 * self::create_guest_author() wrapper.
+	 *
+	 * @subcommand create-single-author
+	 * @synopsis
+	 * [--display_name=<display_name>]
+	 * [--user_login=<user_login>]
+	 * [--first_name=<first_name>]
+	 * [--last_name=<last_name>]
+	 * [--website=<website>]
+	 * [--user_email=<user_email>]
+	 * [--description=<description>]
+	 */
+	public function create_single_author( $args, $assoc_args ) {
+		$this->create_guest_author( $assoc_args );
+	}
+
+	/**
 	 * Subcommand to create guest authors from an author list in a CSV file
 	 *
 	 * @subcommand create-guest-authors-from-csv

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -774,7 +774,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 *
 	 * self::create_guest_author() wrapper.
 	 *
-	 * @subcommand create-single-author
+	 * @subcommand create-author
 	 * @synopsis
 	 * [--display_name=<display_name>]
 	 * [--user_login=<user_login>]
@@ -784,7 +784,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * [--user_email=<user_email>]
 	 * [--description=<description>]
 	 */
-	public function create_single_author( $args, $assoc_args ) {
+	public function create_author( $args, $assoc_args ) {
 		$this->create_guest_author( $assoc_args );
 	}
 


### PR DESCRIPTION
This PR implements #875 .

This is just a wrapper for `create_guest_author()` we can use in the terminal. It should handle all of the scenarios correctly now that we return back the corresponding `WP_Error` telling the user what is missing from the required fields. Given `create_guest_author()` is used in other commands I didn't make any other changes or method rename. 

Happy to discuss anything if needed!

Implements #875 