### PR TITLE
Fix missing author column in wp-admin Posts table

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -250,7 +250,7 @@ class CoAuthors_Plus {
 	 *
 	 * By default, this is the built-in and custom post types that have authors.
 	 *
-	 * @since 3.5.16
+	 * @since 3.6.0
 	 *
 	 * @return array Supported post types.
 	 */
@@ -487,13 +487,23 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Removes the default 'author' dropdown from quick edit
+	 * Removes the default 'author' dropdown from quick edit.
 	 */
 	public function remove_quick_edit_authors_box() {
 		global $pagenow;
 
 		if ( 'edit.php' === $pagenow && $this->is_post_type_enabled() ) {
-			remove_post_type_support( get_post_type(), $this->coauthor_taxonomy );
+			/*
+			 * The author dropdown isn't displayed if wp_dropdown_users( $args ) returns an empty string.
+			 * It will return an empty string if the user query returns an empty array.
+			 * We can force it return an empty array by changing $args to include only the user ID 0 which doesn't exist.
+			 * We can target the $args specific to Quick Edit using the filter quick_edit_dropdown_authors_args.
+			 * See https://github.com/Automattic/Co-Authors-Plus/issues/1033.
+			 */
+			add_filter(
+				'quick_edit_dropdown_authors_args',
+				static fn() => [ 'include' => [ 0 ] ]
+			);
 		}
 	}
 


### PR DESCRIPTION
## Description

In CAP 3.6.0, there was [a bug](https://github.com/Automattic/Co-Authors-Plus/issues/1033) that resulted in the author's column missing in wp-admin Posts table. When removing the author dropdown from the quick edit box, the old logic removed post type support for the CAP-registered author taxonomy, which has the same name as the regular author feature. This hard-hitting removal was likely due to the "inconvenient truths" documented in #1036.

The new logic has a more targeted approach - it updates the query args for getting the quick-edit authors list population to only try and include a `0`, and this successfully bails the dropdown from being displayed.

Fixes #1033.
Fixed #1037.
Closes #1036.

## Steps to Test

Use `3.6.0` tag and see that the author column is missing. Switch to the PR branch, and see that the author column is present. In both cases, the quick edit does not show the author box.

## Screenshots

### 3.6.0
Author column not present (incorrect):

<img width="670" alt="Screenshot 2024-04-25 at 16 06 22" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/00002211-dfea-4a54-98d6-acbea6d3bd1d">

### This PR
Author column present (correct):

<img width="670" alt="Screenshot 2024-04-25 at 16 06 35" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/294810d1-4819-4336-b94c-08bbc03f129a">

Quick Edit view does not include author box (correct):

<img width="709" alt="Screenshot 2024-04-25 at 16 05 50" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/5f269177-a253-4983-b0a4-d6cf9ab016e0">

(For comparison, here's what the view would look like with the author box - we don't want this):

<img width="709" alt="Screenshot 2024-04-25 at 16 05 15" src="https://github.com/Automattic/Co-Authors-Plus/assets/88371/69a16bd4-ed48-42fc-839f-911701d5429f">
