### PR TITLE
Workflows: Fix runner image and matrix

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.allowed_failure }}
 
     env:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,8 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
-        wordpress: [ '5.5', '5.6', '5.7', '5.8', '5.9', '6.0', '6.1' ]
+        php: [ '7.1', '7.2', '7.3', '7.4', '8.0' ]
+        wordpress: [ '5.7', '5.8', '5.9', '6.0', '6.1', '6.2' ]
         allowed_failure: [ false ]
         include:
           - php: "8.0"
@@ -23,9 +23,6 @@ jobs:
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
-        exclude:
-          - php: '8.0'
-            wordpress: '5.5'
       fail-fast: false
 
     steps:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -54,7 +54,11 @@ jobs:
           ./vendor/bin/phpunit --version
 
       - name: Start MySQL service
-        run: sudo /etc/init.d/mysql start
+        run: sudo systemctl start mysql.service
+
+      - name: Setting mysql_native_password for PHP <= 7.3
+        if: ${{ matrix.php <= 7.3 }}
+        run: mysql -u root -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'";
 
       - name: Install WordPress environment
         run: composer prepare ${{ matrix.wordpress }}


### PR DESCRIPTION
## Description

- ubuntu-18.04 is no longer supported.
- moving to a newer runner image means using MySQL 8, which needs a workaround for PHP <=7.3
- the workaround wasn't working for PHP 7.0 or 5.6, so these have been removed.
- PHP 8.1 and 8.2 can't be added until PHPUnit version is increased.
- The new block editor sidebar wasn't appearing before WP 5.7, so don't test before that, with a view to bumping minimum WP (and PHP) version numbers in a future release.

## Deploy Notes

None.

## Steps to Test

See the passed workflows.