### PR TITLE
fix: Make CoAuthors_Plus::get_coauthor_by() compatible with unicode author usernames

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -929,7 +929,7 @@ class CoAuthors_Guest_Authors {
 				}
 				// Ensure we aren't doing the lookup by the prefixed value
 				if ( 'user_login' == $key ) {
-					$value = preg_replace( '#^cap\-#', '', $value );
+					$value = preg_replace( '#^cap\-#', '', sanitize_title( $value ) );
 				}
 				$query   = $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s AND meta_value=%s;", $this->get_post_meta_key( $key ), $value );
 				$post_id = $wpdb->get_var( $query ); // phpcs:ignore

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -929,7 +929,7 @@ class CoAuthors_Guest_Authors {
 				}
 				// Ensure we aren't doing the lookup by the prefixed value
 				if ( 'user_login' == $key ) {
-					$value = preg_replace( '#^cap\-#', '', sanitize_title( $value ) );
+					$value = preg_replace( '#^cap\-#', '', sanitize_title_for_query( $value ) );
 				}
 				$query   = $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key=%s AND meta_value=%s;", $this->get_post_meta_key( $key ), $value );
 				$post_id = $wpdb->get_var( $query ); // phpcs:ignore

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -75,6 +75,31 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 	}
 
 	/**
+	 * Checks coauthor object when he/she is a guest author with unicode user_login
+	 *
+	 * @covers CoAuthors_Plus::get_coauthor_by()
+	 */
+	public function test_get_coauthor_by_when_guest_author_has_unicode_username() {
+
+		global $coauthors_plus;
+
+		$user_login = 'محمود-الحسيني';
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'user_login'	=> $user_login,
+				'display_name'	=> 'محمود الحسيني',
+			)
+		);
+
+		$coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $user_login );
+
+		$this->assertInstanceOf( stdClass::class, $coauthor );
+		$this->assertObjectHasAttribute( 'ID', $coauthor );
+		$this->assertEquals( $guest_author_id, $coauthor->ID );
+		$this->assertEquals( 'guest-author', $coauthor->type );
+	}
+
+	/**
 	 * Checks coauthor object when he/she is a wp author.
 	 *
 	 * @covers CoAuthors_Plus::get_coauthor_by()


### PR DESCRIPTION
Currently CoAuthors_Plus::get_coauthor_by() fails to retrieve guest authors whose "user_login" names contains non-ascii characters. Those user_logins are effectively slugs so they are stored in the database url-encoded, and thus should be compared against a url-encoded version of the user_login if they are to be found.