### PR TITLE
Change esc_html to strip_tags for displayName in _format_author_data function in class-coauthors-endpoint.php

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -211,7 +211,7 @@ class Endpoints {
 			'userNicename' => esc_html( rawurldecode( $author->user_nicename ) ),
 			'login'        => esc_html( $author->user_login ),
 			'email'        => sanitize_email( $author->user_email ),
-			'displayName'  => esc_html( str_replace( '∣', '|', $author->display_name ) ),
+			'displayName'  => strip_tags( str_replace( '∣', '|', $author->display_name ) ),
 			'avatar'       => esc_url( get_avatar_url( $author->ID ) ),
 		);
 	}


### PR DESCRIPTION

## Description

This is a fix for https://github.com/Automattic/Co-Authors-Plus/issues/937#issue-1759165795 where I switched out the esc_html function call for strip_tags for the displayName to fix an apostrophe display issue on the post-edit page.

Should include any special considerations, decisions, and links to relevant GitHub issues.

Please don't include internal or private links

## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Do stuff
