### PR TITLE
Fix avatar collision on profile, post and edit screens

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1960,6 +1960,16 @@ class CoAuthors_Plus {
 			return $args;
 		}
 
+		// Do not filter on the post list screen, profile screen, and post takeover pop-up.
+		if ( isset( $current_screen->base ) && ( 'post' === $current_screen->base || 'profile' === $current_screen->base || 'edit' === $current_screen->base ) ) {
+			return $args;
+		}
+
+		// Do not filter the avatar if this is doing a heartbeat request on WP refresh lock.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Only checking action name, not processing data.
+		if ( wp_doing_ajax() && isset( $_POST['action'] ) && 'heartbeat' === sanitize_key( $_POST['action'] ) ) {
+			return $args;
+		}
 
 		$coauthor = $this->get_coauthor_by( 'id', $id );
 		if ( false !== $coauthor && isset( $coauthor->type ) && 'guest-author' === $coauthor->type ) {


### PR DESCRIPTION
## Description

Fixes filtering issues when a user has the same id as a guest-author post id on the post list screen, profile screen and the post edit takeover pop-up.

Related: #960 #973 #974

## Steps to Test

Create a guest user that has the same `post_id` as another WP `user_id`.

In one browser, log in as the WordPress user and edit a post. In another browser login as the guest user. While logged in as a guest user, go to the post list at `/wp-admin/edit.php` the post will be locked as it's being edited by the WordPress user, however, the incorrect guest user's gravatar will be displayed.

<img width="229" alt="Screenshot 2023-09-06 at 2 35 42 PM" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/4d226f66-0529-4749-b044-864c2af84561">

Correct avatar should be:
<img width="219" alt="Screenshot 2023-09-06 at 2 58 47 PM" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/c0c44a69-cb57-465d-b245-572e595291b5">


Click edit on the post that is being edited, the warning popup will also have the incorrect gravatar from the guest user.
<img width="479" alt="Screenshot 2023-09-06 at 2 37 52 PM" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/b1f2d0b0-95df-492f-9d44-7855a6936b99">

Correct avatar should be:

<img width="471" alt="Screenshot 2023-09-06 at 1 22 37 PM" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/5dc52e90-f479-4727-9e6f-864f02798983">

Take over the post editing. Go back to the browser where the Guest User was editing the post and wait for the "Somone else has taken over this post" pop-up. The incorrect avatar will be displayed:

 
<img width="481" alt="Screenshot on 2023-09-15 at 14-10-16" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/ff85b21f-ae4f-4154-baea-5d3697df6c61">

The correct avatar should be:

<img width="481" alt="Screenshot on 2023-09-15 at 14-05-54" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/6ac67dd0-9303-4326-be6b-a1e46ffabe60">



Now log in as the WordPress user and go to the profile page at `/wp-admin/profile.php` the incorrect gravatar is displayed.

<img width="569" alt="Screenshot 2023-09-06 at 2 40 37 PM" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/97644067-fcd3-41b3-83c1-f0c79467b3f9">

The correct avatar for the WordPress user: 
<img width="570" alt="Screenshot 2023-09-06 at 2 59 38 PM" src="https://github.com/Automattic/Co-Authors-Plus/assets/3019634/fdcb00f2-8d48-4ab0-898e-1332e6aca2ca">






