### PR TITLE
Fix deprecated function message

### DIFF
--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -186,7 +186,12 @@ class Yoast {
 			}
 		}
 		$schema_types  = new Schema_Types();
-		$article_types = $schema_types->get_article_type_options_values();
+		$article_types = array_map(
+			function( $article_type ) {
+				return $article_type['value'];
+			},
+			$schema_types->get_article_type_options()
+		);
 
 		// Change the author reference to reference our multiple authors.
 		$add_to_graph = false;


### PR DESCRIPTION
## Description

Fixes #901 

This PR fixes the deprecated warning for `get_article_type_options_values` function. To do so, we are using the available `get_article_type_options` function instead and returning the desired `value` key for the article type.

