### PR TITLE
Fix tests and add IDE goodies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,16 +9,16 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-tab_width = 4
-indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+indent_style = tab
 
-[*.txt]
-trim_trailing_whitespace = false
-
-[*.{md,json,yml}]
-trim_trailing_whitespace = false
+[*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-VIP-Go" />
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
+
+	<rule ref="PHPCompatibilityWP"/>
+	<config name="testVersion" value="7.2-"/>
+
+	<arg name="extensions" value="php"/>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
+	<file>.</file>
+
+	<exclude-pattern>*/dev-lib/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
+</ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,9 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
+// Load the composer autoloader.
+require_once __DIR__ . '/../vendor/autoload.php';
+
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {


### PR DESCRIPTION
* Fix tests not including composer autoload. This prevents the following error:
```
Error: The PHPUnit Polyfills library is a requirement for running the WP test suite.
```
* Adds a basic `phpcs.xml` file for easy linting on IDEs
* Adds basic `.editorconfig` file for IDEs