### PR TITLE
Increase minimum WordPress version to 5.9

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,18 +13,23 @@ jobs:
 
     strategy:
       matrix:
-        wordpress: [ '5.9', '6.5' ]
-        php: [ '7.4', 'latest' ]
-        allowed_failure: [ false ]
         include:
+          # Check lowest supported WP version, with the lowest supported PHP.
+          - wordpress: '5.9'
+            php: '7.4'
+            allowed_failure: false
+          # Check latest WP with the highest supported PHP.
+          - wordpress: 'latest'
+            php: 'latest'
+            allowed_failure: false
           # Check upcoming WP.
-          - php: 'latest'
-            wordpress: 'trunk'
+          - wordpress: 'trunk'
+            php: 'latest'
             allowed_failure: true
-          # Check upcoming PHP.
-          - php: '8.4'
-            wordpress: 'latest'
-            allowed_failure: true
+          # Check upcoming PHP - only needed when a new version has been forked (typically Sep-Nov)
+#          - wordpress: 'trunk'
+#            php: 'nightly'
+#            allowed_failure: true
       fail-fast: false
 
     steps:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -13,22 +13,18 @@ jobs:
 
     strategy:
       matrix:
-        wordpress: [ '5.7', '6.3' ]
-        php: [ '7.4', '8.0', '8.2' ]
+        wordpress: [ '5.9', '6.5' ]
+        php: [ '7.4', 'latest' ]
         allowed_failure: [ false ]
         include:
           # Check upcoming WP.
-          - php: '8.2'
+          - php: 'latest'
             wordpress: 'trunk'
             allowed_failure: true
           # Check upcoming PHP.
-          - php: '8.3'
+          - php: '8.4'
             wordpress: 'latest'
             allowed_failure: true
-        exclude:
-          # WordPress 5.7 doesn't support PHP 8.2.
-          - php: '8.2'
-            wordpress: '5.7'
       fail-fast: false
 
     steps:
@@ -42,11 +38,6 @@ jobs:
           extensions: ${{ matrix.extensions }}
           ini-values: ${{ matrix.ini-values }}
           coverage: ${{ matrix.coverage }}
-
-      - name: Install PHPUnit 7.x for WP < 5.9
-        if: ${{ matrix.wordpress < 5.9 }}
-        # Ignore platform requirements, so that PHPUnit 7.5 can be installed on PHP 8.0 (and above).
-        run: composer require --dev phpunit/phpunit:"^7.5" --ignore-platform-req=php+ --no-update --no-scripts --no-interaction
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
  * Version:           3.6.1
- * Requires at least: 5.7
+ * Requires at least: 5.9
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
  * Author URI:        https://automattic.com

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"dms/phpunit-arraysubset-asserts": "^0.5.0",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
+		"phpunit/phpunit": "^9",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-cli/extension-command": "^2.0",
 		"wp-cli/wp-cli-tests": "^3",


### PR DESCRIPTION
## Description

Increase the minimum supported WordPress version to 5.9, which allows for a simpler tests setup, since all of the PHPUnit-Polyfills are bundled with WordPress core. This includes a handful of changes:

- Increase the plugin's minimum WordPress version to `5.9`
- Update integration tests to run against WordPress `5.9` at minimum
- Remove unnecessary composer libraries needed for < `5.9`