### PR TITLE
Fix ajax_suggest user and guest author id collision

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1277,6 +1277,11 @@ class CoAuthors_Plus {
 		}
 
 		foreach ( $authors as $author ) {
+			$user_type = 'guest-user';
+			if ( $author instanceof WP_User ) {
+				$user_type = 'wp-user';
+			}
+			
 			printf(
 				"%s ∣ %s ∣ %s ∣ %s ∣ %s ∣ %s \n",
 				esc_html( $author->ID ),
@@ -1286,7 +1291,7 @@ class CoAuthors_Plus {
 				esc_html( str_replace( '∣', '|', $author->display_name ) ),
 				esc_html( $author->user_email ),
 				esc_html( rawurldecode( $author->user_nicename ) ),
-				esc_url( get_avatar_url( $author->ID ) )
+				esc_url( get_avatar_url( $author->ID,  array( 'user_type' => $user_type ) ) )
 			);
 		}
 


### PR DESCRIPTION
## Description

Related to #960. When a WordPress user shares the same id as a guest-author post id, the CAP meta box will display the wrong avatar after searching for user or guest author.

## Steps to Test

Ensure a guest author shares the same id (`post_id`) with a current WordPress user id.

* Login as the WordPress user 
* Create a new article and search for both the guest author and the WordPress user that have colliding ids in the Authors Metabox. Correct avatars will be displayed


