### PR TITLE
Only calculate supported post types for author taxonomy once per request

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -255,6 +255,10 @@ class CoAuthors_Plus {
 	 * @return array Supported post types.
 	 */
 	public function supported_post_types(): array {
+		if ( ! empty( $this->supported_post_types ) ) {
+			return $this->supported_post_types;
+		}
+
 		$post_types = array_values( get_post_types() );
 
 		$excluded_built_in = array(


### PR DESCRIPTION
## Description

This is intended to prevent recaculating the supported post types for the author taxonomy. The problems with the recalculation are laid out thoroughly in #1049 

This was also solved in #1036 however I'm not able to re-open someone else's pull request. Thanks @justinmaurerdotdev for figuring this out the first time.

## Steps to Test

If you add logging before and after the lines changd in this PR you should see 100s of calls to `supported_post_types()` when loading the editor, but it should only proceed with calculation once per request.

For example:
```php
error_log('getting supported post types');
if ( ! empty( $this->supported_post_types ) ) {
    return $this->supported_post_types;
}
error_log('"$_SERVER['REQUEST_URI']");
error_log('calculating supported post types');
```