### PR TITLE
Change permission callback for coauthors/v1/authors and coauthors/v1/search endpoint

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1134,7 +1134,16 @@ class CoAuthors_Plus {
 	 * Checks to see if the current user can set co-authors or not
 	 */
 	function current_user_can_set_authors() {
-		$can_set_authors = current_user_can( 'edit_others_posts' );
+		$current_user = wp_get_current_user();
+		if ( ! $current_user ) {
+			return false;
+		}
+		// Super admins can do anything
+		if ( function_exists( 'is_super_admin' ) && is_super_admin() ) {
+			return true;
+		}
+
+		$can_set_authors = isset( $current_user->allcaps['edit_others_posts'] ) ? $current_user->allcaps['edit_others_posts'] : false;
 
 		return apply_filters( 'coauthors_plus_edit_authors', $can_set_authors );
 	}

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1143,6 +1143,7 @@ class CoAuthors_Plus {
 			return true;
 		}
 
+		// Instead of using current_user_can(), we need to manually check the allcaps because of filter_user_has_cap
 		$can_set_authors = isset( $current_user->allcaps['edit_others_posts'] ) ? $current_user->allcaps['edit_others_posts'] : false;
 
 		return apply_filters( 'coauthors_plus_edit_authors', $can_set_authors );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -909,7 +909,7 @@ class CoAuthors_Plus {
 			return;
 		}
 
-		if ( $this->current_user_can_set_authors( $post ) ) {
+		if ( $this->current_user_can_set_authors() ) {
 			// if current_user_can_set_authors and nonce valid
 			if ( isset( $_POST['coauthors-nonce'] ) && isset( $_POST['coauthors'] ) ) {
 				check_admin_referer( 'coauthors-edit', 'coauthors-nonce' );
@@ -1133,29 +1133,8 @@ class CoAuthors_Plus {
 	/**
 	 * Checks to see if the current user can set co-authors or not
 	 */
-	function current_user_can_set_authors( $post = null ) {
-		global $typenow;
-
-		if ( ! $post ) {
-			$post = get_post();
-			if ( ! $post ) {
-				// if user is on pages, you need to grab post type another way
-				$current_screen = get_current_screen();
-				$post_type      = ( ! empty( $current_screen->post_type ) ) ? $current_screen->post_type : '';
-			} else {
-				$post_type = $post->post_type;
-			}
-		} else {
-			$post_type = $post->post_type;
-		}
-
-		// TODO: need to fix this; shouldn't just say no if don't have post_type
-		if ( ! $post_type ) {
-			return false;
-		}
-
-		$post_type_object = get_post_type_object( $post_type );
-		$current_user     = wp_get_current_user();
+	function current_user_can_set_authors() {
+		$current_user = wp_get_current_user();
 		if ( ! $current_user ) {
 			return false;
 		}

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1134,16 +1134,7 @@ class CoAuthors_Plus {
 	 * Checks to see if the current user can set co-authors or not
 	 */
 	function current_user_can_set_authors() {
-		$current_user = wp_get_current_user();
-		if ( ! $current_user ) {
-			return false;
-		}
-		// Super admins can do anything
-		if ( function_exists( 'is_super_admin' ) && is_super_admin() ) {
-			return true;
-		}
-
-		$can_set_authors = isset( $current_user->allcaps['edit_others_posts'] ) ? $current_user->allcaps['edit_others_posts'] : false;
+		$can_set_authors = current_user_can( 'edit_others_posts' );
 
 		return apply_filters( 'coauthors_plus_edit_authors', $can_set_authors );
 	}

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -59,7 +59,7 @@ class Endpoints {
 				array(
 					'methods'             => 'GET',
 					'callback'            => array( $this, 'get_coauthors_search_results' ),
-					'permission_callback' => array( $this, 'can_edit_posts' ),
+					'permission_callback' => array( $this, 'can_edit_coauthors' ),
 					'args'                => array(
 						'q'                => array(
 							'description' => __( 'Text to search.' ),
@@ -83,7 +83,7 @@ class Endpoints {
 				array(
 					'methods'             => 'GET',
 					'callback'            => array( $this, 'get_coauthors' ),
-					'permission_callback' => array( $this, 'can_edit_posts' ),
+					'permission_callback' => array( $this, 'can_edit_coauthors' ),
 					'args'                => array(
 						'post_id' => array(
 							'required'          => true,
@@ -189,28 +189,20 @@ class Endpoints {
 	}
 
 	/**
-	 * Limit read endpoints to users that can edit posts.
-	 *
-	 * @return bool
-	 */
-	public function can_edit_posts() {
-		return current_user_can( 'edit_posts' );
-	}
-
-	/**
 	 * Permissions for updating coauthors.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return bool
 	 */
 	public function can_edit_coauthors( $request ) {
+		set_current_user( 0 );
 		$post = get_post( $request->get_param( 'post_id' ) );
 
-		if ( ! $post instanceof WP_Post ) {
-			return false;
+		if ( $post instanceof WP_Post ) {
+			return $this->coauthors->current_user_can_set_authors( $post );;
 		}
 
-		return $this->coauthors->current_user_can_set_authors( $post );
+		return $this->coauthors->current_user_can_set_authors();
 	}
 
 	/**

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -194,14 +194,7 @@ class Endpoints {
 	 * @param WP_REST_Request $request Request object.
 	 * @return bool
 	 */
-	public function can_edit_coauthors( $request ) {
-		set_current_user( 0 );
-		$post = get_post( $request->get_param( 'post_id' ) );
-
-		if ( $post instanceof WP_Post ) {
-			return $this->coauthors->current_user_can_set_authors( $post );;
-		}
-
+	public function can_edit_coauthors() {
 		return $this->coauthors->current_user_can_set_authors();
 	}
 

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -191,7 +191,6 @@ class Endpoints {
 	/**
 	 * Permissions for updating coauthors.
 	 *
-	 * @param WP_REST_Request $request Request object.
 	 * @return bool
 	 */
 	public function can_edit_coauthors() {

--- a/tests/test-coauthors-endpoint.php
+++ b/tests/test-coauthors-endpoint.php
@@ -34,6 +34,20 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 			)
 		);
 
+		$this->contributor1 = $this->factory->user->create_and_get(
+			array(
+				'role'       => 'contributor',
+				'user_login' => 'contributor1',
+			)
+		);
+
+		$this->subscriber1 = $this->factory->user->create_and_get(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'subscriber1',
+			)
+		);
+
 		$this->coauthor1 = $coauthors_plus->guest_authors->create(
 			array(
 				'user_login'   => 'coauthor1',
@@ -263,6 +277,35 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 			'GET',
 			''
 		);
+
+		wp_set_current_user( $this->editor1->ID );
+
+		$this->assertTrue( $this->_api->can_edit_coauthors( $request ) );
+
+		wp_set_current_user( $this->author1->ID );
+
+		$this->assertFalse( $this->_api->can_edit_coauthors( $request ) );
+
+		wp_set_current_user( $this->contributor1->ID );
+
+		$this->assertFalse( $this->_api->can_edit_coauthors( $request ) );
+
+		wp_set_current_user( $this->subscriber1->ID );
+
+		$this->assertFalse( $this->_api->can_edit_coauthors( $request ) );
+	}
+
+	public function test_can_edit_coauthors__with_post_param() {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_author' => $this->editor1->ID,
+			)
+		);
+
+		$request = new WP_REST_Request(
+			'GET',
+			''
+		);
 		$request->set_default_params(
 			array(
 				'post_id' => $post_id,
@@ -274,6 +317,14 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 		$this->assertTrue( $this->_api->can_edit_coauthors( $request ) );
 
 		wp_set_current_user( $this->author1->ID );
+
+		$this->assertFalse( $this->_api->can_edit_coauthors( $request ) );
+
+		wp_set_current_user( $this->contributor1->ID );
+
+		$this->assertFalse( $this->_api->can_edit_coauthors( $request ) );
+
+		wp_set_current_user( $this->subscriber1->ID );
 
 		$this->assertFalse( $this->_api->can_edit_coauthors( $request ) );
 	}

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -173,20 +173,10 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 	 *
 	 * @covers CoAuthors_Plus::current_user_can_set_authors()
 	 */
-	public function test_current_user_can_set_authors_using_current_screen() {
-
+	public function test_current_user_can_set_author() {
 		global $coauthors_plus;
 
 		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		$screen = get_current_screen();
-
-		// Set the edit post current screen.
-		set_current_screen( 'edit-post' );
-
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		$GLOBALS['current_screen'] = $screen;
 
 		// Backing up current user.
 		$current_user = get_current_user_id();
@@ -196,22 +186,10 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
 
-		set_current_screen( 'edit-post' );
-
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		$GLOBALS['current_screen'] = $screen;
-
 		// Checks when current user is editor.
 		wp_set_current_user( $this->editor1->ID );
 
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		set_current_screen( 'edit-post' );
-
 		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
-
-		$GLOBALS['current_screen'] = $screen;
 
 		// Checks when current user is admin.
 		$admin1 = $this->factory->user->create_and_get(
@@ -222,101 +200,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		wp_set_current_user( $admin1->ID );
 
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		set_current_screen( 'edit-post' );
-
 		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
-
-		$GLOBALS['current_screen'] = $screen;
-
-		// Restore current user from backup.
-		wp_set_current_user( $current_user );
-	}
-
-	/**
-	 * Checks if the current user can set co-authors or not using global post.
-	 *
-	 * @covers CoAuthors_Plus::current_user_can_set_authors()
-	 */
-	public function test_current_user_can_set_authors_using_global_post() {
-
-		global $coauthors_plus, $post;
-
-		// Backing up global post.
-		$post_backup = $post;
-
-		$post = $this->post;
-
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		// Backing up current user.
-		$current_user = get_current_user_id();
-
-		// Checks when current user is author.
-		wp_set_current_user( $this->author1->ID );
-
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
-
-		// Checks when current user is editor.
-		wp_set_current_user( $this->editor1->ID );
-
-		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
-
-		// Checks when current user is super admin.
-		$admin1 = $this->factory->user->create_and_get(
-			array(
-				'role' => 'administrator',
-			)
-		);
-
-		grant_super_admin( $admin1->ID );
-		wp_set_current_user( $admin1->ID );
-
-		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
-
-		// Restore current user from backup.
-		wp_set_current_user( $current_user );
-
-		// Restore global post from backup.
-		$post = $post_backup;
-	}
-
-	/**
-	 * Checks if the current user can set co-authors or not using normal post.
-	 *
-	 * @covers CoAuthors_Plus::current_user_can_set_authors()
-	 */
-	public function test_current_user_can_set_authors_using_normal_post() {
-
-		global $coauthors_plus;
-
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors( $this->post ) );
-
-		// Backing up current user.
-		$current_user = get_current_user_id();
-
-		// Checks when current user is author.
-		wp_set_current_user( $this->author1->ID );
-
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors( $this->post ) );
-
-		// Checks when current user is editor.
-		wp_set_current_user( $this->editor1->ID );
-
-		$this->assertTrue( $coauthors_plus->current_user_can_set_authors( $this->post ) );
-
-		// Checks when current user is super admin.
-		$admin1 = $this->factory->user->create_and_get(
-			array(
-				'role' => 'administrator',
-			)
-		);
-
-		grant_super_admin( $admin1->ID );
-		wp_set_current_user( $admin1->ID );
-
-		$this->assertTrue( $coauthors_plus->current_user_can_set_authors( $this->post ) );
 
 		// Restore current user from backup.
 		wp_set_current_user( $current_user );
@@ -341,22 +225,22 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 			)
 		);
 
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors( $this->post ) );
+		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
 
 		add_filter( 'coauthors_plus_edit_authors', '__return_true' );
 
-		$this->assertTrue( $coauthors_plus->current_user_can_set_authors( $this->post ) );
+		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
 
 		remove_filter( 'coauthors_plus_edit_authors', '__return_true' );
 
 		// Checks when current user is editor.
 		wp_set_current_user( $this->editor1->ID );
 
-		$this->assertTrue( $coauthors_plus->current_user_can_set_authors( $this->post ) );
+		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
 
 		add_filter( 'coauthors_plus_edit_authors', '__return_false' );
 
-		$this->assertFalse( $coauthors_plus->current_user_can_set_authors( $this->post ) );
+		$this->assertFalse( $coauthors_plus->current_user_can_set_authors() );
 
 		remove_filter( 'coauthors_plus_edit_authors', '__return_false' );
 
@@ -774,4 +658,3 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 	}
 }
-


### PR DESCRIPTION
This PR does two things:
- Simplifies `current_user_can_set_authors()` to user caps only. It shouldn't matter what the `post_type` is...especially when the endpoint at the end of the day falls back to user caps anyways, so we can save on processing for that
- Changes the permission callback for `coauthors/v1/authors` and `coauthors/v1/search` endpoint