### PR TITLE
Avoid fatals in nav menu filter

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -73,7 +73,7 @@ class CoAuthors_Guest_Authors {
 		add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'filter_personal_data_exporter' ), 1 );
 
 		// Filters the guest author menu URL in nav menus.
-		add_filter( 'nav_menu_link_attributes', array( $this, 'filter_nav_menu_attributes' ), 10, 4 );
+		add_filter( 'nav_menu_link_attributes', array( $this, 'filter_nav_menu_attributes' ), 10, 2 );
 
 		// Allow users to change where this is placed in the WordPress admin
 		$this->parent_page = apply_filters( 'coauthors_guest_author_parent_page', $this->parent_page );
@@ -1642,8 +1642,8 @@ class CoAuthors_Guest_Authors {
 	/**
 	 * Filters the guest author menu item attributes
 	 *
-	 * @param array $atts {
-	 *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
+	 * @param array   $atts {
+	 *       The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
 	 *
 	 *     @type string $title        Title attribute.
 	 *     @type string $target       Target attribute.
@@ -1651,12 +1651,10 @@ class CoAuthors_Guest_Authors {
 	 *     @type string $href         The href attribute.
 	 *     @type string $aria-current The aria-current attribute.
 	 * }
-	 * @param WP_Post  $menu_item The current menu item object.
-	 * @param stdClass $args      An object of wp_nav_menu() arguments.
-	 * @param int      $depth     Depth of menu item. Used for padding.
-	 * @return void
+	 * @param WP_Post $menu_item The current menu item object.
+	 * @return array
 	 */
-	public function filter_nav_menu_attributes( $atts, $menu_item, $args, $depth ) {
+	public function filter_nav_menu_attributes( $atts, $menu_item ) {
 		if ( ! empty( $menu_item->object ) && 'guest-author' === $menu_item->object ) {
 			$author = $this->get_guest_author_by( 'ID', $menu_item->object_id );
 			if ( ! empty( $author->type ) && $author->type === 'guest-author' ) {


### PR DESCRIPTION
## Description

It was reported that the filter might be called without all the params. See https://wordpress.org/support/topic/php-error-in-latest-version-2/

## Deploy Notes

Nothing to note

## Steps to Test

See https://github.com/Automattic/Co-Authors-Plus/pull/913. It should still work the same way
