### PR TITLE
Define dynamic guest_authors property

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -69,6 +69,11 @@ class CoAuthors_Plus {
 	var $to_be_filtered_caps = array();
 
 	/**
+	 * @var CoAuthors_Guest_Authors
+	 */
+	public $guest_authors;
+
+	/**
 	 * __construct()
 	 */
 	function __construct() {
@@ -1841,7 +1846,7 @@ class CoAuthors_Plus {
 
 	/**
 	 * Conditionally Hide Author Term Description
-	 * 
+	 *
 	 * If the current user does not have the required capability,
 	 * hide the author term description by unsetting it.
 	 *


### PR DESCRIPTION
## Description

Dynamic properties are deprecated in PHP 8.2. This PR explicitly defines a class property. It needs to stay public as it is referenced in other classes directly.

## Deploy Notes

None

## Steps to Test

With PHP 8.2, a message of:

> PHP message: Deprecated: Creation of dynamic property CoAuthors_Plus::$guest_authors is deprecated in /var/www/wp-content/plugins/co-authors-plus/co-authors-plus.php on line 158

...would be logged. After applying the patch, this will no longer appear.