### PR TITLE
Support for Yoast `Name` variable

### DIFF
--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -87,6 +87,7 @@ class Yoast {
 		add_filter( 'wpseo_enhanced_slack_data', [__CLASS__, 'filter_slack_data'], 10, 2 );
 		add_filter( 'wpseo_robots_array', [ __CLASS__, 'allow_indexing_guest_author_archive' ], 10, 2 );
 		add_filter( 'wpseo_opengraph_url', [ __CLASS__, 'fix_guest_author_archive_url_presenter' ], 10, 2 );
+		add_filter( 'wpseo_replacements', [ __CLASS__, 'filter_author_name_variable' ], 10, 2 );
 	}
 
 	/**
@@ -326,6 +327,30 @@ class Yoast {
 		}
 
 		return get_author_posts_url( $user->ID, $user->user_nicename );
+	}
+
+	/**
+	 * Uses guest authors in the '%%name%%' Yoast variable when needed.
+	 *
+	 * See https://yoast.com/features/meta-tag-variables/.
+	 *
+	 * @param array    $replacements Key/val pair of variables and their transformed value.
+	 * @param stdClass $args         Info about current queried object.
+	 * @return array   Modified $replacements.
+	 */
+	public static function filter_author_name_variable( $replacements, $args ): array {
+		if ( isset( $replacements['%%name%%'], $args->ID ) ) {
+			$author_objects = get_coauthors( $args->ID );
+
+			// Fallback in case of error.
+			if ( empty( $author_objects ) ) {
+				return $replacements;
+			}
+
+			$replacements['%%name%%'] = self::get_authors_display_names_output( $author_objects );
+		}
+
+		return $replacements;
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds support for the `%%name%%` variable that Yoast uses for meta descriptions. Currently this variable will display the name of the user that created a post instead of the guest/multiple authors.

Ref:
- https://yoast.com/features/meta-tag-variables/
- https://yoast.com/help/list-available-snippet-variables-yoast-seo/

## Deploy Notes

Should be safe. No compatibility implications.

## Steps to Test

1. Before applying this PR, have a site with CAP and Yoast SEO active.
2. At the bottom of a post with a guest author, in the Yoast meta area, add the `Name` variable in the SEO title field. Observe in the preview it shows the non-guest-author. In the frontend source code there should be a `<title>` tag in the head that has the same wording as that preview.

<img width="1728" alt="Screenshot 2024-05-14 at 10 19 05 AM" src="https://github.com/Automattic/Co-Authors-Plus/assets/7317227/bb1e1ff2-1495-4982-96e7-745bfd7b804c">


3. Apply this PR. Refresh the edit and the frontend pages. The preview and `<title>` tag should accurately reflect the guest author.

<img width="1717" alt="Screenshot 2024-05-14 at 10 21 34 AM" src="https://github.com/Automattic/Co-Authors-Plus/assets/7317227/1b0b9c4d-4be0-49f5-9ba6-28e621b3f4c9">


4. Add more than one author. Refresh the edit and the frontend pages. The preview and `<title>` tag should accurately reflect the authors.