### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for CAP using Composer, use `--prefer-source`.
+# https://blog.madewithlove.be/post/gitattributes/
+
+/.github/         export-ignore
+/bin/             export-ignore
+/src/__mocks__/   export-ignore
+/src/__tests__/   export-ignore
+/tests/           export-ignore
+/.distignore      export-ignore
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.phpcs.xml.dist  export-ignore
+/phpunit.xml.dist export-ignore
+/CHANGELOG.md     export-ignore
+/phpunit.xml.dist export-ignore
+
+# Auto detect text files and perform LF normalization
+# https://pablorsk.medium.com/be-a-git-ninja-the-gitattributes-file-e58c07c9e915
+
+* text=auto
+
+# The above will handle all files NOT found below
+
+*.md text
+*.php text
+*.inc text


### PR DESCRIPTION
## Description

This removes development files and folders from release archives, and makes them unavailable when using Composer with `--prefer-dist`.

## Deploy Notes

None.

## Steps to Test

Run:
 ```sh
cd /tmp && composer require --prefer-dist automattic/co-authors-plus:dev-add/gitattributes-file && cd wp-content/plugins/co-authors-plus
```

...and note that the development files are not present.
