### PR TITLE
Author archive: ensure queried object ID is an int

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1221,7 +1221,7 @@ class CoAuthors_Plus {
 
 		if ( is_object( $authordata ) || ! empty( $term ) ) {
 			$wp_query->queried_object    = $authordata;
-			$wp_query->queried_object_id = $authordata->ID;
+			$wp_query->queried_object_id = (int) $authordata->ID;
 			if ( ! is_paged() ) {
 				add_filter( 'pre_handle_404', '__return_true' );
 			}


### PR DESCRIPTION
## Description

The `fix_author_page()` method amends the content of author archives. It modifies the queried object data if it's a real user or a guest author. The `WP_User::get_data_by()` method uses `$wpdb->get_row()` which makes a `stdClass`, and `\CoAuthors_Guest_Authors::get_guest_author_by()` casts an array to a `stdObject` object on return. As such, the ID property under both conditions becomes a string. This differs from the default queried object data when `fix_author_page()` is not run.

Fixes #645.


## Steps to Test

In `fix_author_page()`, add some `var_dump()` to show that the ID is a string. After patch, see that it is an integer.