### PR TITLE
3.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog for Co-Authors Plus
 
+**3.5.11 (Jul 24, 2023)**
+* Author select improvements #924
+* Show author taxonomy in REST API, hide description based on capabilities #931
+  * The author taxonomy was first added to the REST API in CAP 3.5.0, then removed in 3.5.2 over concerns of author email addresses being visible in the description. This adds it back but with the description hidden by default (filterable).
+* Guest Authors: Add labels property #942
+* Define dynamic guest_authors property #947
+* Bump NPM dependencies #927 #933 #943 #944
+* Workflows: Fix runner image and matrix #946
+* CI: Split out CS and update integration tests workflow #948
+* Improve tests setup #949
+
 **3.5.10 (Jan 24, 2023)**
 * Fix: Authors not being updated properly in the editor #920
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 * Contributors: batmoo, danielbachhuber, automattic
 * Tags: authors, users, multiple authors, co-authors, multi-author, publishing
-* Tested up to: 6.1
+* Tested up to: 6.2
 * Requires at least: 4.1
-* Stable tag: 3.5.10
+* Stable tag: 3.5.11
 
 Assign multiple bylines to posts, pages, and custom post types with a search-as-you-type input box.
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -3,7 +3,7 @@
 Plugin Name: Co-Authors Plus
 Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
 Description: Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
-Version: 3.5.10
+Version: 3.5.11
 Author: Mohammad Jangda, Daniel Bachhuber, Automattic
 Copyright: 2008-2015 Shared and distributed between Mohammad Jangda, Daniel Bachhuber, Weston Ruter
 
@@ -32,7 +32,7 @@ Co-author - in the context of a single post, a guest author or user assigned to 
 Author - user with the role of author
 */
 
-define( 'COAUTHORS_PLUS_VERSION', '3.5.10' );
+define( 'COAUTHORS_PLUS_VERSION', '3.5.11' );
 
 require_once dirname( __FILE__ ) . '/template-tags.php';
 require_once dirname( __FILE__ ) . '/deprecated.php';

--- a/readme.txt
+++ b/readme.txt
@@ -11,9 +11,9 @@ Assign multiple bylines to posts, pages, and custom post types via a search-as-y
 
 Assign multiple bylines to posts, pages, and custom post types via a search-as-you-type input box. Co-authored posts appear on a co-author's archive page and in their feed. Co-authors may edit the posts they are associated with, and co-authors who are contributors may only edit posts if they have not been published (as is core behavior).
 
-Add writers as bylines without creating WordPress user accounts. Simply [create a guest author profile](http://vip.wordpress.com/documentation/add-guest-bylines-to-your-content-with-co-authors-plus/) for the writer and assign the byline as you normally would.
+Add writers as bylines without creating WordPress user accounts. Simply [create a guest author profile](https://github.com/Automattic/Co-Authors-Plus/wiki/Creating-and-editing-guest-authors) for the writer and assign the byline as you normally would.
 
-On the frontend, use the [Co-Authors Plus template tags](http://vip.wordpress.com/documentation/incorporate-co-authors-plus-template-tags-into-your-theme/) to list co-authors anywhere you'd normally list the author.
+On the frontend, use the [Co-Authors Plus template tags](https://github.com/Automattic/Co-Authors-Plus/wiki/Template-tags) to list co-authors anywhere you'd normally list the author.
 
 This plugin is an almost complete rewrite of the [Co-Authors](https://wordpress.org/plugins/co-authors/) plugin originally developed by Weston Ruter (2007). The original plugin was inspired by the '[Multiple Authors](https://txfx.net/2005/08/16/new-plugin-multiple-authors/)' plugin by Mark Jaquith (2005).
 
@@ -21,7 +21,7 @@ This plugin is an almost complete rewrite of the [Co-Authors](https://wordpress.
 
 = How do I add Co-Authors Plus support to my theme? =
 
-If you've just installed Co-Authors Plus, you might notice that the bylines are being added in the backend but aren't appearing on the frontend. You'll need to [add the template tags to your theme](http://vip.wordpress.com/documentation/incorporate-co-authors-plus-template-tags-into-your-theme/) before the bylines will appear.
+If you've just installed Co-Authors Plus, you might notice that the bylines are being added in the backend but aren't appearing on the frontend. You'll need to [add the template tags to your theme](https://github.com/Automattic/Co-Authors-Plus/wiki/Template-tags) before the bylines will appear.
 
 = What happens to posts and pages when I delete a user assigned to a post or page as a coauthor? =
 
@@ -51,7 +51,7 @@ Yep! Guest authors can be disabled entirely through an apt filter. Having the fo
 1. IMPORTANT: Please disable the original Co-Authors plugin (if you are using it) before installing Co-Authors Plus
 2. Extract the coauthors-plus.zip file and upload its contents to the `/wp-content/plugins/` directory. Alternately, you can install directly from the Plugin directory within your WordPress Install.
 3. Activate the plugin through the "Plugins" menu in WordPress.
-4. Place the appropriate [co-authors template tags](http://vip.wordpress.com/documentation/incorporate-co-authors-plus-template-tags-into-your-theme/) in your template.
+4. Place the appropriate [co-authors template tags](https://github.com/Automattic/Co-Authors-Plus/wiki/Template-tags) in your template.
 5. Add co-authors to your posts and pages.
 
 == Screenshots ==

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Co-Authors Plus ===
 Contributors: batmoo, danielbachhuber, automattic
 Tags: authors, users, multiple authors, coauthors, multi-author, publishing
-Tested up to: 6.1
+Tested up to: 6.2
 Requires at least: 4.1
-Stable tag: 3.5.10
+Stable tag: 3.5.11
 
 Assign multiple bylines to posts, pages, and custom post types via a search-as-you-type input box
 
@@ -62,7 +62,14 @@ Yep! Guest authors can be disabled entirely through an apt filter. Having the fo
 
 == Changelog ==
 
-= 3.5.10 (Jan 24, 2023) =
-* Fix: Authors not being updated properly in the editor #920
+= 3.5.11 (Jul 24, 2023) =
+* Author select improvements #924
+* Show author taxonomy in REST API, hide description based on capabilities #931
+* Guest Authors: Add labels property #942
+* Define dynamic guest_authors property #947
+* Bump NPM dependencies #927 #933 #943 #944
+* Workflows: Fix runner image and matrix #946
+* CI: Split out CS and update integration tests workflow #948
+* Improve tests setup #949
 
 For all previous changes, [view the Changelog](https://github.com/Automattic/Co-Authors-Plus/blob/master/CHANGELOG.md)


### PR DESCRIPTION
## Description

3.5.11 release.

## Deploy Notes

Should deploy to WordPress.org automatically.

## Steps to Test

Only version changes and docs update - nothing to test really.