### PR TITLE
Ensure 'nickname' is created to prevent is_author() PHP notice with Guest Author

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -973,7 +973,7 @@ class CoAuthors_Guest_Authors {
 		$guest_author['type']          = 'guest-author';
 
 		if ( ! isset( $guest_author['nickname'] ) ) {
-			$guest_author['nickname'] = $guest_author['display_name'] ?? '';
+			$guest_author['nickname'] = '';
 		}
 
 		wp_cache_set( $cache_key, (object) $guest_author, self::$cache_group );

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -971,6 +971,7 @@ class CoAuthors_Guest_Authors {
 		// Hack to model the WP_User object
 		$guest_author['user_nicename'] = sanitize_title( $guest_author['user_login'] );
 		$guest_author['type']          = 'guest-author';
+		$guest_author['nickname']      = $guest_author['display_name'] ?? '';
 
 		wp_cache_set( $cache_key, (object) $guest_author, self::$cache_group );
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -971,7 +971,10 @@ class CoAuthors_Guest_Authors {
 		// Hack to model the WP_User object
 		$guest_author['user_nicename'] = sanitize_title( $guest_author['user_login'] );
 		$guest_author['type']          = 'guest-author';
-		$guest_author['nickname']      = $guest_author['display_name'] ?? '';
+
+		if ( ! isset( $guest_author['nickname'] ) ) {
+			$guest_author['nickname'] = $guest_author['display_name'] ?? '';
+		}
 
 		wp_cache_set( $cache_key, (object) $guest_author, self::$cache_group );
 


### PR DESCRIPTION
Ensure `nickname` is created on the object to prevent an issue with `nickname` not existing on the Guest Author's object: https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-query.php#L4087