### PR TITLE
fix: prevent the backfill from running forever.

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1260,7 +1260,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 *
 	 * @return WP_User
 	 */
-	public function get_first_admin_user() {
+	private function get_first_admin_user() {
 		if ( ! wp_cache_get( 'co-authors-plus-most-prolific-author', 'co-authors-plus' ) ) {
 			$admin_user_query = new WP_User_Query(
 				[

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -192,6 +192,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					$author = get_user_by( 'id', $record->post_author );
 
 					if ( false === $author ) {
+						// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- This is just trying to convey where the root problem should be resolved.
 						WP_CLI::warning( sprintf( 'Post Author ID %d does not exist in %s table, inserting skip postmeta (`%s`).', $record->post_author, $wpdb->users, self::SKIP_POST_FOR_BACKFILL_META_KEY ) );
 						$this->skip_backfill_for_post( $record->post_id, 'nonexistent_post_author_id' );
 						continue;

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -191,13 +191,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					$nonexistent_user_id = $record->post_author;
 					$record->post_author = $author_trans[ $record->post_author ];
 					$author              = $authors[ $record->post_author ];
-					WP_CLI::warning( sprintf( 'Must transfer posts from User ID: %d to Author ID: %d (%s)', $nonexistent_user_id, $author->ID, $author->user_nicename ) );
+					WP_CLI::warning( sprintf( 'Must transfer posts from User ID: %d to Admin ID: %d (%s)', $nonexistent_user_id, $author->ID, $author->user_nicename ) );
 				} else {
 					$author = get_user_by( 'id', $record->post_author );
 
 					if ( false === $author ) {
 						$author = $this->get_first_admin_user();
-						WP_CLI::warning( sprintf( 'Must transfer posts from User ID: %d to Author ID: %d (%s)', $record->post_author, $author->ID, $author->user_nicename ) );
+						WP_CLI::warning( sprintf( 'Must transfer posts from User ID: %d to Admin ID: %d (%s)', $record->post_author, $author->ID, $author->user_nicename ) );
 						$author_trans[ $record->post_author ] = $author->ID;
 						$record->post_author                  = $author->ID;
 					}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -137,7 +137,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @subcommand create-author-terms-for-posts
 	 * @synopsis [--post-types=<csv>] [--post-statuses=<csv>] [--unbatched] [--records-per-batch=<records-per-batch>] [--specific-post-ids=<csv>] [--above-post-id=<above-post-id>] [--below-post-id=<below-post-id>]
 	 * @return void
-	 * @throws Exception If above-post-id is greater than or equal to below-post-id, or if unable to obtain a prolific author account.
+	 * @throws Exception If above-post-id is greater than or equal to below-post-id.
 	 */
 	public function create_author_terms_for_posts( $args, $assoc_args ) {
 		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post' ];
@@ -162,7 +162,6 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		WP_CLI::line( sprintf( 'Found %d posts with missing author terms.', $count_of_posts_with_missing_author_terms ) );
 
 		$authors      = [];
-		$author_trans = [];
 		$author_terms = [];
 		$count        = 0;
 		$affected     = 0;


### PR DESCRIPTION
## Description
There's an edge case where an author that no longer exists can still be assigned to a post. This throws the backfill script into an infinite loop, because the respective author-term is never found/created, and so the underlying problem of missing author-term records is never resolved. The infinite loop is started when at the end of the while loop, the script asks for "remaining posts which need author terms" and so it returns the same rows over and over.

This fix addresses this in 2 ways:
1. If an author is not found, we insert a postmeta record indicating that it should be skipped for processing. This prevents the loop continuously returning the same post for processing.
2. Checks have been added so that the script can't go beyond what should be the maximum number of rows needing to be addressed.

## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?
No.

## Steps to Test

1. Create a handful of new posts. Make sure they're published.
2. Confirm what the maximum User ID is with `SELECT MAX(ID) FROM wp_users`.
3. Update the `post_author` column for those posts to IDs that *do not exist* in the `wp_users` table (any ID above MAX(ID)).
4. Run the command (`wp co-authors-plus create-author-terms-for-posts`). Be prepared to kill it. Notice how it goes beyond 100%.
5. Check out the PR.
6. Re-run the command from Step 4. This time, notice how the posts with non-existing authors have been skipped for processing, and the command finishes running on its own.
