### PR TITLE
Update GitHub action to install SVN before deploy to WordPress.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install SVN (Subversion)
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
+
       - name: Push to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:


### PR DESCRIPTION
The `ubuntu-latest` / `ubuntu-24.04` runner on GitHub Actions [no longer includes SVN](https://github.com/GaryJones/plugin-boilerplate/pull/25), so this updates the `deploy.yml` file used by GitHub Actions so that it installs SVN before deploying the plugin to WordPress.org.