### PR TITLE
Fix Changelog link in README.md, fixes #1071

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Yes! You can disable guest authors entirely through a filter. Having the followi
 
 ## Change Log
 
-[View the change log](https://github.com/Automattic/Co-Authors-Plus/blob/master/CHANGELOG.md).
+[View the change log](https://github.com/Automattic/Co-Authors-Plus/blob/develop/CHANGELOG.md).


### PR DESCRIPTION
## Description

Changelog link references `master` branch which is incorrect, change to `develop` reference.

Replacement PR for previous https://github.com/Automattic/Co-Authors-Plus/pull/1072