### PR TITLE
Composer: Update dev-dependencies & consolidate PHPCS

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -2,12 +2,18 @@
 <ruleset name="WordPress Coding Standards for Plugins">
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
-	<rule ref="WordPress-Extra" />
-	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-VIP-Go" />
-	<rule ref="WordPress">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
-	</rule>
+
+	<!-- Rules: WordPress Coding Standards - see
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+<!--	<rule ref="WordPress-Extra">--> <!-- Includes WordPress-Core -->
+<!--		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />-->
+<!--	</rule>-->
+	<!--<rule ref="WordPress-Docs"/>-->
+	<!-- For help in understanding this minimum_supported_wp_version:
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
+	<config name="minimum_supported_wp_version" value="5.9"/>
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
@@ -17,12 +23,15 @@
 	</rule>
 
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 
-	<arg name="extensions" value="php"/>
-
-	<!-- Show sniff codes in all reports -->
-	<arg value="s"/>
+	<!-- How to scan -->
+	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg value="n"/> <!-- No warnings -->
+	<arg name="colors"/> <!-- Show results with colors. Disable if working on Windows -->
+	<arg name="basepath" value="."/> <!-- Strip the file paths down to the relevant bit -->
+	<arg name="parallel" value="8"/> <!-- Enables parallel processing when available for faster results -->
+	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
 
 	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
 	<file>.</file>
@@ -30,5 +39,6 @@
 	<exclude-pattern>*/dev-lib/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/dist/*</exclude-pattern>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -56,10 +56,10 @@
 			"@php ./vendor/bin/phpunit --exclude=ms-excluded"
 		],
 		"cs": [
-			"@php ./vendor/bin/phpcs -p -s -v -n . --standard=\"WordPress-VIP-Go\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
+			"@php ./vendor/bin/phpcs"
 		],
 		"cbf": [
-			"@php ./vendor/bin/phpcbf -p -s -v -n . --standard=\"WordPress-VIP-Go\" --extensions=php --ignore=\"/vendor/*,/node_modules/*,/tests/*\""
+			"@php ./vendor/bin/phpcbf"
 		],
 		"lint": [
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"

--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,14 @@
 		"php": ">=7.4"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "^2.2",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+		"automattic/vipwpcs": "^3",
 		"dms/phpunit-arraysubset-asserts": "^0.5.0",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"phpunit/phpunit": "^9",
-		"squizlabs/php_codesniffer": "^3.5",
 		"wp-cli/extension-command": "^2.0",
-		"wp-cli/wp-cli-tests": "^3",
-		"wp-coding-standards/wpcs": "^2.3.0",
+		"wp-cli/wp-cli-tests": "^v4",
+		"wp-coding-standards/wpcs": "^3.1",
 		"yoast/wp-test-utils": "^1.2"
 	},
 	"autoload": {


### PR DESCRIPTION
## Description

Update dev-dependencies.

Also consolidates PHPCS configs into the PHPCS config file instead of the composer.json command overriding the config values. In time, the tests directory should have the CS fixed, the warnings should not be ignored, and WordPress-Extra and WordPress-Docs can be enabled and the code updated as needed.

## Deploy Notes

None

## Steps to Test

None - if tests continue to pass, then all good for now.