### PR TITLE
Add .distignore file

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,9 @@
+/.distignore
+/.editorconfig
+/.git
+/.gitignore
+/.github
+/bin
+/package.json
+/composer.json
+/tests


### PR DESCRIPTION
Specify which files should not be included in the push to WordPress.org. These are all development files and directories.

Note that `/vendor` is not included here - that means that it WILL be available in the plugin on WordPress.org, which is essential as we have some `require` dependencies.

The deploy Action will use rsync + `.distignore` if the `.distignore` exists, so it doesn't care what may or may not be ignored via `.gitignore`.