### PR TITLE
Fixes guest author menu item url

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -72,6 +72,9 @@ class CoAuthors_Guest_Authors {
 		// Add a Personal Data Exporter to guest authors
 		add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'filter_personal_data_exporter' ), 1 );
 
+		// Filters the guest author menu URL in nav menus.
+		add_filter( 'nav_menu_link_attributes', array( $this, 'filter_nav_menu_attributes' ), 10, 4 );
+
 		// Allow users to change where this is placed in the WordPress admin
 		$this->parent_page = apply_filters( 'coauthors_guest_author_parent_page', $this->parent_page );
 
@@ -1634,5 +1637,32 @@ class CoAuthors_Guest_Authors {
 			'data' => $data_to_export,
 			'done' => true,
 		);
+	}
+
+	/**
+	 * Filters the guest author menu item attributes
+	 *
+	 * @param array $atts {
+	 *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
+	 *
+	 *     @type string $title        Title attribute.
+	 *     @type string $target       Target attribute.
+	 *     @type string $rel          The rel attribute.
+	 *     @type string $href         The href attribute.
+	 *     @type string $aria-current The aria-current attribute.
+	 * }
+	 * @param WP_Post  $menu_item The current menu item object.
+	 * @param stdClass $args      An object of wp_nav_menu() arguments.
+	 * @param int      $depth     Depth of menu item. Used for padding.
+	 * @return void
+	 */
+	public function filter_nav_menu_attributes( $atts, $menu_item, $args, $depth ) {
+		if ( ! empty( $menu_item->object ) && 'guest-author' === $menu_item->object ) {
+			$author = $this->get_guest_author_by( 'ID', $menu_item->object_id );
+			if ( ! empty( $author->type ) && $author->type === 'guest-author' ) {
+				$atts['href'] = get_author_posts_url( $author->ID, $author->user_nicename );
+			}
+		}
+		return $atts;
 	}
 }


### PR DESCRIPTION
## Description

Fixes #904

Fixes the Guest Author Nav menu item URL

## Deploy Notes

Nothing 

## Steps to Test

1. Create one or more guest authors
2. Go to Appearance > Menus
3. On the top of the page, click on Screen Options and enable Guest Authors
4. On the left sidebar, select a guest author and add it to a menu
5. Visit the site and look at the menu
6. On `master` you will notice that the menu item links to an invalid URL, as if the guest author was a regular post type
7. On this branch, the menu item will link to the guest author archive
