### PR TITLE
Fixes CoAuthors Plus & Elementor Archive Pages conflict. #905

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1169,7 +1169,7 @@ class CoAuthors_Plus {
 	 */
 	public function fix_author_page( $selection ) {
 
-		global $wp_query, $authordata;
+		global $wp_query, $authordata, $post;
 
 		if ( ! isset( $wp_query ) ) {
 			return;
@@ -1184,7 +1184,12 @@ class CoAuthors_Plus {
 			return;
 		}
 
-		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
+		if ( ! isset( $post->post_author ) ) {
+			$author = $this->get_coauthor_by( 'user_nicename', $author_name );
+		} else {
+			$author = $this->get_coauthor_by( 'id', $post->post_author );
+		}
+
 		if ( is_object( $author ) ) {
 			$authordata = $author; //phpcs:ignore
 			$term       = $this->get_author_term( $authordata );


### PR DESCRIPTION
## Description

Fixes issue where `fix_author_page()` makes every post show on the author archive page be the same author as the archive author.  This is an issue when you have a sidebar that lists out posts from site that do not belong to the archive author.


## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Do stuff
