### PR TITLE
Docs: Fix code blocks for WPORG view of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Use the inline layout to display co-authors in a list on a single wrapping line.
 
 You can control the characters displayed before, between and after co-authors in the list using the block settings, or change the defaults using the following server-side filters:
 
-```
+~~~
 coauthors_default_before
 coauthors_default_between
 coauthors_default_between_last
 coauthors_default_after
-```
+~~~
 
 #### Block Layout
 
@@ -135,11 +135,11 @@ If you want to display data about the author on their own archive, use the indiv
 If you make a custom block and want to use the author context, add `co-authors-plus/author` to the `usesContext` property in your block.json file.
 
 Example:
-```json
+~~~json
 {
 	"usesContext": ["co-authors-plus/author"]
 }
-```
+~~~
 
 ## Block Example Data
 


### PR DESCRIPTION
## Description

The Markdown parser for the README.md on the WordPress.org plugin repository works slightly differently than in GitHub. Over there, it requires the 3x tilde code fence, rather than the backticks. GitHub supports both. Any language marker is ignored over there when tilde code fences are used, so we can still use it for syntax highlighting in GitHub.

## Steps to Test

See the following screenshots of how it's currently broken with the backtick code fences:

The `JSON` language marker is visible:
<img width="485" alt="Screenshot 2024-08-09 at 15 46 22" src="https://github.com/user-attachments/assets/70419e0e-1fec-4205-8c80-6aa2875e4e09">

The code is outside of the rendered code block.
<img width="797" alt="Screenshot 2024-08-09 at 15 46 33" src="https://github.com/user-attachments/assets/69130ca8-87b4-4805-aaca-992d3fa83a01">

Compare this to correctly rendered code blocks on https://wordpress.org/plugins/wp-parsely/ and see how that's been done in the [raw README](https://raw.githubusercontent.com/Parsely/wp-parsely/develop/README.md).
