### PR TITLE
remove composer autoloader dependency

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -34,16 +34,13 @@ Author - user with the role of author
 
 define( 'COAUTHORS_PLUS_VERSION', '3.5.6' );
 
-require_once dirname( __FILE__ ) . '/vendor/autoload.php';
-
 require_once dirname( __FILE__ ) . '/template-tags.php';
 require_once dirname( __FILE__ ) . '/deprecated.php';
 
 require_once dirname( __FILE__ ) . '/php/class-coauthors-template-filters.php';
 require_once dirname( __FILE__ ) . '/php/class-coauthors-endpoint.php';
 require_once dirname( __FILE__ ) . '/php/integrations/amp.php';
-
-CoAuthors\Integrations\Yoast::init();
+require_once dirname( __FILE__ ) . '/php/integrations/yoast.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once dirname( __FILE__ ) . '/php/class-wp-cli.php';

--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -39,6 +39,7 @@ class Yoast {
 	 */
 	public static function do_initialization() {
 		if ( self::should_initialize() ) {
+			require_once dirname( __FILE__ ) . '/yoast/class-coauthor.php';
 			self::register_hooks();
 		}
 	}
@@ -242,3 +243,5 @@ class Yoast {
 	}
 
 }
+
+Yoast::init();


### PR DESCRIPTION
## Description

Removes the composer autoloader dependency

Fixes #897

## Deploy Notes

We are removing composer autoloader dependecy, so we no longer need the vendor folder to be shipped.

## Steps to Test

1. Activate the plugin and make sure you see no errors or warnings
2. Test it with and without Yoast plugin activated alongside it
