### PR TITLE
i18n: Add text domain header

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -5,6 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/co-authors-plus/
 Description: Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
 Version: 3.5.13
 Author: Mohammad Jangda, Daniel Bachhuber, Automattic
+Text Domain: co-authors-plus
 Copyright: 2008-2015 Shared and distributed between Mohammad Jangda, Daniel Bachhuber, Weston Ruter
 
 GNU General Public License, Free Software Foundation <http://creativecommons.org/licenses/GPL/2.0/>


### PR DESCRIPTION
## Description
Since the plugin still claims to support WordPress < 4.5, then the text domain header is still needed for language packs to work correctly.

Fixes #983.