### PR TITLE
UI: Add capability check to Add New button

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -12,6 +12,7 @@ class CoAuthors_Guest_Authors {
 	public $post_type              = 'guest-author';
 	public $parent_page            = 'users.php';
 	public $list_guest_authors_cap = 'list_users';
+	public $add_guest_author_cap   = 'edit_posts';
 
 	public static $cache_group = 'coauthors-plus-guest-authors';
 
@@ -546,11 +547,15 @@ class CoAuthors_Guest_Authors {
 			echo '</form>';
 			echo '</div>';
 		} else {
-			// @todo caps check for creating a new user
 			?>
 			<div class="wrap">
 				<h1 class="wp-heading-inline"><?php echo esc_html( get_admin_page_title() ); ?></h1>
-				<a href="<?php echo esc_url( admin_url( "post-new.php?post_type={$this->post_type}" ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add New', 'co-authors-plus' ); ?></a>
+				<?php
+				if ( current_user_can( $this->add_guest_author_cap ) ) {
+					$add_new_url = admin_url( "post-new.php?post_type={$this->post_type}" );
+					?><a href="<?php echo esc_url( $add_new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'co-authors-plus' ); ?></a><?php
+				}
+				?>
 				<hr class="wp-header-end" />
 				<form id="guest-authors-filter" action="" method="GET">
 					<input type="hidden" name="page" value="view-guest-authors" />


### PR DESCRIPTION
## Description

- Take a role like Subscriber which only has `read` capability.
- Adding `list_users` to an account with a Subscriber role allows the Users admin menu to appear, and the Guest Authors list page to be accessed.
- However, clicking on the Add New button won't work, as they haven't got permission to edit this post type.
- Allowing `edit_posts` capability allows the Add New screen to be accessed; currently the `list_authors` capability is used on the handling of the guest author creation.

Fixes #1001.

### Before

Button visible, but clicking through leads to a cap check failure.

<img width="330" alt="Screenshot 2023-09-19 at 16 45 35" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/f6185a6f-9364-4b78-a731-ee6c66c21eb1">

<img width="423" alt="Screenshot 2023-09-19 at 16 53 53" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/06781419-dbe2-427a-a90f-f1f2daafb882">


### After

Button not visible. Trying to accessing the page directly through URL manipulation will still give the cap check failure.

<img width="330" alt="Screenshot 2023-09-19 at 16 46 03" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/dc4df706-726f-4774-8d22-b2e0d1f84324">
