### PR TITLE
CLI: Add Behat functional tests

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,7 @@
+default:
+  suites:
+    default:
+      contexts:
+        - Automattic\CoAuthorsPlus\Tests\Behat\FeatureContext
+      paths:
+        - features

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,8 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
     "squizlabs/php_codesniffer": "^3.5",
+	"wp-cli/extension-command": "^2.0",
+	"wp-cli/wp-cli-tests": "^3",
     "wp-coding-standards/wpcs": "^2.3.0",
     "yoast/wp-test-utils": "^1.1"
   },
@@ -40,7 +42,12 @@
 		"classmap": [
 			"php"
 		]
-	},
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Automattic\\CoAuthorsPlus\\Tests\\": "tests/"
+	}
+  },
   "scripts": {
     "cs": [
       "@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"WordPress-VIP-Go\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
@@ -63,7 +70,10 @@
     "integration-ms": [
       "@putenv WP_MULTISITE=1",
       "@php ./vendor/bin/phpunit --exclude=ms-excluded"
-    ]
+    ],
+	"behat": "run-behat-tests",
+	"behat-rerun": "rerun-behat-tests",
+	"prepare-behat-tests": "install-package-tests"
   },
   "config": {
     "allow-plugins": {

--- a/features/create-guest-author.feature
+++ b/features/create-guest-author.feature
@@ -1,0 +1,23 @@
+Feature: Guest authors can be created
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+
+	Scenario: Create a guest author
+		When I run `wp co-authors-plus create-guest-authors`
+		Then STDOUT should be:
+      """
+      All done! Here are your results:
+      - 1 guest author profiles were created
+      - 0 users already had guest author profiles
+      """
+
+	Scenario: Try to create a guest authors a second time
+		When I run `wp co-authors-plus create-guest-authors`
+		Then I run the previous command again
+		Then STDOUT should be:
+      """
+      All done! Here are your results:
+      - 0 guest author profiles were created
+      - 1 users already had guest author profiles
+      """

--- a/features/rename-coauthor.feature
+++ b/features/rename-coauthor.feature
@@ -1,0 +1,45 @@
+Feature: Co-authors can be renamed
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+
+	Scenario: Error on a missing required --from parameter
+		When I try `wp co-authors-plus rename-coauthor --to="still-not-a-user"`
+		Then STDERR should be:
+          """
+	      Error: Parameter errors:
+           missing --from parameter
+          """
+
+	Scenario: Error on a missing required --to parameter
+		When I try `wp co-authors-plus rename-coauthor --from="not-a-user"`
+		Then STDERR should be:
+          """
+	      Error: Parameter errors:
+           missing --to parameter
+          """
+
+	Scenario: Error on an invalid co-author
+		When I try `wp co-authors-plus rename-coauthor --from="not-a-user" --to="still-not-a-user"`
+		Then STDERR should be:
+          """
+	      Error: No co-author found for not-a-user
+          """
+
+	Scenario: Try to rename co-author to the same name
+		When I try `wp co-authors-plus create-guest-authors`
+		Then I try `wp co-authors-plus rename-coauthor --from="admin" --to="admin"`
+		Then STDERR should be:
+          """
+	      Error: New user_login value conflicts with existing co-author
+          """
+
+	Scenario: Rename co-author
+		When I run `wp co-authors-plus create-guest-authors`
+		Then I run `wp co-authors-plus rename-coauthor --from="admin" --to="renamed-admin"`
+		Then STDOUT should be:
+          """
+	      Renaming admin to renamed-admin
+	      Updated guest author profile value too
+	      Success: All done!
+          """

--- a/features/testing.feature
+++ b/features/testing.feature
@@ -1,0 +1,28 @@
+  Feature: The Behat tests are configured correctly
+
+  Scenario: WP-CLI loads for your tests
+    Given a WP install
+
+    When I run `wp eval 'echo "Hello world.";'`
+    Then STDOUT should be:
+      """
+      Hello world.
+      """
+
+  Scenario: WP-CLI recognises plugin commands
+    Given a WP install
+
+    When I run `wp plugin --help`
+    Then STDOUT should contain:
+      """
+      Manages plugins, including installs, activations, and updates.
+      """
+
+  Scenario: WP-CLI recognises Co-Authors Plus commands when the plugin is loaded
+    Given a WP installation with the Co-Authors Plus plugin
+
+    When I run `wp co-authors-plus --help`
+    Then STDOUT should contain:
+      """
+      Manage co-authors and guest authors.
+      """

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Co-Authors Plus commands for the WP-CLI framework
+ * Manage co-authors and guest authors.
  *
  * @package wp-cli
  * @since 3.0

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Feature tests context class with Co-Authors Plus specific steps.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+namespace Automattic\CoAuthorsPlus\Tests\Behat;
+
+use WP_CLI\Tests\Context\FeatureContext as WP_CLI_FeatureContext;
+
+/**
+ * Feature tests context class with Co-Authors Plus-specific steps.
+ *
+ * This class extends the one that is provided by the wp-cli/wp-cli-tests package.
+ * To see a list of all recognized step definitions, run `vendor/bin/behat -dl`.
+ */
+final class FeatureContext extends WP_CLI_FeatureContext {
+
+	/**
+	 * Set up the plugin to be active.
+	 *
+	 * @Given a WP install(ation) with the Co-Authors Plus plugin
+	 *
+	 * Adapted from https://github.com/wearerequired/traduttore/blob/master/tests/phpunit/tests/Behat/FeatureContext.php
+	 * with credit and thanks to them.
+	 */
+	public function given_a_wp_installation_with_the_cap_plugin() {
+		$this->install_wp();
+
+		// Symlink the current project folder into the WP folder as a plugin.
+		$project_dir = realpath( self::get_vendor_dir() . '/../' );
+		$plugin_dir  = $this->variables['RUN_DIR'] . '/wp-content/plugins';
+		$this->ensure_dir_exists( $plugin_dir );
+		$this->proc( "ln -s {$project_dir} {$plugin_dir}/co-authors-plus" )->run_check();
+
+		// Activate the plugin.
+		$this->proc( 'wp plugin activate co-authors-plus' )->run_check();
+	}
+
+	/**
+	 * Ensure that a requested directory exists and create it recursively as needed.
+	 *
+	 * Copied as is from the Tradutorre repo as well.
+	 *
+	 * @param string $directory Directory to ensure the existence of.
+	 * @throws \RuntimeException Directory could not be created.
+	 */
+	private function ensure_dir_exists( $directory ) {
+		$parent = dirname( $directory );
+
+		if ( ! empty( $parent ) && ! is_dir( $parent ) ) {
+			$this->ensure_dir_exists( $parent );
+		}
+
+		if ( ! is_dir( $directory ) && ! mkdir( $directory ) && ! is_dir( $directory ) ) {
+			throw new \RuntimeException( "Could not create directory '{$directory}'." );
+		}
+	}
+
+	/**
+	 * Add a published post.
+	 *
+	 * @Given there is a published post with a slug of :post_name
+	 *
+	 * @param string $post_name Post name to use.
+	 */
+	public function there_is_a_published_post( $post_name ) {
+		$this->proc( "wp post create --post_title='{$post_name}' --post_name='{$post_name}' --post_status='publish'" )->run_check();
+	}
+}


### PR DESCRIPTION
## Description

Behat is a good tool to use for testing the output of CLI commands. This PR adds the general Behat setup, and a few basic tests (not comprehensive) to get started with.

## Steps to Test

Run `composer update && composer prepare-behat-tests` as a one-off task, then run `composer behat` to run the tests.## Description