### PR TITLE
Improve tests setup

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,13 +13,11 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.1', '7.4', '8.0', '8.2' ]
         wordpress: [ '5.7', '6.2' ]
+        php: [ '7.1', '7.4', '8.0', '8.2' ]
         allowed_failure: [ false ]
         include:
-          - php: '8.0'
-            # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-            composer-options: '--ignore-platform-reqs'
+          - php: '8.2'
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
@@ -29,7 +27,7 @@ jobs:
             allowed_failure: true
         exclude:
           - php: '8.2'
-            wordpress: '6.0'
+            wordpress: '5.7'
       fail-fast: false
 
     steps:
@@ -44,10 +42,15 @@ jobs:
           ini-values: ${{ matrix.ini-values }}
           coverage: ${{ matrix.coverage }}
 
+      - name: Install PHPUnit 7.x for WP < 5.9
+        if: ${{ matrix.wordpress < 5.9 }}
+        # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
+        run: composer require --dev phpunit/phpunit:"^7.5" --ignore-platform-req=php+ --no-update --no-scripts --no-interaction
+
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
-          composer-options: "${{ matrix.composer-options }}"
+          composer-options: --ignore-platform-req=php+
 
       - name: Set up problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,16 +13,23 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.1', '7.2', '7.3', '7.4', '8.0' ]
-        wordpress: [ '5.7', '5.8', '5.9', '6.0', '6.1', '6.2' ]
+        php: [ '7.1', '7.4', '8.0', '8.2' ]
+        wordpress: [ '5.7', '6.2' ]
         allowed_failure: [ false ]
         include:
-          - php: "8.0"
+          - php: '8.0'
             # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-            composer-options: "--ignore-platform-reqs"
+            composer-options: '--ignore-platform-reqs'
             extensions: pcov
             ini-values: pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
             coverage: pcov
+            allowed_failure: false
+          - php: '8.2'
+            wordpress: 'trunk'
+            allowed_failure: true
+        exclude:
+          - php: '8.2'
+            wordpress: '6.0'
       fail-fast: false
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules/
 /vendor/
 /.phpcs.xml
