### PR TITLE
Add an action to signal processing co-author has finished

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1029,6 +1029,7 @@ class CoAuthors_Plus {
 			$wpdb->update( $wpdb->posts, array( 'post_author' => $new_author->ID ), array( 'ID' => $post_id ) );
 			clean_post_cache( $post_id );
 		}
+	        do_action('coauthors_post_updated', $post_id, $coauthor_objects);
 		return true;
 
 	}

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -956,6 +956,8 @@ class CoAuthors_Plus {
 				}
 			}
 		}
+		do_action('cap_finished', $post_id);
+
 	}
 
 	public function has_author_terms( $post_id ): bool {
@@ -1029,7 +1031,6 @@ class CoAuthors_Plus {
 			$wpdb->update( $wpdb->posts, array( 'post_author' => $new_author->ID ), array( 'ID' => $post_id ) );
 			clean_post_cache( $post_id );
 		}
-	        do_action('coauthors_post_updated', $post_id, $coauthor_objects);
 		return true;
 
 	}


### PR DESCRIPTION
## Description

Adds a (partly) solution for #1024. Which we also encounter at our company.
We sync posts to an external database secondary database, so we need to know when all data has been updated. 

Because CAP saves co-authors with CPTs and metadata, the authors are updated only after save_post has finished.
It's counter-intuitive from a user perspective but logical from the architecture perspective.

This PR adds an action to explicitly signal when CAP has finished processing, allowing it to hook into that, for example, when syncing to external systems.

## Deploy Notes
❌

## Steps to Test
- Add a minimal plugin that hooks into the save_post action and var_dump (or use a tool like Xdebug to use step debugging)
- Observe that the save_post hook doesn't have up-to-date data when updating an author
- Check out this PR
- Observe the previous functionality is unchanged
- Observe that a new hook is now present that fires after the co-author has been updated, allowing for a direct hook into that.
<details>
<summary>Minimal reproduction</summary>

``` php

<?php  
  
add_action('save_post', 'savePost', 10, 2 );  
  
function savePost ($post_id, $post) {  
    var_dump($post);  
    return true;}  
  
add_action('coauthors_post_updated', 'coAuthorUpdate', 10, 2 );  
  
function coAuthorUpdate ($post_id, $coauthor_objects) {  
    var_dump($coauthor_objects);  
    return true;}  
  
?>

````
</details>
