### PR TITLE
Guest Authors: Add labels property

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -8,7 +8,7 @@
 
 class CoAuthors_Guest_Authors {
 
-
+	public $labels;
 	var $post_type              = 'guest-author';
 	var $parent_page            = 'users.php';
 	var $list_guest_authors_cap = 'list_users';


### PR DESCRIPTION
## Description

Dynamically created class properties are deprecated in PHP 8.2, so this change explicitly defines the property in the class.

The `$labels` property is assigned to in the constructor of this Guest Authors class.

The property needs to be public, as it is used by the list table class when defining the search box label.

## Steps to Test

Note that running on PHP 8.2 generates a PHP deprecation message like:

> PHP message: Deprecated: Creation of dynamic property CoAuthors_Guest_Authors::$labels is deprecated in /var/www/wp-content/plugins/co-authors-plus/php/class-coauthors-guest-authors.php on line 85

After merging, this deprecation message will stop.