### PR TITLE
Tests: Add previously deleted test back in

### DIFF
--- a/tests/test-author-queried-object.php
+++ b/tests/test-author-queried-object.php
@@ -82,4 +82,36 @@ class Test_Author_Queried_Object extends CoAuthorsPlus_TestCase {
 
 		restore_current_blog();
 	}
+
+	/**
+	 * On author pages, when paginated,
+	 * if page number is outside the range, throws 404.
+	 *
+	 * @group ms-required
+	 */
+	function test__author_non_existent_page_throws_404() {
+		global $wp_rewrite;
+
+		/**
+		 * Set up
+		 */
+		$author = $this->factory()->user->create( array( 'user_login' => 'author' ) );
+		$blog   = $this->factory()->blog->create( array( 'user_id' => $author ) );
+
+		switch_to_blog( $blog );
+		$wp_rewrite->init();
+
+		/**
+		* Author non-existent page throws 404
+		*/
+	   $non_existent_page = 1000;
+	   $this->go_to( get_author_posts_url( $author ) . 'page/' . $non_existent_page );
+	   $this->assertQueryTrue( 'is_404' );
+
+		/**
+		* Author existent page loads
+		*/
+	   $this->go_to( get_author_posts_url( $author ) );
+	   $this->assertQueryTrue( 'is_archive', 'is_author' );
+	}
 }


### PR DESCRIPTION
## Description

This test was previously failing but now seems to be working correctly. Previously removed (0f3def89f00eaca61c6004557c00f1cb6c709e7c) for 3.5.11.