### PR TITLE
Improve I18n strings

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,6 +8,13 @@
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="co-authors-plus"/>
+			</property>
+		</properties>
+	</rule>
 
 	<rule ref="PHPCompatibilityWP"/>
 	<config name="testVersion" value="7.2-"/>

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1795,6 +1795,7 @@ class CoAuthors_Plus {
 		$author_slug = sanitize_user( get_query_var( 'author_name' ) );
 		$author      = $this->get_coauthor_by( 'user_nicename', $author_slug );
 
+		/* translators: Author display name. */
 		return sprintf( __( 'Author: %s' ), $author->display_name );
 	}
 
@@ -1840,11 +1841,11 @@ class CoAuthors_Plus {
 		if ( ! $id || ! $this->is_guest_authors_enabled() || ! is_numeric( $id ) || isset( $args['url'] ) ) {
 			return $args;
 		}
-		
+
 		// Do not filter the icon in the admin bar
 		if ( doing_filter( 'admin_bar_menu' ) ) {
 			return $args;
-		} 
+		}
 
 		// Do not filter when we have a WordPress user sent from CAP meta box
 		if ( isset( $args['user_type'] ) && 'wp-user' === $args['user_type'] ) {
@@ -1857,7 +1858,7 @@ class CoAuthors_Plus {
 			return $args;
 		}
 
-		
+
 		$coauthor = $this->get_coauthor_by( 'id', $id );
 		if ( false !== $coauthor && isset( $coauthor->type ) && 'guest-author' === $coauthor->type ) {
 			if ( has_post_thumbnail( $id ) ) {
@@ -1953,29 +1954,37 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 			}
 
 			if ( 'comment' == $comment_type ) {
+				/* translators: Post title. */
 				$notify_message = sprintf( __( 'New comment on your post "%s"' ), $post->post_title ) . "\r\n";
 				/* translators: 1: comment author, 2: author IP, 3: author domain */
 				$notify_message .= sprintf( __( 'Author : %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+				/* translators: Comment author emal address. */
 				$notify_message .= sprintf( __( 'E-mail : %s' ), $comment->comment_author_email ) . "\r\n";
+				/* translators: Comment author URL. */
 				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
+				/* translators: Comment author IP address. */
 				$notify_message .= sprintf( __( 'Whois  : http://whois.arin.net/rest/ip/%s' ), $comment->comment_author_IP ) . "\r\n";
 				$notify_message .= __( 'Comment: ' ) . "\r\n" . $comment->comment_content . "\r\n\r\n";
 				$notify_message .= __( 'You can see all comments on this post here: ' ) . "\r\n";
 				/* translators: 1: blog name, 2: post title */
 				$subject = sprintf( __( '[%1$s] Comment: "%2$s"' ), $blogname, $post->post_title );
 			} elseif ( 'trackback' == $comment_type ) {
+				/* translators: Post title. */
 				$notify_message = sprintf( __( 'New trackback on your post "%s"' ), $post->post_title ) . "\r\n";
-				/* translators: 1: website name, 2: author IP, 3: author domain */
+				/* translators: 1: comment author, 2: author IP, 3: author domain */
 				$notify_message .= sprintf( __( 'Website: %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+				/* translators: Comment author URL. */
 				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
 				$notify_message .= __( 'Excerpt: ' ) . "\r\n" . $comment->comment_content . "\r\n\r\n";
 				$notify_message .= __( 'You can see all trackbacks on this post here: ' ) . "\r\n";
 				/* translators: 1: blog name, 2: post title */
 				$subject = sprintf( __( '[%1$s] Trackback: "%2$s"' ), $blogname, $post->post_title );
 			} elseif ( 'pingback' == $comment_type ) {
+				/* translators: Post title. */
 				$notify_message = sprintf( __( 'New pingback on your post "%s"' ), $post->post_title ) . "\r\n";
 				/* translators: 1: comment author, 2: author IP, 3: author domain */
 				$notify_message .= sprintf( __( 'Website: %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+				/* translators: Comment author URL. */
 				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
 				$notify_message .= __( 'Excerpt: ' ) . "\r\n" . sprintf( '[...] %s [...]', $comment->comment_content ) . "\r\n\r\n";
 				$notify_message .= __( 'You can see all pingbacks on this post here: ' ) . "\r\n";
@@ -1983,12 +1992,16 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 				$subject = sprintf( __( '[%1$s] Pingback: "%2$s"' ), $blogname, $post->post_title );
 			}
 			$notify_message .= get_permalink( $comment->comment_post_ID ) . "#comments\r\n\r\n";
+			/* translators: Comment URL. */
 			$notify_message .= sprintf( __( 'Permalink: %s' ), get_permalink( $comment->comment_post_ID ) . '#comment-' . $comment_id ) . "\r\n";
 			if ( EMPTY_TRASH_DAYS ) {
+				/* translators: URL for trashing a comment. */
 				$notify_message .= sprintf( __( 'Trash it: %s' ), admin_url( "comment.php?action=trash&c=$comment_id" ) ) . "\r\n";
 			} else {
+				/* translators: URL for deleting a comment. */
 				$notify_message .= sprintf( __( 'Delete it: %s' ), admin_url( "comment.php?action=delete&c=$comment_id" ) ) . "\r\n";
 			}
+			/* translators: URL for marking a comment as spam. */
 			$notify_message .= sprintf( __( 'Spam it: %s' ), admin_url( "comment.php?action=spam&c=$comment_id" ) ) . "\r\n";
 
 			$wp_email = 'wordpress@' . preg_replace( '#^www\.#', '', strtolower( $_SERVER['SERVER_NAME'] ) ); // phpcs:ignore

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -228,8 +228,8 @@ class CoAuthors_Plus {
 		$args = array(
 			'hierarchical' => false,
 			'labels'       => array(
-				'name'      => __( 'Authors' ),
-				'all_items' => __( 'All Authors' ),
+				'name'      => __( 'Authors', 'co-authors-plus' ),
+				'all_items' => __( 'All Authors', 'co-authors-plus' ),
 			),
 			'query_var'    => false,
 			'rewrite'      => false,
@@ -1796,7 +1796,7 @@ class CoAuthors_Plus {
 		$author      = $this->get_coauthor_by( 'user_nicename', $author_slug );
 
 		/* translators: Author display name. */
-		return sprintf( __( 'Author: %s' ), $author->display_name );
+		return sprintf( __( 'Author: %s', 'co-authors-plus' ), $author->display_name );
 	}
 
 	/**
@@ -1955,54 +1955,54 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 
 			if ( 'comment' == $comment_type ) {
 				/* translators: Post title. */
-				$notify_message = sprintf( __( 'New comment on your post "%s"' ), $post->post_title ) . "\r\n";
+				$notify_message = sprintf( __( 'New comment on your post "%s"', 'co-authors-plus' ), $post->post_title ) . "\r\n";
 				/* translators: 1: comment author, 2: author IP, 3: author domain */
-				$notify_message .= sprintf( __( 'Author : %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+				$notify_message .= sprintf( __( 'Author : %1$s (IP: %2$s , %3$s)', 'co-authors-plus' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
 				/* translators: Comment author emal address. */
-				$notify_message .= sprintf( __( 'Email : %s' ), $comment->comment_author_email ) . "\r\n";
+				$notify_message .= sprintf( __( 'Email : %s', 'co-authors-plus' ), $comment->comment_author_email ) . "\r\n";
 				/* translators: Comment author URL. */
-				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
+				$notify_message .= sprintf( __( 'URL    : %s', 'co-authors-plus' ), $comment->comment_author_url ) . "\r\n";
 				/* translators: Comment author IP address. */
-				$notify_message .= sprintf( __( 'Whois  : http://whois.arin.net/rest/ip/%s' ), $comment->comment_author_IP ) . "\r\n";
-				$notify_message .= __( 'Comment: ' ) . "\r\n" . $comment->comment_content . "\r\n\r\n";
-				$notify_message .= __( 'You can see all comments on this post here: ' ) . "\r\n";
+				$notify_message .= sprintf( __( 'Whois  : http://whois.arin.net/rest/ip/%s', 'co-authors-plus' ), $comment->comment_author_IP ) . "\r\n";
+				$notify_message .= __( 'Comment: ', 'co-authors-plus' ) . "\r\n" . $comment->comment_content . "\r\n\r\n";
+				$notify_message .= __( 'You can see all comments on this post here: ', 'co-authors-plus' ) . "\r\n";
 				/* translators: 1: blog name, 2: post title */
-				$subject = sprintf( __( '[%1$s] Comment: "%2$s"' ), $blogname, $post->post_title );
+				$subject = sprintf( __( '[%1$s] Comment: "%2$s"', 'co-authors-plus' ), $blogname, $post->post_title );
 			} elseif ( 'trackback' == $comment_type ) {
 				/* translators: Post title. */
-				$notify_message = sprintf( __( 'New trackback on your post "%s"' ), $post->post_title ) . "\r\n";
+				$notify_message = sprintf( __( 'New trackback on your post "%s"', 'co-authors-plus' ), $post->post_title ) . "\r\n";
 				/* translators: 1: comment author, 2: author IP, 3: author domain */
-				$notify_message .= sprintf( __( 'Website: %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+				$notify_message .= sprintf( __( 'Website: %1$s (IP: %2$s , %3$s)', 'co-authors-plus' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
 				/* translators: Comment author URL. */
-				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
-				$notify_message .= __( 'Excerpt: ' ) . "\r\n" . $comment->comment_content . "\r\n\r\n";
-				$notify_message .= __( 'You can see all trackbacks on this post here: ' ) . "\r\n";
+				$notify_message .= sprintf( __( 'URL    : %s', 'co-authors-plus' ), $comment->comment_author_url ) . "\r\n";
+				$notify_message .= __( 'Excerpt: ', 'co-authors-plus' ) . "\r\n" . $comment->comment_content . "\r\n\r\n";
+				$notify_message .= __( 'You can see all trackbacks on this post here: ', 'co-authors-plus' ) . "\r\n";
 				/* translators: 1: blog name, 2: post title */
-				$subject = sprintf( __( '[%1$s] Trackback: "%2$s"' ), $blogname, $post->post_title );
+				$subject = sprintf( __( '[%1$s] Trackback: "%2$s"', 'co-authors-plus' ), $blogname, $post->post_title );
 			} elseif ( 'pingback' == $comment_type ) {
 				/* translators: Post title. */
-				$notify_message = sprintf( __( 'New pingback on your post "%s"' ), $post->post_title ) . "\r\n";
+				$notify_message = sprintf( __( 'New pingback on your post "%s"', 'co-authors-plus' ), $post->post_title ) . "\r\n";
 				/* translators: 1: comment author, 2: author IP, 3: author domain */
-				$notify_message .= sprintf( __( 'Website: %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
+				$notify_message .= sprintf( __( 'Website: %1$s (IP: %2$s , %3$s)', 'co-authors-plus' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
 				/* translators: Comment author URL. */
-				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
-				$notify_message .= __( 'Excerpt: ' ) . "\r\n" . sprintf( '[...] %s [...]', $comment->comment_content ) . "\r\n\r\n";
-				$notify_message .= __( 'You can see all pingbacks on this post here: ' ) . "\r\n";
+				$notify_message .= sprintf( __( 'URL    : %s', 'co-authors-plus' ), $comment->comment_author_url ) . "\r\n";
+				$notify_message .= __( 'Excerpt: ', 'co-authors-plus' ) . "\r\n" . sprintf( '[...] %s [...]', $comment->comment_content ) . "\r\n\r\n";
+				$notify_message .= __( 'You can see all pingbacks on this post here: ', 'co-authors-plus' ) . "\r\n";
 				/* translators: 1: blog name, 2: post title */
-				$subject = sprintf( __( '[%1$s] Pingback: "%2$s"' ), $blogname, $post->post_title );
+				$subject = sprintf( __( '[%1$s] Pingback: "%2$s"', 'co-authors-plus' ), $blogname, $post->post_title );
 			}
 			$notify_message .= get_permalink( $comment->comment_post_ID ) . "#comments\r\n\r\n";
 			/* translators: Comment URL. */
-			$notify_message .= sprintf( __( 'Permalink: %s' ), get_permalink( $comment->comment_post_ID ) . '#comment-' . $comment_id ) . "\r\n";
+			$notify_message .= sprintf( __( 'Permalink: %s', 'co-authors-plus' ), get_permalink( $comment->comment_post_ID ) . '#comment-' . $comment_id ) . "\r\n";
 			if ( EMPTY_TRASH_DAYS ) {
 				/* translators: URL for trashing a comment. */
-				$notify_message .= sprintf( __( 'Trash it: %s' ), admin_url( "comment.php?action=trash&c=$comment_id" ) ) . "\r\n";
+				$notify_message .= sprintf( __( 'Trash it: %s', 'co-authors-plus' ), admin_url( "comment.php?action=trash&c=$comment_id" ) ) . "\r\n";
 			} else {
 				/* translators: URL for deleting a comment. */
-				$notify_message .= sprintf( __( 'Delete it: %s' ), admin_url( "comment.php?action=delete&c=$comment_id" ) ) . "\r\n";
+				$notify_message .= sprintf( __( 'Delete it: %s', 'co-authors-plus' ), admin_url( "comment.php?action=delete&c=$comment_id" ) ) . "\r\n";
 			}
 			/* translators: URL for marking a comment as spam. */
-			$notify_message .= sprintf( __( 'Spam it: %s' ), admin_url( "comment.php?action=spam&c=$comment_id" ) ) . "\r\n";
+			$notify_message .= sprintf( __( 'Spam it: %s', 'co-authors-plus' ), admin_url( "comment.php?action=spam&c=$comment_id" ) ) . "\r\n";
 
 			$wp_email = 'wordpress@' . preg_replace( '#^www\.#', '', strtolower( $_SERVER['SERVER_NAME'] ) ); // phpcs:ignore
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -465,7 +465,7 @@ class CoAuthors_Plus {
 				?>
 				</ul>
 				<div class="clear"></div>
-				<p><?php echo wp_kses( __( '<strong>Note:</strong> To edit post authors, please enable javascript or use a javascript-capable browser', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
+				<p><?php echo wp_kses( __( '<strong>Note:</strong> To edit post authors, please enable JavaScript or use a JavaScript-capable browser', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
 			</div>
 			<?php
 		endif;
@@ -1959,7 +1959,7 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 				/* translators: 1: comment author, 2: author IP, 3: author domain */
 				$notify_message .= sprintf( __( 'Author : %1$s (IP: %2$s , %3$s)' ), $comment->comment_author, $comment->comment_author_IP, $comment_author_domain ) . "\r\n";
 				/* translators: Comment author emal address. */
-				$notify_message .= sprintf( __( 'E-mail : %s' ), $comment->comment_author_email ) . "\r\n";
+				$notify_message .= sprintf( __( 'Email : %s' ), $comment->comment_author_email ) . "\r\n";
 				/* translators: Comment author URL. */
 				$notify_message .= sprintf( __( 'URL    : %s' ), $comment->comment_author_url ) . "\r\n";
 				/* translators: Comment author IP address. */

--- a/languages/co-authors-plus.pot
+++ b/languages/co-authors-plus.pot
@@ -1,574 +1,654 @@
-# Copyright (C) 2014 Co-Authors Plus
-# This file is distributed under the same license as the Co-Authors Plus package.
+# Copyright (C) 2023 Mohammad Jangda, Daniel Bachhuber, Automattic
+# This file is distributed under the same license as the Co-Authors Plus plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Co-Authors Plus 3.1-beta\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/tag/co-authors-plus\n"
-"POT-Creation-Date: 2014-03-17 15:59:18+00:00\n"
+"Project-Id-Version: Co-Authors Plus 3.5.11\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/co-authors-plus\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2023-07-29T21:49:27+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.8.1\n"
+"X-Domain: co-authors-plus\n"
 
-#: co-authors-plus.php:300 co-authors-plus.php:401 co-authors-plus.php:487
-#: co-authors-plus.php:1290
+#. Plugin Name of the plugin
+msgid "Co-Authors Plus"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "http://wordpress.org/extend/plugins/co-authors-plus/"
+msgstr ""
+
+#. Description of the plugin
+msgid "Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter."
+msgstr ""
+
+#. Author of the plugin
+msgid "Mohammad Jangda, Daniel Bachhuber, Automattic"
+msgstr ""
+
+#: co-authors-plus.php:231
+#: co-authors-plus.php:398
+#: co-authors-plus.php:509
+#: co-authors-plus.php:598
+#: co-authors-plus.php:1643
+#: build/index.js:1
+#: src/index.js:20
 msgid "Authors"
 msgstr ""
 
-#: co-authors-plus.php:362
-msgid ""
-"<strong>Note:</strong> To edit post authors, please enable javascript or use "
-"a javascript-capable browser"
+#: co-authors-plus.php:232
+msgid "All Authors"
 msgstr ""
 
-#: co-authors-plus.php:369 co-authors-plus.php:489 co-authors-plus.php:1095
-msgid ""
-"Click on an author to change them. Drag to change their order. Click on "
-"<strong>Remove</strong> to remove them."
+#: co-authors-plus.php:468
+msgid "<strong>Note:</strong> To edit post authors, please enable JavaScript or use a JavaScript-capable browser"
 msgstr ""
 
-#: co-authors-plus.php:449 php/class-coauthors-wp-list-table.php:148
+#: co-authors-plus.php:475
+#: co-authors-plus.php:600
+#: co-authors-plus.php:1394
+msgid "Click on an author to change them. Drag to change their order. Click on <strong>Remove</strong> to remove them."
+msgstr ""
+
+#: co-authors-plus.php:561
+#: php/class-coauthors-wp-list-table.php:177
 msgid "Posts"
 msgstr ""
 
-#: co-authors-plus.php:466
+#: co-authors-plus.php:580
 msgid "View posts by this author"
 msgstr ""
 
-#: co-authors-plus.php:531 co-authors-plus.php:548
+#: co-authors-plus.php:643
+#: co-authors-plus.php:661
 msgid "No co-author exists for that term"
 msgstr ""
 
-#: co-authors-plus.php:1090 php/class-coauthors-wp-list-table.php:212
+#: co-authors-plus.php:1389
+#: php/class-coauthors-wp-list-table.php:241
 msgid "Edit"
 msgstr ""
 
-#: co-authors-plus.php:1091
+#: co-authors-plus.php:1390
 msgid "Remove"
 msgstr ""
 
-#: co-authors-plus.php:1092
+#: co-authors-plus.php:1391
 msgid "Are you sure you want to remove this author?"
 msgstr ""
 
-#: co-authors-plus.php:1093
+#: co-authors-plus.php:1392
 msgid "Click to change this author, or drag to change their position"
 msgstr ""
 
-#: co-authors-plus.php:1094
+#: co-authors-plus.php:1393
 msgid "Search for an author"
 msgstr ""
 
-#: co-authors-plus.php:1132
+#: co-authors-plus.php:1435
 msgid "Mine"
 msgstr ""
 
-#: co-authors-plus.php:1402
+#. translators: Author display name.
+#: co-authors-plus.php:1799
+msgid "Author: %s"
+msgstr ""
+
+#. translators: Post title.
+#: co-authors-plus.php:1958
 msgid "New comment on your post \"%s\""
 msgstr ""
 
 #. translators: 1: comment author, 2: author IP, 3: author domain
-#: co-authors-plus.php:1404 co-authors-plus.php:1521
+#: co-authors-plus.php:1960
 msgid "Author : %1$s (IP: %2$s , %3$s)"
 msgstr ""
 
-#: co-authors-plus.php:1405 co-authors-plus.php:1522
-msgid "E-mail : %s"
+#. translators: Comment author emal address.
+#: co-authors-plus.php:1962
+msgid "Email : %s"
 msgstr ""
 
-#: co-authors-plus.php:1406 co-authors-plus.php:1416 co-authors-plus.php:1425
-#: co-authors-plus.php:1508 co-authors-plus.php:1515 co-authors-plus.php:1523
+#. translators: Comment author URL.
+#: co-authors-plus.php:1964
+#: co-authors-plus.php:1977
+#: co-authors-plus.php:1988
 msgid "URL    : %s"
 msgstr ""
 
-#: co-authors-plus.php:1407 co-authors-plus.php:1524
+#. translators: Comment author IP address.
+#: co-authors-plus.php:1966
 msgid "Whois  : http://whois.arin.net/rest/ip/%s"
 msgstr ""
 
-#: co-authors-plus.php:1408 co-authors-plus.php:1525
+#: co-authors-plus.php:1967
 msgid "Comment: "
 msgstr ""
 
-#: co-authors-plus.php:1409
+#: co-authors-plus.php:1968
 msgid "You can see all comments on this post here: "
 msgstr ""
 
 #. translators: 1: blog name, 2: post title
-#: co-authors-plus.php:1411
+#: co-authors-plus.php:1970
 msgid "[%1$s] Comment: \"%2$s\""
 msgstr ""
 
-#: co-authors-plus.php:1413
+#. translators: Post title.
+#: co-authors-plus.php:1973
 msgid "New trackback on your post \"%s\""
 msgstr ""
 
-#. translators: 1: website name, 2: author IP, 3: author domain
 #. translators: 1: comment author, 2: author IP, 3: author domain
-#: co-authors-plus.php:1415 co-authors-plus.php:1424
+#: co-authors-plus.php:1975
+#: co-authors-plus.php:1986
 msgid "Website: %1$s (IP: %2$s , %3$s)"
 msgstr ""
 
-#: co-authors-plus.php:1417 co-authors-plus.php:1426
+#: co-authors-plus.php:1978
+#: co-authors-plus.php:1989
 msgid "Excerpt: "
 msgstr ""
 
-#: co-authors-plus.php:1418
+#: co-authors-plus.php:1979
 msgid "You can see all trackbacks on this post here: "
 msgstr ""
 
 #. translators: 1: blog name, 2: post title
-#: co-authors-plus.php:1420
+#: co-authors-plus.php:1981
 msgid "[%1$s] Trackback: \"%2$s\""
 msgstr ""
 
-#: co-authors-plus.php:1422
+#. translators: Post title.
+#: co-authors-plus.php:1984
 msgid "New pingback on your post \"%s\""
 msgstr ""
 
-#: co-authors-plus.php:1427
+#: co-authors-plus.php:1990
 msgid "You can see all pingbacks on this post here: "
 msgstr ""
 
 #. translators: 1: blog name, 2: post title
-#: co-authors-plus.php:1429
+#: co-authors-plus.php:1992
 msgid "[%1$s] Pingback: \"%2$s\""
 msgstr ""
 
-#: co-authors-plus.php:1432
+#. translators: Comment URL.
+#: co-authors-plus.php:1996
 msgid "Permalink: %s"
 msgstr ""
 
-#: co-authors-plus.php:1434 co-authors-plus.php:1531
+#. translators: URL for trashing a comment.
+#: co-authors-plus.php:1999
 msgid "Trash it: %s"
 msgstr ""
 
-#: co-authors-plus.php:1436 co-authors-plus.php:1533
+#. translators: URL for deleting a comment.
+#: co-authors-plus.php:2002
 msgid "Delete it: %s"
 msgstr ""
 
-#: co-authors-plus.php:1437 co-authors-plus.php:1534
+#. translators: URL for marking a comment as spam.
+#: co-authors-plus.php:2005
 msgid "Spam it: %s"
 msgstr ""
 
-#: co-authors-plus.php:1505
-msgid "A new trackback on the post \"%s\" is waiting for your approval"
+#: php/class-coauthors-endpoint.php:65
+msgid "Text to search."
 msgstr ""
 
-#: co-authors-plus.php:1507 co-authors-plus.php:1514
-msgid "Website : %1$s (IP: %2$s , %3$s)"
+#: php/class-coauthors-endpoint.php:70
+msgid "Names of existing coauthors to exclude from search results."
 msgstr ""
 
-#: co-authors-plus.php:1509
-msgid "Trackback excerpt: "
-msgstr ""
-
-#: co-authors-plus.php:1512
-msgid "A new pingback on the post \"%s\" is waiting for your approval"
-msgstr ""
-
-#: co-authors-plus.php:1516
-msgid "Pingback excerpt: "
-msgstr ""
-
-#: co-authors-plus.php:1519
-msgid "A new comment on the post \"%s\" is waiting for your approval"
-msgstr ""
-
-#: co-authors-plus.php:1529
-msgid "Approve it: %s"
-msgstr ""
-
-#: co-authors-plus.php:1536
-msgid ""
-"Currently %s comment is waiting for approval. Please visit the moderation "
-"panel:"
-msgid_plural ""
-"Currently %s comments are waiting for approval. Please visit the moderation "
-"panel:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: co-authors-plus.php:1540
-msgid "[%1$s] Please moderate: \"%2$s\""
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:80
-msgid "Guest Author"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:81
-msgid "Guest Authors"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:82
-msgid "All Guest Authors"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:83
-msgid "Add New Guest Author"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:84
-msgid "Edit Guest Author"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:85
-msgid "New Guest Author"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:86
-msgid "View Guest Author"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:87
-msgid "Search Guest Authors"
+#: php/class-coauthors-endpoint.php:113
+msgid "Names of co-authors to save."
 msgstr ""
 
 #: php/class-coauthors-guest-authors.php:88
-msgid "No guest authors found"
+#: php/class-coauthors-guest-authors.php:1552
+#: php/class-coauthors-guest-authors.php:1625
+msgid "Guest Author"
 msgstr ""
 
 #: php/class-coauthors-guest-authors.php:89
-msgid "No guest authors found in Trash"
+msgid "Guest Authors"
 msgstr ""
 
 #: php/class-coauthors-guest-authors.php:90
-msgid "Update Guest Author"
+msgid "All Guest Authors"
 msgstr ""
 
 #: php/class-coauthors-guest-authors.php:91
+msgid "Add New Guest Author"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:92
+msgid "Edit Guest Author"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:93
+msgid "New Guest Author"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:94
+msgid "View Guest Author"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:95
+msgid "Search Guest Authors"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:96
+msgid "No guest authors found"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:97
+msgid "No guest authors found in Trash"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:98
+msgid "Update Guest Author"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:99
 msgid "About the guest author"
 msgstr ""
 
 #: php/class-coauthors-guest-authors.php:100
+msgid "Avatar"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:101
+msgid "Set Avatar"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:102
+msgid "Use Avatar"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:103
+msgid "Remove Avatar"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:113
 msgctxt "guest author"
 msgid "Add New"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:156
-#: php/class-coauthors-guest-authors.php:162
+#. translators: Guest author URL
+#: php/class-coauthors-guest-authors.php:167
+#: php/class-coauthors-guest-authors.php:174
 msgid "Guest author updated. <a href=\"%s\">View profile</a>"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:157
+#: php/class-coauthors-guest-authors.php:168
 msgid "Custom field updated."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:158
+#: php/class-coauthors-guest-authors.php:169
 msgid "Custom field deleted."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:159
+#: php/class-coauthors-guest-authors.php:170
 msgid "Guest author updated."
 msgstr ""
 
 #. translators: %s: date and time of the revision
-#: php/class-coauthors-guest-authors.php:161
+#: php/class-coauthors-guest-authors.php:172
 msgid "Guest author restored to revision from %s"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:163
+#: php/class-coauthors-guest-authors.php:175
 msgid "Guest author saved."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:164
-msgid ""
-"Guest author submitted. <a target=\"_blank\" href=\"%s\">Preview profile</a>"
+#. translators: Guest author URL
+#: php/class-coauthors-guest-authors.php:177
+msgid "Guest author submitted. <a target=\"_blank\" href=\"%s\">Preview profile</a>"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:165
-msgid ""
-"Guest author scheduled for: <strong>%1$s</strong>. <a target=\"_blank\" href="
-"\"%2$s\">Preview profile</a>"
+#. translators: Guest author profile preview URL.
+#: php/class-coauthors-guest-authors.php:180
+msgid "Guest author scheduled for: <strong>%1$s</strong>. <a target=\"_blank\" href=\"%2$s\">Preview profile</a>"
 msgstr ""
 
-#. translators: Publish box date format, see http:php.net/date
-#: php/class-coauthors-guest-authors.php:167
+#. translators: Publish box date format, see http://php.net/date
+#: php/class-coauthors-guest-authors.php:182
 msgid "M j, Y @ G:i"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:168
-msgid ""
-"Guest author updated. <a target=\"_blank\" href=\"%s\">Preview profile</a>"
+#. translators: Guest author profile preview URL.
+#: php/class-coauthors-guest-authors.php:186
+msgid "Guest author updated. <a target=\"_blank\" href=\"%s\">Preview profile</a>"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:185
-#: php/class-coauthors-guest-authors.php:218
-#: php/class-coauthors-guest-authors.php:437
+#: php/class-coauthors-guest-authors.php:204
+#: php/class-coauthors-guest-authors.php:243
+#: php/class-coauthors-guest-authors.php:480
 msgid "Doin' something fishy, huh?"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:188
-#: php/class-coauthors-guest-authors.php:222
+#: php/class-coauthors-guest-authors.php:208
+#: php/class-coauthors-guest-authors.php:248
 msgid "You don't have permission to perform this action."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:227
-#: php/class-coauthors-guest-authors.php:442
+#: php/class-coauthors-guest-authors.php:254
+#: php/class-coauthors-guest-authors.php:486
 msgid "Guest author can't be deleted because it doesn't exist."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:241
+#: php/class-coauthors-guest-authors.php:270
 msgid "Co-author does not exists. Try again?"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:249
+#: php/class-coauthors-guest-authors.php:280
 msgid "Please make sure to pick an option."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:393
+#: php/class-coauthors-guest-authors.php:436
 msgid "Guest author deleted."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:417
+#: php/class-coauthors-guest-authors.php:460
 msgid "Save"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:418
+#: php/class-coauthors-guest-authors.php:461
 msgid "Unique Slug"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:420
+#: php/class-coauthors-guest-authors.php:463
 msgid "Name"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:421
+#: php/class-coauthors-guest-authors.php:464
 msgid "Contact Info"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:446
-msgid "Delete %s"
+#: php/class-coauthors-guest-authors.php:495
+msgid "Delete Guest Authors"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:447
+#: php/class-coauthors-guest-authors.php:496
 msgid "You have specified this guest author for deletion:"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:449
-msgid "What should be done with posts assigned to this guest author?"
+#: php/class-coauthors-guest-authors.php:500
+msgid "There are no posts associated with this guest author."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:450
-msgid ""
-"Note: If you'd like to delete the guest author and all of their posts, you "
-"should delete their posts first and then come back to delete the guest "
-"author."
+#: php/class-coauthors-guest-authors.php:502
+msgid "Note: If you'd like to delete the guest author and all of their posts, you should delete their posts first and then come back to delete the guest author."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:459
+#. translators: Count of posts
+#: php/class-coauthors-guest-authors.php:505
+msgid "There is %d post associated with this guest author. What should be done with the post assigned to this Guest Author?"
+msgid_plural "There are %d posts associated with this guest author. What should be done with the posts assigned to this Guest Author?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: php/class-coauthors-guest-authors.php:531
 msgid "Reassign to another co-author:"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:465
+#. translators: Name of a linked user account.
+#: php/class-coauthors-guest-authors.php:538
 msgid "Leave posts assigned to the mapped user, %s."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:470
+#: php/class-coauthors-guest-authors.php:543
 msgid "Remove byline from posts (but leave each post in its current status)."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:473
+#: php/class-coauthors-guest-authors.php:551
+#: php/class-coauthors-guest-authors.php:553
 msgid "Confirm Deletion"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:482
+#: php/class-coauthors-guest-authors.php:563
 msgid "Add New"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:543
+#: php/class-coauthors-guest-authors.php:628
 msgid "WordPress User Mapping"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:545
+#: php/class-coauthors-guest-authors.php:633
 msgid "-- Not mapped --"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:679
-#: php/class-coauthors-guest-authors.php:688
+#: php/class-coauthors-guest-authors.php:783
+#: php/class-coauthors-guest-authors.php:794
 msgid "Guest authors cannot be created without display names."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:697
-msgid ""
-"Guest authors cannot be created with the same user_login value as a user. "
-"Try creating a profile from the user on the Manage Users listing instead."
+#: php/class-coauthors-guest-authors.php:808
+msgid "There is a WordPress user with the same username as this guest author, please go back and link them in order to update."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:702
+#: php/class-coauthors-guest-authors.php:814
 msgid "Display name conflicts with another guest author display name."
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:896
+#: php/class-coauthors-guest-authors.php:1031
+#: php/class-coauthors-guest-authors.php:1582
 msgid "ID"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:903
-#: php/class-coauthors-wp-list-table.php:143
+#: php/class-coauthors-guest-authors.php:1038
+#: php/class-coauthors-guest-authors.php:1584
+#: php/class-coauthors-wp-list-table.php:172
 msgid "Display Name"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:909
-#: php/class-coauthors-wp-list-table.php:144
+#: php/class-coauthors-guest-authors.php:1044
+#: php/class-coauthors-guest-authors.php:1586
+#: php/class-coauthors-wp-list-table.php:173
 msgid "First Name"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:914
-#: php/class-coauthors-wp-list-table.php:145
+#: php/class-coauthors-guest-authors.php:1049
+#: php/class-coauthors-guest-authors.php:1587
+#: php/class-coauthors-wp-list-table.php:174
 msgid "Last Name"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:919
+#: php/class-coauthors-guest-authors.php:1054
 msgid "Slug"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:926
-#: php/class-coauthors-wp-list-table.php:146
+#: php/class-coauthors-guest-authors.php:1061
+#: php/class-coauthors-wp-list-table.php:175
 msgid "E-mail"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:932
-#: php/class-coauthors-wp-list-table.php:147
+#: php/class-coauthors-guest-authors.php:1067
+#: php/class-coauthors-wp-list-table.php:176
 msgid "Linked Account"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:937
+#: php/class-coauthors-guest-authors.php:1072
+#: php/class-coauthors-guest-authors.php:1588
 msgid "Website"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:943
-msgid "AIM"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:948
-msgid "Yahoo IM"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:953
-msgid "Jabber / Google Talk"
-msgstr ""
-
-#: php/class-coauthors-guest-authors.php:958
+#: php/class-coauthors-guest-authors.php:1078
+#: php/class-coauthors-guest-authors.php:1592
 msgid "Biographical Info"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1122
+#. translators: Name of a form field.
+#: php/class-coauthors-guest-authors.php:1255
 msgid "%s is a required field"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1128
+#: php/class-coauthors-guest-authors.php:1261
 msgid "user_login cannot duplicate existing guest author or mapped user"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1173
+#: php/class-coauthors-guest-authors.php:1317
 msgid "Guest author does not exist"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1185
+#: php/class-coauthors-guest-authors.php:1332
 msgid "Reassignment co-author does not exist"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1217
+#: php/class-coauthors-guest-authors.php:1372
 msgid "No user exists with that ID"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1275
+#: php/class-coauthors-guest-authors.php:1435
 msgid "Edit Profile"
 msgstr ""
 
-#: php/class-coauthors-guest-authors.php:1284
+#: php/class-coauthors-guest-authors.php:1444
 msgid "Create Profile"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:19
+#: php/class-coauthors-guest-authors.php:1583
+msgid "Login Name"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:1585
+msgid "Email"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:1589
+msgid "AIM"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:1590
+msgid "Yahoo IM"
+msgstr ""
+
+#: php/class-coauthors-guest-authors.php:1591
+msgid "Jabber / Google Talk"
+msgstr ""
+
+#: php/class-coauthors-wp-list-table.php:23
 msgid "Co-Authors"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:20
+#: php/class-coauthors-wp-list-table.php:24
 msgid "Co-Author"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:81
+#: php/class-coauthors-wp-list-table.php:89
 msgid "Show all"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:82
+#: php/class-coauthors-wp-list-table.php:90
 msgid "With linked account"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:83
+#: php/class-coauthors-wp-list-table.php:91
 msgid "Without linked account"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:135
-msgid "No matching guest authors were found."
+#: php/class-coauthors-wp-list-table.php:164
+msgid "No matching co-authors were found."
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:215
+#: php/class-coauthors-wp-list-table.php:244
 msgid "Delete"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:217
+#: php/class-coauthors-wp-list-table.php:246
 msgid "View Posts"
 msgstr ""
 
-#: php/class-coauthors-wp-list-table.php:267
+#: php/class-coauthors-wp-list-table.php:293
 msgid "Filter"
 msgstr ""
 
-#: php/class-wp-cli.php:220
+#: php/class-wp-cli.php:228
 msgid "Please specify a valid user_login"
 msgstr ""
 
-#: php/class-wp-cli.php:223
+#: php/class-wp-cli.php:232
 msgid "Please specify a valid co-author login"
 msgstr ""
 
-#: php/class-wp-cli.php:230
-msgid "Skipping - Post #%d already has co-authors assigned: %s"
+#. translators: 1: Post ID, 2: Comma-separated list of co-author slugs.
+#: php/class-wp-cli.php:245
+msgid "Skipping - Post #%1$d already has co-authors assigned: %2$s"
 msgstr ""
 
-#: php/class-wp-cli.php:235
-msgid "Updating - Adding %s's byline to post #%d"
+#. translators: 1: Co-author login, 2: Post ID
+#: php/class-wp-cli.php:255
+msgid "Updating - Adding %1$s's byline to post #%2$d"
 msgstr ""
 
-#: php/class-wp-cli.php:240
-msgid "All done! %d posts were affected."
+#. translators: Count of posts.
+#: php/class-wp-cli.php:264
+msgid "All done! %d post was affected."
+msgid_plural "All done! %d posts were affected."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: Guest Author ID.
+#: php/class-wp-cli.php:901
+msgid "-- Author already exists (ID #%s); skipping."
 msgstr ""
 
-#: template-tags.php:79
-msgid ""
-"No post ID provided for CoAuthorsIterator constructor. Are you not in a loop "
-"or is $post not set?"
+#: php/class-wp-cli.php:904
+msgid "-- Not found; creating profile."
 msgstr ""
 
-#: template-tags.php:133
+#. translators: The error message.
+#: php/class-wp-cli.php:921
+msgid "-- Failed to create guest author: %s"
+msgstr ""
+
+#. translators: Guest Author ID.
+#: php/class-wp-cli.php:931
+msgid "-- Created as guest author #%s"
+msgstr ""
+
+#: php/integrations/yoast.php:262
+msgid "Written by"
+msgstr ""
+
+#: template-tags.php:155
 msgid " and "
 msgstr ""
 
-#: template-tags.php:233 template-tags.php:468
+#. translators: Author display name.
+#: template-tags.php:303
+#: template-tags.php:697
 msgid "Posts by %s"
 msgstr ""
 
-#: template-tags.php:350
+#. translators: Author display name.
+#: template-tags.php:473
+#: template-tags.php:481
 msgid "Visit %s&#8217;s website"
 msgstr ""
 
-#. Plugin Name of the plugin/theme
-msgid "Co-Authors Plus"
+#: build/index.js:1
+#: src/components/author-selection/index.jsx:74
+msgid "Move Up"
 msgstr ""
 
-#. Plugin URI of the plugin/theme
-msgid "http://wordpress.org/extend/plugins/co-authors-plus/"
+#: build/index.js:1
+#: src/components/author-selection/index.jsx:85
+msgid "Move down"
 msgstr ""
 
-#. Description of the plugin/theme
-msgid ""
-"Allows multiple authors to be assigned to a post. This plugin is an extended "
-"version of the Co-Authors plugin developed by Weston Ruter."
+#: build/index.js:1
+#: src/components/author-selection/index.jsx:102
+msgid "Remove Author"
 msgstr ""
 
-#. Author of the plugin/theme
-msgid "Mohammad Jangda, Daniel Bachhuber, Automattic"
+#: build/index.js:1
+#: src/components/co-authors/index.jsx:189
+msgid "Select An Author"
 msgstr ""

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -110,7 +110,7 @@ class Endpoints {
 							'validate_callback' => array( $this, 'validate_numeric' ),
 						),
 						'new_authors' => array(
-							'description' => __( 'Names of coauthors to save.' ),
+							'description' => __( 'Names of co-authors to save.' ),
 							'type'        => 'string',
 							'required'    => false,
 						),

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -62,12 +62,12 @@ class Endpoints {
 					'permission_callback' => array( $this, 'can_edit_coauthors' ),
 					'args'                => array(
 						'q'                => array(
-							'description' => __( 'Text to search.' ),
+							'description' => __( 'Text to search.', 'co-authors-plus' ),
 							'required'    => false,
 							'type'        => 'string',
 						),
 						'existing_authors' => array(
-							'description' => __( 'Names of existing coauthors to exclude from search results.' ),
+							'description' => __( 'Names of existing coauthors to exclude from search results.', 'co-authors-plus' ),
 							'type'        => 'string',
 							'required'    => false,
 						),
@@ -110,7 +110,7 @@ class Endpoints {
 							'validate_callback' => array( $this, 'validate_numeric' ),
 						),
 						'new_authors' => array(
-							'description' => __( 'Names of co-authors to save.' ),
+							'description' => __( 'Names of co-authors to save.', 'co-authors-plus' ),
 							'type'        => 'string',
 							'required'    => false,
 						),

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -504,12 +504,17 @@ class CoAuthors_Guest_Authors {
 				$post_count_message = '<p>' . sprintf( __( 'There are no posts associated with this guest author.', 'co-authors-plus' ), strtolower( $this->labels['singular'] ) ) . '</p>';
 			} else {
 				$note = '<p class="description">' . sprintf( __( "Note: If you'd like to delete the %1\$s and all of their posts, you should delete their posts first and then come back to delete the %2\$s.", 'co-authors-plus' ), strtolower( $this->labels['singular'] ), strtolower( $this->labels['singular'] ) ) . '</p>';
-				if ( 1 === $count ) {
-					$post_count_message = '<p>' . sprintf( __( 'There is %1$d post associated with this guest author. What should be done with the post assigned to this %2$s?', 'co-authors-plus' ), $count, strtolower( $this->labels['singular'] ) ) . '</p>';
-				} else {
-					$post_count_message = '<p>' . sprintf( __( 'There are %1$d posts associated with this guest author. What should be done with the posts assigned to this %2$s?', 'co-authors-plus' ), $count, strtolower( $this->labels['singular'] ) ) . '</p>';
-				}
-				$post_count_message .= $note;
+				$post_count_message_text = sprintf(
+					/* translators: Count of posts */
+					_n(
+						'There is %d post associated with this guest author. What should be done with the post assigned to this Guest Author?',
+						'There are %d posts associated with this guest author. What should be done with the posts assigned to this Guest Author?',
+						$count,
+						'co-authors-plus'
+					),
+					number_format_i18n( $count )
+				);
+				$post_count_message = '<p>' . $post_count_message_text . '</p>' . $note;
 			}
 			$allowed_html = array(
 				'p' => array(

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -163,21 +163,26 @@ class CoAuthors_Guest_Authors {
 
 		$messages[ $this->post_type ] = array(
 			0  => '', // Unused. Messages start at index 1.
+			/* translators: Guest author URL */
 			1  => sprintf( __( 'Guest author updated. <a href="%s">View profile</a>', 'co-authors-plus' ), esc_url( $guest_author_link ) ),
 			2  => __( 'Custom field updated.', 'co-authors-plus' ),
 			3  => __( 'Custom field deleted.', 'co-authors-plus' ),
 			4  => __( 'Guest author updated.', 'co-authors-plus' ),
 			/* translators: %s: date and time of the revision */
 			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Guest author restored to revision from %s', 'co-authors-plus' ), wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			/* translators: Guest author URL */
 			6  => sprintf( __( 'Guest author updated. <a href="%s">View profile</a>', 'co-authors-plus' ), esc_url( $guest_author_link ) ),
 			7  => __( 'Guest author saved.', 'co-authors-plus' ),
+			/* translators: Guest author URL */
 			8  => sprintf( __( 'Guest author submitted. <a target="_blank" href="%s">Preview profile</a>', 'co-authors-plus' ), esc_url( add_query_arg( 'preview', 'true', $guest_author_link ) ) ),
 			9  => sprintf(
+				/* translators: Guest author profile preview URL. */
 				__( 'Guest author scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview profile</a>', 'co-authors-plus' ),
 				// translators: Publish box date format, see http://php.net/date
 				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ),
 				esc_url( $guest_author_link )
 			),
+			/* translators: Guest author profile preview URL. */
 			10 => sprintf( __( 'Guest author updated. <a target="_blank" href="%s">Preview profile</a>', 'co-authors-plus' ), esc_url( add_query_arg( 'preview', 'true', $guest_author_link ) ) ),
 		);
 		return $messages;
@@ -246,6 +251,7 @@ class CoAuthors_Guest_Authors {
 		// Make sure the guest author actually exists
 		$guest_author = $this->get_guest_author_by( 'ID', (int) $_POST['id'] );
 		if ( ! $guest_author ) {
+			/* translators: Singular name of the guest author post type e.g. Guest Author. */
 			wp_die( esc_html( sprintf( __( "%s can't be deleted because it doesn't exist.", 'co-authors-plus' ), $this->labels['singular'] ) ) );
 		}
 
@@ -478,6 +484,7 @@ class CoAuthors_Guest_Authors {
 			// Make sure the guest author actually exists
 			$guest_author = $this->get_guest_author_by( 'ID', (int) $_GET['id'] );
 			if ( ! $guest_author ) {
+				/* translators: Singular name of the guest author post type e.g. Guest Author. */
 				wp_die( esc_html( sprintf( __( "%s can't be deleted because it doesn't exist.", 'co-authors-plus' ), $this->labels['singular'] ) ) );
 			}
 
@@ -487,7 +494,9 @@ class CoAuthors_Guest_Authors {
 
 			echo '<div class="wrap">';
 			echo '<div class="icon32" id="icon-users"><br/></div>';
+			/* translators: Plural name of the guest author post type e.g. Guest Authors. */
 			echo '<h2>' . esc_html( sprintf( __( 'Delete %s', 'co-authors-plus ' ), $this->labels['plural'] ) ) . '</h2>';
+			/* translators: Singular name of the guest author post type e.g. Guest Author. */
 			echo '<p>' . esc_html( sprintf( __( 'You have specified this %s for deletion:', 'co-authors-plus' ), strtolower( $this->labels['singular'] ) ) ) . '</p>';
 			echo '<p>#' . esc_html( $guest_author->ID . ': ' . $guest_author->display_name ) . '</p>';
 			// display wording differently per post count
@@ -524,6 +533,7 @@ class CoAuthors_Guest_Authors {
 				// Leave mapped to a linked account
 				if ( get_user_by( 'login', $guest_author->linked_account ) ) {
 					echo '<li><label for="leave-assigned">';
+					/* translators: Name of a linked user account. */
 					echo '<input type="radio" id="leave-assigned" class="reassign-option" name="reassign" value="leave-assigned" />&nbsp;&nbsp;' . esc_html( sprintf( __( 'Leave posts assigned to the mapped user, %s.', 'co-authors-plus' ), $guest_author->linked_account ) );
 					echo '</label></li>';
 				}
@@ -1240,6 +1250,7 @@ class CoAuthors_Guest_Authors {
 
 			// Make sure required fields are there
 			if ( isset( $field['required'] ) && $field['required'] && empty( $args[ $field['key'] ] ) ) {
+				/* translators: Name of a form field. */
 				return new WP_Error( 'field-required', sprintf( __( '%s is a required field', 'co-authors-plus' ), $field['key'] ) );
 			}
 

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -251,8 +251,7 @@ class CoAuthors_Guest_Authors {
 		// Make sure the guest author actually exists
 		$guest_author = $this->get_guest_author_by( 'ID', (int) $_POST['id'] );
 		if ( ! $guest_author ) {
-			/* translators: Singular name of the guest author post type e.g. Guest Author. */
-			wp_die( esc_html( sprintf( __( "%s can't be deleted because it doesn't exist.", 'co-authors-plus' ), $this->labels['singular'] ) ) );
+			wp_die( esc_html__( "Guest author can't be deleted because it doesn't exist.", 'co-authors-plus' ) );
 		}
 
 		// Perform the reassignment if needed
@@ -484,8 +483,7 @@ class CoAuthors_Guest_Authors {
 			// Make sure the guest author actually exists
 			$guest_author = $this->get_guest_author_by( 'ID', (int) $_GET['id'] );
 			if ( ! $guest_author ) {
-				/* translators: Singular name of the guest author post type e.g. Guest Author. */
-				wp_die( esc_html( sprintf( __( "%s can't be deleted because it doesn't exist.", 'co-authors-plus' ), $this->labels['singular'] ) ) );
+				wp_die( esc_html__( "Guest author can't be deleted because it doesn't exist.", 'co-authors-plus' ) );
 			}
 
 			// get post count
@@ -494,16 +492,14 @@ class CoAuthors_Guest_Authors {
 
 			echo '<div class="wrap">';
 			echo '<div class="icon32" id="icon-users"><br/></div>';
-			/* translators: Plural name of the guest author post type e.g. Guest Authors. */
-			echo '<h2>' . esc_html( sprintf( __( 'Delete %s', 'co-authors-plus' ), $this->labels['plural'] ) ) . '</h2>';
-			/* translators: Singular name of the guest author post type e.g. Guest Author. */
-			echo '<p>' . esc_html( sprintf( __( 'You have specified this %s for deletion:', 'co-authors-plus' ), strtolower( $this->labels['singular'] ) ) ) . '</p>';
+			echo '<h2>' . esc_html__( 'Delete Guest Authors', 'co-authors-plus' ) . '</h2>';
+			echo '<p>' . esc_html__( 'You have specified this guest author for deletion:', 'co-authors-plus' ) . '</p>';
 			echo '<p>#' . esc_html( $guest_author->ID . ': ' . $guest_author->display_name ) . '</p>';
 			// display wording differently per post count
 			if ( 0 === $count ) {
-				$post_count_message = '<p>' . sprintf( __( 'There are no posts associated with this guest author.', 'co-authors-plus' ), strtolower( $this->labels['singular'] ) ) . '</p>';
+				$post_count_message = '<p>' . esc_html__( 'There are no posts associated with this guest author.', 'co-authors-plus' ) . '</p>';
 			} else {
-				$note = '<p class="description">' . sprintf( __( "Note: If you'd like to delete the %1\$s and all of their posts, you should delete their posts first and then come back to delete the %2\$s.", 'co-authors-plus' ), strtolower( $this->labels['singular'] ), strtolower( $this->labels['singular'] ) ) . '</p>';
+				$note = '<p class="description">' . __( "Note: If you'd like to delete the guest author and all of their posts, you should delete their posts first and then come back to delete the guest author.", 'co-authors-plus' ) . '</p>';
 				$post_count_message_text = sprintf(
 					/* translators: Count of posts */
 					_n(

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -179,7 +179,7 @@ class CoAuthors_Guest_Authors {
 				/* translators: Guest author profile preview URL. */
 				__( 'Guest author scheduled for: <strong>%1$s</strong>. <a target="_blank" href="%2$s">Preview profile</a>', 'co-authors-plus' ),
 				// translators: Publish box date format, see http://php.net/date
-				date_i18n( __( 'M j, Y @ G:i' ), strtotime( $post->post_date ) ),
+				date_i18n( __( 'M j, Y @ G:i', 'co-authors-plus' ), strtotime( $post->post_date ) ),
 				esc_url( $guest_author_link )
 			),
 			/* translators: Guest author profile preview URL. */
@@ -495,7 +495,7 @@ class CoAuthors_Guest_Authors {
 			echo '<div class="wrap">';
 			echo '<div class="icon32" id="icon-users"><br/></div>';
 			/* translators: Plural name of the guest author post type e.g. Guest Authors. */
-			echo '<h2>' . esc_html( sprintf( __( 'Delete %s', 'co-authors-plus ' ), $this->labels['plural'] ) ) . '</h2>';
+			echo '<h2>' . esc_html( sprintf( __( 'Delete %s', 'co-authors-plus' ), $this->labels['plural'] ) ) . '</h2>';
 			/* translators: Singular name of the guest author post type e.g. Guest Author. */
 			echo '<p>' . esc_html( sprintf( __( 'You have specified this %s for deletion:', 'co-authors-plus' ), strtolower( $this->labels['singular'] ) ) ) . '</p>';
 			echo '<p>#' . esc_html( $guest_author->ID . ': ' . $guest_author->display_name ) . '</p>';

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -241,6 +241,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			if ( ! empty( $coauthors ) ) {
 				WP_CLI::line(
 					sprintf(
+						/* translators: 1: Post ID, 2: Comma-separated list of co-author slugs. */
 						__( 'Skipping - Post #%1$d already has co-authors assigned: %2$s', 'co-authors-plus' ),
 						$post_id,
 						implode( ', ', wp_list_pluck( $coauthors, 'slug' ) )
@@ -884,7 +885,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		}
 
 		if ( $guest_author ) {
-			// translators: Guest Author ID.
+			/* translators: Guest Author ID. */
 			return WP_CLI::warning( sprintf( esc_html__( '-- Author already exists (ID #%s); skipping.', 'co-authors-plus' ), $guest_author->ID ) );
 		}
 
@@ -904,7 +905,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		);
 
 		if ( is_wp_error( $guest_author_id ) ) {
-			// translators: The error message.
+			/* translators: The error message. */
 			return WP_CLI::warning( sprintf( esc_html__( '-- Failed to create guest author: %s', 'co-authors-plus' ), $guest_author_id->get_error_message() ) );
 		}
 
@@ -914,7 +915,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		update_post_meta( $guest_author_id, '_original_author_login', $author['user_login'] );
 
-		// translators: Guest Author ID.
+		/* translators: Guest Author ID. */
 		WP_CLI::success( sprintf( esc_html__( '-- Created as guest author #%s', 'co-authors-plus' ), $guest_author_id ) );
 	}
 

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -233,7 +233,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		}
 
 		$post_types = implode( "','", $coauthors_plus->supported_post_types );
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching 
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ({$post_types})", $user->ID ) );
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
@@ -251,6 +251,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			$coauthors_plus->add_coauthors( $post_id, array( $coauthor->user_login ) );
+			/* translators: 1: Co-author login, 2: Post ID */
 			WP_CLI::line( sprintf( __( "Updating - Adding %1\$s's byline to post #%2\$d", 'co-authors-plus' ), $coauthor->user_login, $post_id ) );
 			$affected++;
 			if ( $affected && 0 === $affected % 100 ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -257,7 +257,18 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				sleep( 2 );
 			}
 		}
-		WP_CLI::success( sprintf( __( 'All done! %d posts were affected.', 'co-authors-plus' ), $affected ) );
+
+		$success_message = sprintf(
+			/* translators: Count of posts. */
+			_n(
+				'All done! %d post was affected.',
+				'All done! %d posts were affected.',
+				$affected,
+				'co-authors-plus'
+			),
+			number_format_i18n( $affected )
+		);
+		WP_CLI::success( $success_message );
 
 	}
 

--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -259,7 +259,7 @@ class Yoast {
 		}
 
 		$output = self::get_authors_display_names_output( $author_objects );
-		$data[ \__( 'Written by', 'wordpress-seo' ) ] = $output;
+		$data[ \__( 'Written by', 'co-authors-plus' ) ] = $output;
 		return $data;
 	}
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -299,6 +299,7 @@ function coauthors_posts_links_single( $author ) {
 		'before_html' => '',
 		'href'        => get_author_posts_url( $author->ID, $author->user_nicename ),
 		'rel'         => 'author',
+		/* translators: Author display name. */
 		'title'       => sprintf( __( 'Posts by %s', 'co-authors-plus' ), apply_filters( 'the_author', $author->display_name ) ),
 		'class'       => 'author url fn',
 		'text'        => apply_filters( 'the_author', $author->display_name ),
@@ -468,6 +469,7 @@ function coauthors_links_single( $author ) {
 		return sprintf(
 			'<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'website' ) ),
+			/* translators: Author display name. */
 			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )
 		);
@@ -475,6 +477,7 @@ function coauthors_links_single( $author ) {
 		return sprintf(
 			'<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'url' ) ),
+			/* translators: Author's display name. */
 			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )
 		);
@@ -690,6 +693,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 				$link = $name;
 			}
 		} else {
+			/* translators: Author name. */
 			$link = '<a href="' . get_author_posts_url( $author->ID, $author->user_nicename ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
 
 			if ( ( ! empty( $args['feed_image'] ) ) || ( ! empty( $args['feed'] ) ) ) {

--- a/template-tags.php
+++ b/template-tags.php
@@ -470,7 +470,7 @@ function coauthors_links_single( $author ) {
 			'<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'website' ) ),
 			/* translators: Author display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )
 		);
 	} elseif ( get_the_author_meta( 'url' ) ) {
@@ -478,7 +478,7 @@ function coauthors_links_single( $author ) {
 			'<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'url' ) ),
 			/* translators: Author's display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), esc_html( get_the_author() ) ) ),
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )
 		);
 	} else {

--- a/template-tags.php
+++ b/template-tags.php
@@ -95,7 +95,7 @@ class CoAuthorsIterator {
 		}
 
 		if ( ! $postID ) {
-			trigger_error( esc_html__( 'No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?', 'co-authors-plus' ) ); // return null;
+			trigger_error( esc_html( 'No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?' ) ); // return null;
 		}
 
 		$this->original_authordata = $this->current_author = $authordata;

--- a/template-tags.php
+++ b/template-tags.php
@@ -477,7 +477,7 @@ function coauthors_links_single( $author ) {
 		return sprintf(
 			'<a href="%s" title="%s" rel="author external">%s</a>',
 			esc_url( get_the_author_meta( 'url' ) ),
-			/* translators: Author's display name. */
+			/* translators: Author display name. */
 			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
 			esc_html( get_the_author() )
 		);
@@ -693,7 +693,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 				$link = $name;
 			}
 		} else {
-			/* translators: Author name. */
+			/* translators: Author display name. */
 			$link = '<a href="' . get_author_posts_url( $author->ID, $author->user_nicename ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
 
 			if ( ( ! empty( $args['feed_image'] ) ) || ( ! empty( $args['feed'] ) ) ) {

--- a/tests/test-coauthors-guest-authors.php
+++ b/tests/test-coauthors-guest-authors.php
@@ -482,7 +482,7 @@ class Test_CoAuthors_Guest_Authors extends CoAuthorsPlus_TestCase {
 		// Back up $_POST.
 		$_post_backup = $_POST;
 
-		$expected = sprintf( __( "%s can't be deleted because it doesn't exist.", 'co-authors-plus' ), $guest_author_obj->labels['singular'] );
+		$expected = __( "Guest author can't be deleted because it doesn't exist.", 'co-authors-plus' );
 
 		// Back up current user.
 		$current_user = get_current_user_id();


### PR DESCRIPTION
## Description

- I18n: Add missing translators comments
- I18n: Fix typos in strings
- I18n: Remove error message from i18n
- I18n: Mark-up pluralised strings correctly
- I18n: Add text domain to PHPCS config
- I18n: Add missing text domains
- I18n: Remove post type labels placeholders
- I18n: Use consistent translator comments
- I18n: Refreshed .pot file

## Deploy Notes

None specifically, though there should be new translations available for locales at https://translate.wordpress.org/projects/wp-plugins/co-authors-plus/ (as of now, en-gb has 100% completion of 129 strings in the Stable package).

## Steps to Test
