### PR TITLE
Revert "Fixes CoAuthors Plus & Elementor Archive Pages conflict"

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1193,7 +1193,7 @@ class CoAuthors_Plus {
 	 */
 	public function fix_author_page( $selection ) {
 
-		global $wp_query, $authordata, $post;
+		global $wp_query, $authordata;
 
 		if ( ! isset( $wp_query ) ) {
 			return;
@@ -1208,12 +1208,7 @@ class CoAuthors_Plus {
 			return;
 		}
 
-		if ( ! isset( $post->post_author ) ) {
-			$author = $this->get_coauthor_by( 'user_nicename', $author_name );
-		} else {
-			$author = $this->get_coauthor_by( 'id', $post->post_author );
-		}
-
+		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
 		if ( is_object( $author ) ) {
 			$authordata = $author; //phpcs:ignore
 			$term       = $this->get_author_term( $authordata );


### PR DESCRIPTION
Reverts Automattic/Co-Authors-Plus#926

The original change was since found to have caused problems, with author archives showing the wrong bio (and title/avatar) or a missing bio.

The `fix_author_page()` is hooked to both `the_post()` (which makes sense), but also `posts_selection`, which makes less sense. A deeper understanding of what the intent of this function was meant to be is needed before further changes can be made to it. 