### PR TITLE
Add supported_post_types() method

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -239,7 +239,7 @@ class Endpoints {
 	 */
 	public function modify_responses() {
 
-		$post_types = $this->coauthors->supported_post_types;
+		$post_types = $this->coauthors->supported_post_types();
 
 		if ( empty( $post_types ) || ! is_array( $post_types ) ) {
 			return;

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -208,14 +208,7 @@ class CoAuthors_Plus {
 			add_action( 'edited_term_taxonomy', array( $this, 'action_edited_term_taxonomy_flush_cache' ), 10, 2 );
 		}
 
-		$post_types_with_authors = array_values( get_post_types() );
-		foreach ( $post_types_with_authors as $key => $name ) {
-			if ( ! post_type_supports( $name, $this->coauthor_taxonomy ) || in_array( $name, array( 'revision', 'attachment' ) ) ) {
-				unset( $post_types_with_authors[ $key ] );
-			}
-		}
-		$this->supported_post_types = apply_filters( 'coauthors_supported_post_types', $post_types_with_authors );
-		register_taxonomy( $this->coauthor_taxonomy, $this->supported_post_types, $args );
+		register_taxonomy( $this->coauthor_taxonomy, $this->supported_post_types(), $args );
 	}
 
 	/**
@@ -373,7 +366,7 @@ class CoAuthors_Plus {
 			}
 		}
 
-		return in_array( $post_type, $this->supported_post_types );
+		return in_array( $post_type, $this->supported_post_types() );
 	}
 
 	/**
@@ -1410,7 +1403,7 @@ class CoAuthors_Plus {
 	public function load_edit() {
 
 		$screen = get_current_screen();
-		if ( in_array( $screen->post_type, $this->supported_post_types ) ) {
+		if ( in_array( $screen->post_type, $this->supported_post_types() ) ) {
 			add_filter( 'views_' . $screen->id, array( $this, 'filter_views' ) );
 		}
 	}
@@ -1496,11 +1489,11 @@ class CoAuthors_Plus {
 	 * @return array caps that CAP should filter
 	 */
 	public function get_to_be_filtered_caps() {
-		if ( ! empty( $this->supported_post_types ) && empty( $this->to_be_filtered_caps ) ) {
+		if ( ! empty( $this->supported_post_types() ) && empty( $this->to_be_filtered_caps ) ) {
 			$this->to_be_filtered_caps[] = 'edit_post'; // Need to filter this too, unfortunately: http://core.trac.wordpress.org/ticket/22415
 			$this->to_be_filtered_caps[] = 'read_post';
 
-			foreach ( $this->supported_post_types as $single ) {
+			foreach ( $this->supported_post_types() as $single ) {
 				$obj = get_post_type_object( $single );
 
 				$this->to_be_filtered_caps[] = $obj->cap->edit_post;

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -247,6 +247,45 @@ class CoAuthors_Plus {
 	}
 
 	/**
+	 * Get the list of supported post types.
+	 *
+	 * By default, this is the built-in and custom post types that have authors.
+	 *
+	 * @since 3.5.16
+	 *
+	 * @return array Supported post types.
+	 */
+	public function supported_post_types() {
+		$post_types = array_values( get_post_types() );
+
+		$excluded_built_in = array(
+			'revision',
+			'attachment',
+			'customize_changeset',
+			'wp_template',
+			'wp_template_part',
+		);
+
+		foreach ( $post_types as $key => $name ) {
+			if ( ! post_type_supports( $name, 'author' ) || in_array( $name, $excluded_built_in, true ) ) {
+				unset( $post_types[ $key ] );
+			}
+		}
+
+		/**
+		 * Filter the list of supported post types.
+		 *
+		 * @param array $post_types Post types.
+		 */
+		$supported_post_types = (array) apply_filters( 'coauthors_supported_post_types', $post_types );
+
+		// Set class property for back-compat.
+		$this->supported_post_types = $supported_post_types;
+
+		return $supported_post_types;
+	}
+
+	/**
 	 * Check whether the guest authors functionality is enabled or not
 	 * Guest authors can be disabled entirely with:
 	 *     add_filter( 'coauthors_guest_authors_enabled', '__return_false' )

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -62,7 +62,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$args = array(
 			'order'             => 'ASC',
 			'orderby'           => 'ID',
-			'post_type'         => $coauthors_plus->supported_post_types,
+			'post_type'         => $coauthors_plus->supported_post_types(),
 			'posts_per_page'    => 100,
 			'paged'             => 1,
 			'update_meta_cache' => false,
@@ -235,7 +235,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'Please specify a valid co-author login', 'co-authors-plus' ) );
 		}
 
-		$post_types = implode( "','", $coauthors_plus->supported_post_types );
+		$post_types = implode( "','", $coauthors_plus->supported_post_types() );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ({$post_types})", $user->ID ) );
 		$affected = 0;

--- a/tests/Integration/EndpointsTest.php
+++ b/tests/Integration/EndpointsTest.php
@@ -396,7 +396,7 @@ class EndpointsTest extends TestCase {
 	public function test_modify_response() {
 		$this->_api->modify_responses();
 
-		foreach ( $this->_cap->supported_post_types as $post_type ) {
+		foreach ( $this->_cap->supported_post_types() as $post_type ) {
 			$this->assertEquals(
 				10,
 				has_filter(


### PR DESCRIPTION
## Description

Allows the method to be called at any time, not just as part of an action callback.

This will help in being able to remove some global variable references in tests.

Removes extra built-in post types that have support for an author, but aren't visible and useful for co-authors to be added.

The class property is populated for back-compat, but this could be removed in a major release.

Includes tests.