### PR TITLE
Check if $term->term_id is set before using it to delete the term

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1061,7 +1061,10 @@ class CoAuthors_Plus {
 		if ( is_object( $delete_user ) ) {
 			// Delete term
 			$term = $this->get_author_term( $delete_user );
-			wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
+
+			if ( isset( $term->term_id ) ) {
+				wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
+			}
 		}
 
 		if ( $this->is_guest_authors_enabled() ) {


### PR DESCRIPTION
## Description

Make sure to check if `$term->term_id` is set before using it to delete the term. This will fix the following PHP notice:

```
PHP Notice:  Trying to get property 'term_id' of non-object in [redacted]/wp-content/plugins/co-authors-plus/co-authors-plus.php on line 1064
```

## Steps to Test

1. Go to Users page.
2. Try to delete a user who is not an author.
