### PR TITLE
975-verification with isset before using properties

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -73,7 +73,8 @@ function is_coauthor_for_post( $user, $post_id = 0 ) {
 	}
 
 	foreach ( $coauthors as $coauthor ) {
-		if ( $user == $coauthor->user_login || $user == $coauthor->linked_account ) {
+		if ( ( isset( $coauthor->user_login ) && $user == $coauthor->user_login ) 
+			|| ( isset( $coauthor->linked_account ) && $user == $coauthor->linked_account ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## Description

This is just one line of code to ensure that we are not trying to access to an non existing property in an instance of a coauthor.

## Deploy Notes

No dependencies.

## Steps to Test

Basic fix, just a regular use of the plugin to ensure it goes ok.
