### PR TITLE
fix invalid sql in assign-user-to-coauthor subcommand

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -426,7 +426,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'Please specify a valid co-author login', 'co-authors-plus' ) );
 		}
 
-		$post_types = implode( "','", $coauthors_plus->supported_post_types() );
+		$post_types = "'" . implode( "','", $coauthors_plus->supported_post_types() ) . "'";
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ({$post_types})", $user->ID ) );
 		$affected = 0;


### PR DESCRIPTION


## Description

ensure that the list of post-types is correctly wrapped in single quotes to ensure that the resulting sql is valid.

currently $post_types evaluates to `post','page` resulting in an invalid sql query, after the change $post_type will evaluate to `'post','page'` with is the expected syntax for this sql query

## Deploy Notes

N/A

## Steps to Test

Run `wp co-authors-plus assign-user-to-coauthor --user_login=<user_login> --coauthor=<cap-user_login> `  confirm that the command executes as expected without the error `WordPress database error You have an error in your SQL syntax;` being returned
