### PR TITLE
Release 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] - 2024-04-25
+
+### Fixed
+
+* Fix missing author column in wp-admin Posts table #1038
+
 ## [3.6.0] - 2024-04-22
 
 ### Added
@@ -488,6 +494,7 @@ Props to the many people who helped make this release possible: [catchmyfame](ht
 **1.1.0 (Apr. 14, 2009)**
 * Initial beta release.
 
+[3.6.1]: https://github.com/automattic/co-authors-plus/compare/3.6.0..3.6.1
 [3.6.0]: https://github.com/automattic/co-authors-plus/compare/3.5.15...3.6.0
 [3.5.15]: https://github.com/automattic/co-authors-plus/compare/3.5.14...3.5.15
 [3.5.14]: https://github.com/automattic/co-authors-plus/compare/3.5.13...3.5.14

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# Co-Authors Plus
 
-Stable tag: 3.6.0  
+Stable tag: 3.6.1  
 Requires at least: 4.1  
 Tested up to: 6.5  
 Requires PHP: 5.6  

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Co-Authors Plus
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
- * Version:           3.6.0
+ * Version:           3.6.1
  * Requires at least: 5.7
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
@@ -21,7 +21,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const COAUTHORS_PLUS_VERSION = '3.6.0';
+const COAUTHORS_PLUS_VERSION = '3.6.1';
 const COAUTHORS_PLUS_FILE = __FILE__;
 
 require_once __DIR__ . '/template-tags.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "co-authors-plus",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "co-authors-plus",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "Allows multiple authors to be assigned to a post.",
 	"license": "GPL-2.0-or-later",
 	"private": true,


### PR DESCRIPTION
## Description

This minor patch fixes missing authors from the posts table documented in https://github.com/Automattic/Co-Authors-Plus/issues/1033 and https://github.com/Automattic/Co-Authors-Plus/issues/1037:

- Fix missing author column in wp-admin Posts table #1038
