### PR TITLE
Issue#958/ unable to change avatar images sizes

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -56,8 +56,6 @@ class CoAuthors_Plus {
 	var $coauthors_meta_box_name   = 'coauthorsdiv';
 	var $force_guest_authors       = false;
 
-	var $gravatar_size = 25;
-
 	var $_pages_whitelist = array( 'post.php', 'post-new.php', 'edit.php' );
 
 	var $supported_post_types = array();
@@ -449,7 +447,7 @@ class CoAuthors_Plus {
 					$avatar_url = get_avatar_url( $coauthor->ID );
 					?>
 					<li>
-						<?php echo get_avatar( $coauthor->ID, $this->gravatar_size ); ?>
+						<?php echo get_avatar( $coauthor->ID ); ?>
 						<span id="<?php echo esc_attr( 'coauthor-readonly-' . $count ); ?>" class="coauthor-tag">
 							<input type="text" name="coauthorsinput[]" readonly="readonly" value="<?php echo esc_attr( $coauthor->display_name ); ?>" />
 							<input type="text" name="coauthors[]" value="<?php echo esc_attr( $coauthor->user_login ); ?>" />

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1839,7 +1839,7 @@ class CoAuthors_Plus {
 		$coauthor = $this->get_coauthor_by( 'id', $id );
 		if ( false !== $coauthor && isset( $coauthor->type ) && 'guest-author' === $coauthor->type ) {
 			if ( has_post_thumbnail( $id ) ) {
-				$args['url'] = get_the_post_thumbnail_url( $id, $this->gravatar_size );
+				$args['url'] = get_the_post_thumbnail_url( $id, array( $args['width'], $args['height'] ) );
 			} elseif ( isset( $coauthor->user_email ) ) {
 				$args['url'] = get_avatar_url( $coauthor->user_email );
 			} else {

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1841,9 +1841,9 @@ class CoAuthors_Plus {
 			if ( has_post_thumbnail( $id ) ) {
 				$args['url'] = get_the_post_thumbnail_url( $id, array( $args['width'], $args['height'] ) );
 			} elseif ( isset( $coauthor->user_email ) ) {
-				$args['url'] = get_avatar_url( $coauthor->user_email );
+				$args['url'] = get_avatar_url( $coauthor->user_email, $args );
 			} else {
-				$args['url'] = get_avatar_url( '' ); // Fallback to default.
+				$args['url'] = get_avatar_url( '', $args ); // Fallback to default.
 			}
 		}
 		return $args;

--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -102,6 +102,8 @@
 		}
 		#coauthors-readonly ul li .avatar {
 			float: left;
+			width: 25px;
+			height: 25px;
 		}
 		#coauthors-readonly ul li .coauthor-tag {
 			display:block;


### PR DESCRIPTION
## Description

Resolves #958 
#854 may also be resolved by this

- Updated `filter_pre_get_avatar_data_url` so it passes the requested width and height arguments to `get_the_post_thumbnail_url`
  - Ensures the requested avatar size ( or the closest your particular combination of theme and hosting environment can produce ) is applied to a guest author's feature image.
- Updated `filter_pre_get_avatar_data_url` so it passes the same arguments it received when recursively calling `get_avatar_url`
  - Ensures the requested avatar size is applied to Gravatar images rather than reverting to the default.

## Steps to Test

- Add the Post Author block to a post or template.
  - Any changes to the Avatar Size should be reflected in the rendered content.
- Inspect the response to a request for `/wp-json/wp/v2/users/:user-id/` from the block editor.
  - The URLs in the `avatar_urls` object should match their associated keys. For example the default sizes: 24, 48, 96
- Inspect the response to a request for `/wp-json/coauthors/v1/authors/:post-id/` from the block editor.
  - For authors using gravatar, the avatar should use the default size of 96px.
  - For guest authors using a feature image, the value should use the closest available size to 96px.
- Inspect the classic editor coauthor meta box.
  - For authors using gravatar, the avatar should use the default size of 96px.
  - For guest authors using a feature image, the value should use the closest available size to 96px. 
- Use your browser's dev tools to turn off JavaScript and open a post in the classic editor.
  - The coauthor avatars in `#coauthors-readonly` should be constrained to 25px through CSS.