### PR TITLE
Show author taxonomy in REST API, hide description based on capabilities

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1855,8 +1855,7 @@ class CoAuthors_Plus {
 			'edit_posts'
 		);
 
-		// Short circuit with empty string to make description publicly accessible.
-		if ( '' === $capability || current_user_can( $capability ) ) {
+		if ( current_user_can( $capability ) ) {
 			return $response;
 		}
 
@@ -1866,7 +1865,7 @@ class CoAuthors_Plus {
 			return $response;
 		}
 
-		$data['description'] = '';
+		unset( $data['description'] );
 
 		$response->set_data( $data );
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -141,6 +141,9 @@ class CoAuthors_Plus {
 
 		// Block editor assets for the sidebar plugin.
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_sidebar_plugin_assets' ) );
+
+		// REST API: Depending on user capabilities, hide author term description.
+		add_action( 'rest_prepare_author', array( $this, 'conditionally_hide_author_term_description' ) );
 	}
 
 	/**
@@ -231,6 +234,8 @@ class CoAuthors_Plus {
 			'sort'         => true,
 			'args'         => array( 'orderby' => 'term_order' ),
 			'show_ui'      => false,
+			'show_in_rest' => true,
+			'rest_base'    => 'coauthors',
 		);
 
 		// If we use the nasty SQL query, we need our custom callback. Otherwise, we still need to flush cache.
@@ -1832,6 +1837,40 @@ class CoAuthors_Plus {
 			}
 		}
 		return $args;
+	}
+
+	/**
+	 * Conditionally Hide Author Term Description
+	 * 
+	 * If the current user does not have the required capability,
+	 * hide the author term description by changing it to an empty string.
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/930
+	 * @param WP_REST_Response $response Response for an individual author taxonomy term.
+	 * @return WP_REST_Response $response Same response, possibly mutated to eliminate value of description.
+	 */
+	public function conditionally_hide_author_term_description( WP_REST_Response $response ) : WP_REST_Response {
+		$capability = apply_filters(
+			'coauthors_view_author_description_capability',
+			'edit_posts'
+		);
+
+		// Short circuit with empty string to make description publicly accessible.
+		if ( '' === $capability || current_user_can( $capability ) ) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+
+		if ( ! is_array( $data ) || ! array_key_exists( 'description', $data ) ) {
+			return $response;
+		}
+
+		$data['description'] = '';
+
+		$response->set_data( $data );
+
+		return $response;
 	}
 }
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1843,7 +1843,7 @@ class CoAuthors_Plus {
 	 * Conditionally Hide Author Term Description
 	 * 
 	 * If the current user does not have the required capability,
-	 * hide the author term description by changing it to an empty string.
+	 * hide the author term description by unsetting it.
 	 *
 	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/930
 	 * @param WP_REST_Response $response Response for an individual author taxonomy term.

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1851,7 +1851,7 @@ class CoAuthors_Plus {
 	 */
 	public function conditionally_hide_author_term_description( WP_REST_Response $response ) : WP_REST_Response {
 		$capability = apply_filters(
-			'coauthors_view_author_description_capability',
+			'coauthors_rest_view_description_cap',
 			'edit_posts'
 		);
 


### PR DESCRIPTION
## Description

Continues from #899 resolves #930 using the last of the proposed solutions in which the author taxonomy is made available in the WP REST API with the base `coauthors` but without the term description.

The privacy issue pointed out in #850 and fixed by #851 is handled based on capabilities. In a filter on `rest_prepare_author`, the description is changed to an empty string if the current user does not have the `edit_posts` capability.

My intention was to make the view context of the coauthors endpoint available to anyone who could open a post in the block editor. In that way, it could be used in custom blocks as was mentioned in #851 but would not be available to subscribers or unauthenticated users.

I am open to making revisions if security of the email addresses needs to be more strict or if a different approach is preferable for another reason.

## Steps to Test

I used Application Passwords for authentication in my own testing.

- [ ] GET `/wp-json/wp/v2/coauthors` as an unauthenticated user. The description should be ~~an empty string~~ undefined.
- [ ] GET `/wp-json/wp/v2/coauthors` as a user with the Subscriber role. The description should be ~~an empty string~~ undefined.
- [ ] GET `/wp-json/wp/v2/coauthors` as a user with the Author role or above. The description should appear in its original state.
