### PR TITLE
check get_current_screen exists

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1860,8 +1860,8 @@ class CoAuthors_Plus {
 		}
 
 		// Do not filter when on the user screen
-		$current_screen = get_current_screen();
-		if ( isset( $current_screen->parent_base ) && 'users' == $current_screen->parent_base ) {
+		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! is_null( $current_screen ) && isset( $current_screen->parent_base ) && 'users' === $current_screen->parent_base ) {
 			return $args;
 		}
 


### PR DESCRIPTION
The Avada theme (and possibly others) seem to try and retrieve avatars before the `get_current_screen()` method is available - see https://wordpress.org/support/topic/fatal-error-with-avada-theme/ and https://wordpress.org/support/topic/updated-recent-co-authors-plus-plugin-and-caused-error/ - so let's check we can use that function. It isn't easy to test without access to Avada itself.