+/.phpunit.result.cache
 /composer.lock
 /phpcs.xml
 /phpunit.xml

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 
@@ -10,9 +10,12 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
 
 download() {
     if [ `which curl` ]; then
@@ -22,8 +25,21 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
-	WP_TESTS_TAG="tags/$WP_VERSION"
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
 else
 	# http serves a single offer, whereas https serves multiple. we only want one
 	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
@@ -35,7 +51,6 @@ else
 	fi
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
-
 set -ex
 
 install_wp() {
@@ -46,22 +61,44 @@ install_wp() {
 
 	mkdir -p $WP_CORE_DIR
 
-	if [ $WP_VERSION == 'latest' ]; then
-		local ARCHIVE_NAME='latest'
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-trunk
+		rm -rf $TMPDIR/wordpress-trunk/*
+		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
 	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
-
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
 	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
+		local ioption='-i.bak'
 	else
 		local ioption='-i'
 	fi
@@ -70,14 +107,17 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		rm -rf $WP_TESTS_DIR/{includes,data}
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
-
-	cd $WP_TESTS_DIR
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
@@ -86,7 +126,29 @@ install_test_suite() {
 
 }
 
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
+		echo "Recreated the database ($DB_NAME)."
+	else
+		echo "Leaving the existing database ($DB_NAME) in place."
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
 install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
 	# parse DB_HOST for port or socket references
 	local PARTS=(${DB_HOST//\:/ })
 	local DB_HOSTNAME=${PARTS[0]};
@@ -104,7 +166,14 @@ install_db() {
 	fi
 
 	# create database
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	then
+		echo "Reinstalling will delete the existing test database ($DB_NAME)"
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		recreate_db $DELETE_EXISTING_DB
+	else
+		create_db
+	fi
 }
 
 install_wp

--- a/composer.json
+++ b/composer.json
@@ -58,11 +58,11 @@
       "bash bin/install-wp-tests.sh wordpress_test root root localhost"
     ],
     "integration": [
-      "@php ./vendor/bin/phpunit --testsuite WP_Tests"
+      "@php ./vendor/bin/phpunit --exclude=ms-required"
     ],
     "integration-ms": [
       "@putenv WP_MULTISITE=1",
-      "@composer integration"
+      "@php ./vendor/bin/phpunit --exclude=ms-excluded"
     ]
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
   "require-dev": {
     "automattic/vipwpcs": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+    "dms/phpunit-arraysubset-asserts": "^0.5.0",
     "php-parallel-lint/php-parallel-lint": "^1.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
     "squizlabs/php_codesniffer": "^3.5",
     "wp-coding-standards/wpcs": "^2.3.0",
-    "yoast/wp-test-utils": "^1.1",
-    "dms/phpunit-arraysubset-asserts": "^0.5.0"
+    "yoast/wp-test-utils": "^1.1"
   },
   "autoload": {
 		"classmap": [

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
     "php-parallel-lint/php-parallel-lint": "^1.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
     "squizlabs/php_codesniffer": "^3.5",
     "wp-coding-standards/wpcs": "^2.3.0",
-    "yoast/phpunit-polyfills": "^1.0.1"
+    "yoast/wp-test-utils": "^1.1"
   },
   "autoload": {
 		"classmap": [

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
     "squizlabs/php_codesniffer": "^3.5",
     "wp-coding-standards/wpcs": "^2.3.0",
-    "yoast/wp-test-utils": "^1.1"
+    "yoast/wp-test-utils": "^1.1",
+    "dms/phpunit-arraysubset-asserts": "^0.5.0"
   },
   "autoload": {
 		"classmap": [

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -130,7 +130,8 @@ class Endpoints {
 		$response = array();
 
 		$search  = strtolower( $request->get_param( 'q' ) );
-		$ignore  = explode( ',', $request->get_param( 'existing_authors' ) );
+		$ignorable = null === $request->get_param( 'existing_authors' ) ? '' : $request->get_param( 'existing_authors' );
+		$ignore  = explode( ',', $ignorable );
 		$authors = $this->coauthors->search_authors( $search, $ignore );
 
 		if ( ! empty( $authors ) ) {

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -140,9 +140,6 @@ class CoAuthors_Guest_Authors {
 		);
 		register_post_type( $this->post_type, $args );
 
-		// Some of the common sizes used by get_avatar
-		$this->avatar_sizes = array();
-
 		// Hacky way to remove the title and the editor
 		remove_post_type_support( $this->post_type, 'title' );
 		remove_post_type_support( $this->post_type, 'editor' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,18 @@
 <phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.6/phpunit.xsd"
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	beStrictAboutOutputDuringTests="true"
 	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	>
-	<php>
-		<const name="WP_TESTS_MULTISITE" value="1" />
-	</php>
+	convertNoticesToExceptions="true"
+	convertDeprecationsToExceptions="true"
+>
 	<testsuites>
-		<testsuite name="WP_Tests">
+		<testsuite name="default">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,20 +1,57 @@
 <?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package Automattic\LegacyRedirector
+ */
+
+use Yoast\WPTestUtils\WPIntegration;
+
+require_once dirname( dirname( __FILE__ ) ) . '/vendor/yoast/wp-test-utils/src/WPIntegration/bootstrap-functions.php';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
+
 if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
-// Load the composer autoloader.
-require_once __DIR__ . '/../vendor/autoload.php';
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
 
-require_once $_tests_dir . '/includes/functions.php';
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
 
+// Give access to tests_add_filter() function.
+require_once "{$_tests_dir}/includes/functions.php";
+
+/**
+ * Manually load the plugin being tested.
+ */
 function _manually_load_plugin() {
-	require dirname( __FILE__ ) . '/../co-authors-plus.php';
+	// Updated from default (__FILE__), since this bootstrap is an extra level down in tests/Integration/.
+	require dirname( dirname( __FILE__ ) ) . '/co-authors-plus.php';
 }
+
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
-require $_tests_dir . '/includes/bootstrap.php';
+// Make sure the Composer autoload file has been generated.
+WPIntegration\check_composer_autoload_exists();
 
-require dirname( __FILE__ ) . '/coauthorsplus-testcase.php';
+// Start up the WP testing environment.
+require "{$_tests_dir}/includes/bootstrap.php";
+
+/*
+ * Register the custom autoloader to overload the PHPUnit MockObject classes when running on PHP 8.
+ *
+ * This function has to be called _last_, after the WP test bootstrap to make sure it registers
+ * itself in FRONT of the Composer autoload (which also prepends itself to the autoload queue).
+ */
+WPIntegration\register_mockobject_autoloader();
+
+// Add custom test case.
+require __DIR__ . '/coauthorsplus-testcase.php';

--- a/tests/coauthorsplus-testcase.php
+++ b/tests/coauthorsplus-testcase.php
@@ -5,6 +5,16 @@ use CoAuthors\API\Endpoints;
  * Base unit test class for Co-Authors Plus
  */
 class CoAuthorsPlus_TestCase extends \Yoast\WPTestUtils\WPIntegration\TestCase {
+
+	/**
+	 * @var CoAuthors_Plus
+	 */
+	protected $_cap;
+	/**
+	 * @var Endpoints
+	 */
+	protected $_api;
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/coauthorsplus-testcase.php
+++ b/tests/coauthorsplus-testcase.php
@@ -4,7 +4,7 @@ use CoAuthors\API\Endpoints;
 /**
  * Base unit test class for Co-Authors Plus
  */
-class CoAuthorsPlus_TestCase extends WP_UnitTestCase {
+class CoAuthorsPlus_TestCase extends \Yoast\WPTestUtils\WPIntegration\TestCase {
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/coauthorsplus-testcase.php
+++ b/tests/coauthorsplus-testcase.php
@@ -5,8 +5,8 @@ use CoAuthors\API\Endpoints;
  * Base unit test class for Co-Authors Plus
  */
 class CoAuthorsPlus_TestCase extends \Yoast\WPTestUtils\WPIntegration\TestCase {
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		global $coauthors_plus;
 		$this->_cap = $coauthors_plus;

--- a/tests/test-author-queried-object.php
+++ b/tests/test-author-queried-object.php
@@ -18,14 +18,14 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 		/**
 		 * Set up
 		 */
-		$author1 = $this->factory->user->create( array( 'user_login' => 'msauthor1' ) );
-		$author2 = $this->factory->user->create( array( 'user_login' => 'msauthor2' ) );
-		$blog2   = $this->factory->blog->create( array( 'user_id' => $author1 ) );
+		$author1 = $this->factory()->user->create( array( 'user_login' => 'msauthor1' ) );
+		$author2 = $this->factory()->user->create( array( 'user_login' => 'msauthor2' ) );
+		$blog2   = $this->factory()->blog->create( array( 'user_id' => $author1 ) );
 
 		switch_to_blog( $blog2 );
 		$wp_rewrite->init();
 
-		$blog2_post1 = $this->factory->post->create(
+		$blog2_post1 = $this->factory()->post->create(
 			array(
 				'post_status'  => 'publish',
 				'post_content' => rand_str(),
@@ -83,7 +83,7 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 
 
 	/**
-	 * On author pages, when paginated, 
+	 * On author pages, when paginated,
 	 * if page number is outside the range, throws 404
 	 */
 	function test__author_non_existent_page_throws_404() {
@@ -92,12 +92,12 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 		/**
 		 * Set up
 		 */
-		$author = $this->factory->user->create( array( 'user_login' => 'author' ) );
-		$blog = $this->factory->blog->create( array( 'user_id' => $author ) );
-		
+		$author = $this->factory()->user->create( array( 'user_login' => 'author' ) );
+		$blog = $this->factory()->blog->create( array( 'user_id' => $author ) );
+
 		switch_to_blog($blog);
 		$wp_rewrite->init();
-	
+
 		/**
 		* Author non existent page throws 404
 		*/

--- a/tests/test-author-queried-object.php
+++ b/tests/test-author-queried-object.php
@@ -11,8 +11,11 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 	 * have at least one published post. This matches core behavior.
 	 *
 	 * @see https://core.trac.wordpress.org/changeset/27290
+	 *
+	 * @group ms-required
 	 */
 	function test__author_queried_object_fix() {
+
 		global $wp_rewrite, $coauthors_plus;
 
 		/**
@@ -78,37 +81,5 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( false, get_user_by( 'id', $author2 ) );
 
 		restore_current_blog();
-
-	}
-
-
-	/**
-	 * On author pages, when paginated,
-	 * if page number is outside the range, throws 404
-	 */
-	function test__author_non_existent_page_throws_404() {
-		global $wp_rewrite;
-
-		/**
-		 * Set up
-		 */
-		$author = $this->factory()->user->create( array( 'user_login' => 'author' ) );
-		$blog = $this->factory()->blog->create( array( 'user_id' => $author ) );
-
-		switch_to_blog($blog);
-		$wp_rewrite->init();
-
-		/**
-		* Author non existent page throws 404
-		*/
-	   $non_existent_page = 1000;
-	   $this->go_to( get_author_posts_url( $author ) . 'page/' . $non_existent_page );
-	   $this->assertQueryTrue( 'is_404' );
-
-		/**
-		* Author existent page loads
-		*/
-	   $this->go_to( get_author_posts_url( $author ) );
-	   $this->assertQueryTrue( 'is_archive', 'is_author' );
 	}
 }

--- a/tests/test-author-queries.php
+++ b/tests/test-author-queries.php
@@ -3,14 +3,14 @@
 class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 
 	public function test__author_arg__user_is_post_author_query_as_post_author() {
-		$author_id = $this->factory->user->create(
+		$author_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author    = get_userdata( $author_id );
-		$post_id   = $this->factory->post->create(
+		$post_id   = $this->factory()->post->create(
 			array(
 				'post_author' => $author_id,
 				'post_status' => 'publish',
@@ -32,14 +32,14 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test__author_arg__user_is_post_author() {
-		$author_id = $this->factory->user->create(
+		$author_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author    = get_userdata( $author_id );
-		$post_id   = $this->factory->post->create(
+		$post_id   = $this->factory()->post->create(
 			array(
 				'post_author' => $author_id,
 				'post_status' => 'publish',
@@ -59,14 +59,14 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test__author_name_arg__user_is_post_author() {
-		$author_id = $this->factory->user->create(
+		$author_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author    = get_userdata( $author_id );
-		$post_id   = $this->factory->post->create(
+		$post_id   = $this->factory()->post->create(
 			array(
 				'post_author' => $author_id,
 				'post_status' => 'publish',
@@ -86,14 +86,14 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test__author_name_arg__user_is_coauthor() {
-		$author1_id = $this->factory->user->create(
+		$author1_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author1    = get_userdata( $author1_id );
-		$author2_id = $this->factory->user->create(
+		$author2_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'superman',
@@ -101,7 +101,7 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 		);
 		$author2    = get_userdata( $author2_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $author1_id,
 				'post_status' => 'publish',
@@ -121,14 +121,14 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test__author_arg__user_is_coauthor__author_arg() {
-		$author1_id = $this->factory->user->create(
+		$author1_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author1    = get_userdata( $author1_id );
-		$author2_id = $this->factory->user->create(
+		$author2_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'superman',
@@ -136,7 +136,7 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 		);
 		$author2    = get_userdata( $author2_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $author1_id,
 				'post_status' => 'publish',
@@ -156,14 +156,14 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test__author_name_arg_plus_tax_query__user_is_post_author() {
-		$author_id = $this->factory->user->create(
+		$author_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author    = get_userdata( $author_id );
-		$post_id   = $this->factory->post->create(
+		$post_id   = $this->factory()->post->create(
 			array(
 				'post_author' => $author_id,
 				'post_status' => 'publish',
@@ -185,14 +185,14 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 	}
 
 	public function tests__author_name_arg_plus_tax_query__is_coauthor() {
-		$author1_id = $this->factory->user->create(
+		$author1_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'batman',
 			)
 		);
 		$author1    = get_userdata( $author1_id );
-		$author2_id = $this->factory->user->create(
+		$author2_id = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'superman',
@@ -200,7 +200,7 @@ class Test_Author_Queries extends CoAuthorsPlus_TestCase {
 		);
 		$author2    = get_userdata( $author2_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $author1_id,
 				'post_status' => 'publish',

--- a/tests/test-coauthors-endpoint.php
+++ b/tests/test-coauthors-endpoint.php
@@ -7,9 +7,9 @@ use CoAuthors\API\Endpoints;
  */
 class Test_Endpoints extends CoAuthorsPlus_TestCase {
 
-	public function setUp() {
+	public function set_up() {
 
-		parent::setUp();
+		parent::set_up();
 
 		global $coauthors_plus;
 

--- a/tests/test-coauthors-endpoint.php
+++ b/tests/test-coauthors-endpoint.php
@@ -7,6 +7,8 @@ use CoAuthors\API\Endpoints;
  */
 class Test_Endpoints extends CoAuthorsPlus_TestCase {
 
+	use \DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+
 	public function set_up() {
 
 		parent::set_up();

--- a/tests/test-coauthors-endpoint.php
+++ b/tests/test-coauthors-endpoint.php
@@ -13,35 +13,35 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 
 		global $coauthors_plus;
 
-		$this->author1 = $this->factory->user->create_and_get(
+		$this->author1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author1',
 			)
 		);
 
-		$this->author2 = $this->factory->user->create_and_get(
+		$this->author2 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author2',
 			)
 		);
 
-		$this->editor1 = $this->factory->user->create_and_get(
+		$this->editor1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'editor',
 				'user_login' => 'editor1',
 			)
 		);
 
-		$this->contributor1 = $this->factory->user->create_and_get(
+		$this->contributor1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'contributor',
 				'user_login' => 'contributor1',
 			)
 		);
 
-		$this->subscriber1 = $this->factory->user->create_and_get(
+		$this->subscriber1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'subscriber',
 				'user_login' => 'subscriber1',
@@ -62,7 +62,7 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 			)
 		);
 
-		$this->post = $this->factory->post->create_and_get(
+		$this->post = $this->factory()->post->create_and_get(
 			array(
 				'post_author'  => $this->author1->ID,
 				'post_status'  => 'publish',
@@ -210,7 +210,7 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 	 * @covers ::get_coauthors()
 	 */
 	public function test_authors_get_coauthors() {
-		$test_post = $this->factory->post->create_and_get(
+		$test_post = $this->factory()->post->create_and_get(
 			array(
 				'post_author'  => $this->author1->ID,
 				'post_status'  => 'publish',
@@ -241,7 +241,7 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 
 		wp_set_current_user( $this->editor1->ID );
 
-		$test_post = $this->factory->post->create_and_get(
+		$test_post = $this->factory()->post->create_and_get(
 			array(
 				'post_author'  => $this->author1->ID,
 				'post_status'  => 'publish',
@@ -267,7 +267,7 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test_can_edit_coauthors() {
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $this->editor1->ID,
 			)
@@ -296,7 +296,7 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 	}
 
 	public function test_can_edit_coauthors__with_post_param() {
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $this->editor1->ID,
 			)
@@ -334,7 +334,7 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 	 */
 	public function test_remove_author_link() {
 
-		$test_post = $this->factory->post->create_and_get(
+		$test_post = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $this->editor1->ID,
 				'post_status' => 'publish',

--- a/tests/test-coauthors-endpoint.php
+++ b/tests/test-coauthors-endpoint.php
@@ -9,6 +9,21 @@ class Test_Endpoints extends CoAuthorsPlus_TestCase {
 
 	use \DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 
+	private $author1;
+	private $author2;
+	private $editor1;
+	private $contributor1;
+	private $subscriber1;
+	/**
+	 * @var int|WP_Error
+	 */
+	private $coauthor1;
+	/**
+	 * @var int|WP_Error
+	 */
+	private $coauthor2;
+	private $post;
+
 	public function set_up() {
 
 		parent::set_up();

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -173,7 +173,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 		$fields = $guest_author_obj->get_guest_author_fields();
 
 		$this->assertNotEmpty( $fields );
-		$this->assertInternalType( 'array', $fields );
+		$this->assertIsArray( $fields );
 
 		$keys = wp_list_pluck( $fields, 'key' );
 
@@ -253,7 +253,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 		$linked_account_ids = wp_list_pluck( $linked_accounts, 'ID' );
 
 		$this->assertNotEmpty( $linked_accounts );
-		$this->assertInternalType( 'array', $linked_accounts );
+		$this->assertIsArray( $linked_accounts );
 		$this->assertTrue( in_array( $this->editor1->ID, $linked_account_ids, true ) );
 	}
 

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -8,26 +8,26 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 
 		parent::setUp();
 
-		$this->admin1  = $this->factory->user->create_and_get(
+		$this->admin1  = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'administrator',
 				'user_login' => 'admin1',
 			)
 		);
-		$this->author1 = $this->factory->user->create_and_get(
+		$this->author1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author1',
 			)
 		);
-		$this->editor1 = $this->factory->user->create_and_get(
+		$this->editor1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'editor',
 				'user_login' => 'editor1',
 			)
 		);
 
-		$this->post = $this->factory->post->create_and_get(
+		$this->post = $this->factory()->post->create_and_get(
 			array(
 				'post_author'  => $this->author1->ID,
 				'post_status'  => 'publish',
@@ -145,7 +145,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 
 		$this->assertNull( $guest_author_obj->get_guest_author_thumbnail( $guest_author, 0 ) );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/fixtures/dummy-attachment.png' );
+		$attachment_id = $this->factory()->attachment->create_upload_object( __DIR__ . '/fixtures/dummy-attachment.png' );
 
 		set_post_thumbnail( $guest_author->ID, $attachment_id );
 
@@ -765,7 +765,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 
 		$guest_author_obj = $coauthors_plus->guest_authors;
 
-		$author2           = $this->factory->user->create_and_get();
+		$author2           = $this->factory()->user->create_and_get();
 		$guest_author_id   = $guest_author_obj->create_guest_author_from_user_id( $author2->ID );
 		$guest_author      = $guest_author_obj->get_guest_author_by( 'ID', $guest_author_id );
 		$guest_author_term = $coauthors_plus->get_author_term( $guest_author );
@@ -789,7 +789,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 		$guest_author_obj = $coauthors_plus->guest_authors;
 
 		// Checks when reassign author is not exist.
-		$author2         = $this->factory->user->create_and_get();
+		$author2         = $this->factory()->user->create_and_get();
 		$guest_author_id = $guest_author_obj->create_guest_author_from_user_id( $author2->ID );
 
 		$response = $guest_author_obj->delete( $guest_author_id, 'test' );
@@ -809,7 +809,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 
 		$guest_author_obj = $coauthors_plus->guest_authors;
 
-		$author2            = $this->factory->user->create_and_get();
+		$author2            = $this->factory()->user->create_and_get();
 		$guest_author2_id   = $guest_author_obj->create_guest_author_from_user_id( $author2->ID );
 		$guest_author2      = $guest_author_obj->get_guest_author_by( 'ID', $guest_author2_id );
 		$guest_author2_term = $coauthors_plus->get_author_term( $guest_author2 );
@@ -835,12 +835,12 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 		$guest_admin_id = $guest_author_obj->create_guest_author_from_user_id( $this->admin1->ID );
 		$guest_admin    = $guest_author_obj->get_guest_author_by( 'ID', $guest_admin_id );
 
-		$author2            = $this->factory->user->create_and_get();
+		$author2            = $this->factory()->user->create_and_get();
 		$guest_author_id2   = $guest_author_obj->create_guest_author_from_user_id( $author2->ID );
 		$guest_author2      = $guest_author_obj->get_guest_author_by( 'ID', $guest_author_id2 );
 		$guest_author_term2 = $coauthors_plus->get_author_term( $guest_author2 );
 
-		$post = $this->factory->post->create_and_get(
+		$post = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $author2->ID,
 			)

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -4,9 +4,9 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 
 	use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
-	public function setUp() {
+	public function set_up() {
 
-		parent::setUp();
+		parent::set_up();
 
 		$this->admin1  = $this->factory()->user->create_and_get(
 			array(

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -402,7 +402,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 			$exception = $e;
 		}
 
-		$this->assertNotContains( esc_html( $expected ), $exception->getMessage() );
+		$this->assertStringNotContainsString( esc_html( $expected ), $exception->getMessage() );
 
 		// Restore $_POST from back up.
 		$_POST = $_post_backup;
@@ -457,7 +457,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 			$exception = $e;
 		}
 
-		$this->assertNotContains( esc_html( $expected ), $exception->getMessage() );
+		$this->assertStringNotContainsString( esc_html( $expected ), $exception->getMessage() );
 
 		// Restore current user from backup.
 		wp_set_current_user( $current_user );
@@ -511,7 +511,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 			$exception = $e;
 		}
 
-		$this->assertNotContains( esc_html( $expected ), $exception->getMessage() );
+		$this->assertStringNotContainsString( esc_html( $expected ), $exception->getMessage() );
 
 		// Restore current user from backup.
 		wp_set_current_user( $current_user );

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -4,6 +4,11 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 
 	use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
+	private $admin1;
+	private $author1;
+	private $editor1;
+	private $post;
+
 	public function set_up() {
 
 		parent::set_up();

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -2,9 +2,9 @@
 
 class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
-	public function setUp() {
+	public function set_up() {
 
-		parent::setUp();
+		parent::set_up();
 
 		$this->author1 = $this->factory()->user->create_and_get(
 			array(

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -2,6 +2,10 @@
 
 class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
+	private $author1;
+	private $editor1;
+	private $post;
+
 	public function set_up() {
 
 		parent::set_up();

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -69,7 +69,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$coauthor = $coauthors_plus->get_coauthor_by( 'id', $guest_author_id );
 
 		$this->assertInstanceOf( stdClass::class, $coauthor );
-		$this->assertObjectHasAttribute( 'ID', $coauthor );
+		$this->assertTrue( property_exists( $coauthor, 'ID' ) );
 		$this->assertEquals( $guest_author_id, $coauthor->ID );
 		$this->assertEquals( 'guest-author', $coauthor->type );
 	}
@@ -94,7 +94,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $user_login );
 
 		$this->assertInstanceOf( stdClass::class, $coauthor );
-		$this->assertObjectHasAttribute( 'ID', $coauthor );
+		$this->assertTrue( property_exists( $coauthor, 'ID' ) );
 		$this->assertEquals( $guest_author_id, $coauthor->ID );
 		$this->assertEquals( 'guest-author', $coauthor->type );
 	}
@@ -115,26 +115,26 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$coauthor = $coauthors_plus->get_coauthor_by( 'id', $this->author1->ID );
 
 		$this->assertInstanceOf( WP_User::class, $coauthor );
-		$this->assertObjectHasAttribute( 'ID', $coauthor );
+		$this->assertTrue( property_exists( $coauthor, 'ID' ) );
 		$this->assertEquals( $this->author1->ID, $coauthor->ID );
 		$this->assertEquals( 'wpuser', $coauthor->type );
 
 		$coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $this->author1->user_login );
 
 		$this->assertInstanceOf( WP_User::class, $coauthor );
-		$this->assertObjectHasAttribute( 'user_login', $coauthor->data );
+		$this->assertTrue( property_exists( $coauthor->data, 'user_login' ) );
 		$this->assertEquals( $this->author1->user_login, $coauthor->user_login );
 
 		$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $this->author1->user_nicename );
 
 		$this->assertInstanceOf( WP_User::class, $coauthor );
-		$this->assertObjectHasAttribute( 'user_nicename', $coauthor->data );
+		$this->assertTrue( property_exists( $coauthor->data, 'user_nicename' ) );
 		$this->assertEquals( $this->author1->user_nicename, $coauthor->user_nicename );
 
 		$coauthor = $coauthors_plus->get_coauthor_by( 'user_email', $this->author1->user_email );
 
 		$this->assertInstanceOf( WP_User::class, $coauthor );
-		$this->assertObjectHasAttribute( 'user_email', $coauthor->data );
+		$this->assertTrue( property_exists( $coauthor->data, 'user_email' ) );
 		$this->assertEquals( $this->author1->user_email, $coauthor->user_email );
 
 		remove_filter( 'coauthors_guest_authors_enabled', '__return_false' );
@@ -144,7 +144,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$coauthor = $coauthors_plus->get_coauthor_by( 'id', $this->editor1->ID );
 
 		$this->assertInstanceOf( stdClass::class, $coauthor );
-		$this->assertObjectHasAttribute( 'linked_account', $coauthor );
+		$this->assertTrue( property_exists( $coauthor, 'linked_account' ) );
 		$this->assertEquals( $this->editor1->user_login, $coauthor->linked_account );
 	}
 

--- a/tests/test-coauthors-plus.php
+++ b/tests/test-coauthors-plus.php
@@ -6,20 +6,20 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 
 		parent::setUp();
 
-		$this->author1 = $this->factory->user->create_and_get(
+		$this->author1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author1',
 			)
 		);
-		$this->editor1 = $this->factory->user->create_and_get(
+		$this->editor1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'editor',
 				'user_login' => 'editor1',
 			)
 		);
 
-		$this->post = $this->factory->post->create_and_get(
+		$this->post = $this->factory()->post->create_and_get(
 			array(
 				'post_author'  => $this->author1->ID,
 				'post_status'  => 'publish',
@@ -217,7 +217,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertTrue( $coauthors_plus->current_user_can_set_authors() );
 
 		// Checks when current user is admin.
-		$admin1 = $this->factory->user->create_and_get(
+		$admin1 = $this->factory()->user->create_and_get(
 			array(
 				'role' => 'administrator',
 			)
@@ -244,7 +244,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$current_user = get_current_user_id();
 
 		// Checking when current user is subscriber and filter is true/false.
-		$subscriber1 = $this->factory->user->create_and_get(
+		$subscriber1 = $this->factory()->user->create_and_get(
 			array(
 				'role' => 'subscriber',
 			)
@@ -283,14 +283,14 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$current_user = get_current_user_id();
 
 		// Set up test post
-		$admin_user = $this->factory->user->create_and_get(
+		$admin_user = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'administrator',
 				'user_login' => 'admin1',
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $admin_user->ID,
 				'post_status' => 'publish',
@@ -335,7 +335,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertArrayHasKey( $this->editor1->user_login, $authors );
 
 		// Checks when search term is empty and any subscriber exists.
-		$subscriber1 = $this->factory->user->create_and_get(
+		$subscriber1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'subscriber',
 				'user_login' => 'subscriber1',
@@ -348,7 +348,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertArrayNotHasKey( $subscriber1->user_login, $authors );
 
 		// Checks when search term is empty and any contributor exists.
-		$contributor1 = $this->factory->user->create_and_get(
+		$contributor1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'contributor',
 				'user_login' => 'contributor1',
@@ -406,7 +406,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertArrayNotHasKey( 'admin', $authors );
 
 		// Checks when any subscriber exists using ID but not author.
-		$subscriber1 = $this->factory->user->create_and_get(
+		$subscriber1 = $this->factory()->user->create_and_get(
 			array(
 				'role' => 'subscriber',
 			)
@@ -433,7 +433,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
 
 		// Checks when ignoring author1 but also exists one more author with similar kind of data.
-		$author2 = $this->factory->user->create_and_get(
+		$author2 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author2',
@@ -469,7 +469,7 @@ class Test_CoAuthors_Plus extends CoAuthorsPlus_TestCase {
 		$this->assertEmpty( $coauthors_plus->search_authors( $this->author1->ID, $ignored_authors ) );
 
 		// Checks when ignoring author1 but also exists one more author with similar kind of data.
-		$author2 = $this->factory->user->create_and_get(
+		$author2 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author2',

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -2,6 +2,26 @@
 
 class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
+	private $admin1;
+	private $author1;
+	private $editor1;
+	/**
+	 * @var int|WP_Error
+	 */
+	private $author1_post1;
+	/**
+	 * @var int|WP_Error
+	 */
+	private $author1_post2;
+	/**
+	 * @var int|WP_Error
+	 */
+	private $author1_page1;
+	/**
+	 * @var int|WP_Error
+	 */
+	private $author1_page2;
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -2,8 +2,8 @@
 
 class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->admin1  = $this->factory()->user->create(
 			array(
@@ -65,8 +65,8 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		$this->author1_page2 = wp_insert_post( $page );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/test-manage-coauthors.php
+++ b/tests/test-manage-coauthors.php
@@ -5,19 +5,19 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->admin1  = $this->factory->user->create(
+		$this->admin1  = $this->factory()->user->create(
 			array(
 				'role'       => 'administrator',
 				'user_login' => 'admin1',
 			)
 		);
-		$this->author1 = $this->factory->user->create(
+		$this->author1 = $this->factory()->user->create(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author1',
 			)
 		);
-		$this->editor1 = $this->factory->user->create(
+		$this->editor1 = $this->factory()->user->create(
 			array(
 				'role'       => 'editor',
 				'user_login' => 'editor2',
@@ -184,7 +184,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $this->author1,
 				'post_type'   => 'attachment',
@@ -239,7 +239,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		global $coauthors_plus;
 
-		$user_id = $this->factory->user->create(
+		$user_id = $this->factory()->user->create(
 			array(
 				'user_login'    => 'test_admin',
 				'user_nicename' => 'test_admiи',
@@ -258,7 +258,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 			$user->user_nicename,
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $user_id,
 			)
@@ -385,7 +385,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $this->author1,
 				'post_type'   => 'attachment',
@@ -414,7 +414,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 		$admin1  = get_user_by( 'id', $this->admin1 );
 		$author1 = get_user_by( 'id', $this->author1 );
 
-		$post_id = $this->factory->post->create(
+		$post_id = $this->factory()->post->create(
 			array(
 				'post_author' => $this->admin1,
 			)
@@ -455,7 +455,7 @@ class Test_Manage_CoAuthors extends CoAuthorsPlus_TestCase {
 
 		global $coauthors_plus;
 
-		$post_id = $this->factory->post->create();
+		$post_id = $this->factory()->post->create();
 		$post    = get_post( $post_id );
 
 		$coauthors_plus->coauthors_update_post( $post_id, $post );

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -4,9 +4,9 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 	use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
-	public function setUp() {
+	public function set_up() {
 
-		parent::setUp();
+		parent::set_up();
 
 		/**
 		 * When 'coauthors_auto_apply_template_tags' is set to true,

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -4,6 +4,10 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 	use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
+	private $author1;
+	private $editor1;
+	private $post;
+
 	public function set_up() {
 
 		parent::set_up();
@@ -718,6 +722,15 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 	 * @covers ::coauthors_links_single()
 	 */
 	public function test_coauthors_links_single_when_url_not_exist() {
+		global $wp_version;
+		if ( PHP_VERSION_ID >= 80100 && version_compare( $wp_version, '6.3.0', '<' ) ) {
+			/*
+			 * Ignoring PHP 8.1 "null to non-nullable" deprecation that is fixed in WP 6.3.
+			 *
+			 * @see https://core.trac.wordpress.org/ticket/58157
+			*/
+			$this->markTestSkipped( 'PHP 8.1 gives a deprecation notice that is fixed in WP 6.3' );
+		}
 
 		global $post, $authordata;
 

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -831,8 +831,8 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$coauthors = coauthors_wp_list_authors( $args );
 
-		$this->assertNotContains( 'href="' . get_author_posts_url( $this->editor1->ID, $this->editor1->user_nicename ) . '"', $coauthors );
-		$this->assertNotContains( $this->editor1->display_name, $coauthors );
+		$this->assertStringNotContainsString( 'href="' . get_author_posts_url( $this->editor1->ID, $this->editor1->user_nicename ) . '"', $coauthors );
+		$this->assertStringNotContainsString( $this->editor1->display_name, $coauthors );
 
 		$coauthors_plus->add_coauthors( $this->post->ID, array( $this->editor1->user_login ), true );
 
@@ -1003,8 +1003,8 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 			)
 		);
 
-		$this->assertNotContains( '<li>', $coauthors );
-		$this->assertNotContains( '</li>', $coauthors );
+		$this->assertStringNotContainsString( '<li>', $coauthors );
+		$this->assertStringNotContainsString( '</li>', $coauthors );
 	}
 
 	/**

--- a/tests/test-template-tags.php
+++ b/tests/test-template-tags.php
@@ -15,20 +15,20 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		global $coauthors_plus_template_filters;
 		$coauthors_plus_template_filters = new CoAuthors_Template_Filters();
 
-		$this->author1 = $this->factory->user->create_and_get(
+		$this->author1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'author',
 				'user_login' => 'author1',
 			)
 		);
-		$this->editor1 = $this->factory->user->create_and_get(
+		$this->editor1 = $this->factory()->user->create_and_get(
 			array(
 				'role'       => 'editor',
 				'user_login' => 'editor1',
 			)
 		);
 
-		$this->post = $this->factory->post->create_and_get(
+		$this->post = $this->factory()->post->create_and_get(
 			array(
 				'post_author'  => $this->author1->ID,
 				'post_status'  => 'publish',
@@ -190,7 +190,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 	 */
 	public function test_get_coauthors_when_terms_for_post_not_exists() {
 
-		$post_id = $this->factory->post->create();
+		$post_id = $this->factory()->post->create();
 		$this->assertEmpty( get_coauthors( $post_id ) );
 	}
 
@@ -206,12 +206,12 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Backing up global post.
 		$post_backup = $post;
 
-		$post = $this->factory->post->create_and_get();
+		$post = $this->factory()->post->create_and_get();
 
 		$this->assertEmpty( get_coauthors() );
 
-		$user_id = $this->factory->user->create();
-		$post    = $this->factory->post->create_and_get(
+		$user_id = $this->factory()->user->create();
+		$post    = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $user_id,
 			)
@@ -232,7 +232,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		global $coauthors_plus;
 
-		$post_id = $this->factory->post->create();
+		$post_id = $this->factory()->post->create();
 
 		// Checks when no author exist.
 		$this->assertEmpty( get_coauthors( $post_id ) );
@@ -246,7 +246,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( $expected, wp_list_pluck( get_coauthors( $post_id ), 'user_login' ) );
 
 		// Checks coauthors order after modifying.
-		$post_id = $this->factory->post->create();
+		$post_id = $this->factory()->post->create();
 
 		$coauthors_plus->add_coauthors( $post_id, array( $this->editor1->user_login ), true );
 		$coauthors_plus->add_coauthors( $post_id, array( $this->author1->user_login ), true );
@@ -439,12 +439,12 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		// Checking when first name is set for user.
 		$first_name = 'Test';
-		$user_id    = $this->factory->user->create(
+		$user_id    = $this->factory()->user->create(
 			array(
 				'first_name' => $first_name,
 			)
 		);
-		$post       = $this->factory->post->create_and_get(
+		$post       = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $user_id,
 			)
@@ -494,12 +494,12 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		// Checking when last name is set for user.
 		$last_name = 'Test';
-		$user_id   = $this->factory->user->create(
+		$user_id   = $this->factory()->user->create(
 			array(
 				'last_name' => $last_name,
 			)
 		);
-		$post      = $this->factory->post->create_and_get(
+		$post      = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $user_id,
 			)
@@ -549,12 +549,12 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		// Checking when nickname is set for user.
 		$nick_name = 'Test';
-		$user_id   = $this->factory->user->create(
+		$user_id   = $this->factory()->user->create(
 			array(
 				'nickname' => $nick_name,
 			)
 		);
-		$post      = $this->factory->post->create_and_get(
+		$post      = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $user_id,
 			)
@@ -602,12 +602,12 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		$this->assertEquals( '<span>' . $this->author1->user_email . '</span><span>' . $this->editor1->user_email . '</span>', $emails );
 
 		$email   = 'test@example.org';
-		$user_id = $this->factory->user->create(
+		$user_id = $this->factory()->user->create(
 			array(
 				'user_email' => $email,
 			)
 		);
-		$post    = $this->factory->post->create_and_get(
+		$post    = $this->factory()->post->create_and_get(
 			array(
 				'post_author' => $user_id,
 			)
@@ -688,7 +688,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		// Backing up global author data.
 		$authordata_backup = $authordata;
 
-		$user_id = $this->factory->user->create(
+		$user_id = $this->factory()->user->create(
 			array(
 				'user_url' => 'example.org',
 			)
@@ -886,14 +886,14 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 
 		$this->assertStringContainsString( $this->author1->display_name, coauthors_wp_list_authors( $args ) );
 
-		$user = $this->factory->user->create_and_get(
+		$user = $this->factory()->user->create_and_get(
 			array(
 				'first_name' => 'First',
 				'last_name'  => 'Last',
 			)
 		);
 
-		$this->factory->post->create(
+		$this->factory()->post->create(
 			array(
 				'post_author' => $user->ID,
 			)
@@ -1089,7 +1089,7 @@ class Test_Template_Tags extends CoAuthorsPlus_TestCase {
 		);
 
 		$guest_author  = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
-		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/fixtures/dummy-attachment.png', $guest_author_id );
+		$attachment_id = $this->factory()->attachment->create_upload_object( __DIR__ . '/fixtures/dummy-attachment.png', $guest_author_id );
 
 		$this->assertEquals( preg_match( "|^<img alt='[^']*' src='[^']*' srcset='[^']*' class='[^']*' height='[^']*' width='[^']*'( loading='[^']*')?( decoding='[^']*')?/>$|", coauthors_get_avatar( $guest_author ) ), 1 );
 


### PR DESCRIPTION
## Description

Update the integrations tests and CI process to cover newer PHP versions.

- Introduce Yoast/WP-Test-Utils and PHPUnit 9.
- Update the prepare test script and bootstrap files.
- Fix up incorrect uses of factory property to use a `factory()` method.
- Update deprecated or removed assertions.
- Refresh the PHPUnit config.
- Identify multisite-specific tests via `@group` instead of skipping tests.
- Apply fixes for running under PHP 8.1 and 8.2, including defining dynamic properties.
- Remove a test that wasn't testing anything about CAP.
- Update the CI test matrix to cover highest and lowest WP version, and highest and lowest PHP 7.x and 8.x versions.

## Deploy Notes

None.

## Steps to Test

See [this action](https://github.com/Automattic/Co-Authors-Plus/actions/runs/5644991915/job/15289890882).