### PR TITLE
fix: verify Guest Authors when running CLI commands

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -24,6 +24,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	public function create_guest_authors( $args, $assoc_args ): void {
 		global $coauthors_plus;
 
+		$this->verify_guest_authors_or_die();
+
 		$defaults = array(
 				// There are no arguments at this time
 		);
@@ -576,6 +578,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	public function rename_coauthor( $args, $assoc_args ): void {
 		global $coauthors_plus, $wpdb;
 
+		$this->verify_guest_authors_or_die();
+
 		$defaults   = array(
 			'from' => null,
 			'to'   => null,
@@ -830,6 +834,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 */
 	public function update_author_terms(): void {
 		global $coauthors_plus;
+
+		$this->verify_guest_authors_or_die();
+
 		$author_terms = get_terms( $coauthors_plus->coauthor_taxonomy, array( 'hide_empty' => false ) );
 		WP_CLI::log( 'Now updating ' . count( $author_terms ) . ' terms' );
 		foreach ( $author_terms as $author_term ) {
@@ -1082,6 +1089,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 */
 	private function create_guest_author( $author ): void {
 		global $coauthors_plus;
+
+		$this->verify_guest_authors_or_die();
+
 		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_email', $author['user_email'], true );
 
 		if ( ! $guest_author ) {
@@ -1315,5 +1325,17 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 */
 	private function get_formatted_complete_percentage( $completed, $total ) {
 		return number_format( ( $completed / $total ) * 100, 2 ) . '%';
+	}
+
+	/**
+	 * Verify Guest Authors is enabled and instantiated, otherwise print error and die.
+	 *
+	 * @return void
+	 */
+	private function verify_guest_authors_or_die(): void {
+		global $coauthors_plus;
+		if ( ! $coauthors_plus->is_guest_authors_enabled() || ! $coauthors_plus->guest_authors instanceof CoAuthors_Guest_Authors ) {
+			WP_CLI::error( __( 'Guest Authors needs to be enabled and instantiated to run this command.', 'co-authors-plus' ) );
+		}
 	}
 }


### PR DESCRIPTION
## Description

Co-authors-plus allows developers to use the filter `add_filter( 'coauthors_guest_authors_enabled', '__return_false' )`, but when developers implement this filter, many of the Co-Authors-Plus CLI commands will then throw FATAL PHP errors.

This PR will verify that when a developers uses the filter `add_filter( 'coauthors_guest_authors_enabled', '__return_false' )`, that the CLI commands that need Guest Authors will display an error and die gracefully as opposed to throwing a fatal error in the debug.log.

This PR may not be inclusive of all the Co-Authors-Plus CLI commands that need to verified.  I simply searched for `$coauthors_plus->guest_authors` in each command; and if found, I added `$this->verify_guest_authors_or_die();`.

I did not fully test all commands nor all edge cases as I'm not a Co-Authors-Plus expert.

Example fatal error (without this PR) when running CLI commands:

```
PHP Fatal error:  Uncaught Error: Call to a member function get_guest_author_by() on null in wp-content/plugins/co-authors-plus/php/class-wp-cli.php:1087
Stack trace:
#0 wp-content/plugins/co-authors-plus/php/class-wp-cli.php(995): CoAuthorsPlus_Command->create_guest_author()
#1 [internal function]: CoAuthorsPlus_Command->create_author()
```

## Deploy Notes

No new dependencies were added.

## Steps to Test

1. Do not pull this PR yet.
2. Implement `add_filter( 'coauthors_guest_authors_enabled', '__return_false' )` in a separate plugin.
3. Run Co-Authors-Plus CLI commands and see that they throw FATAL errors.
4. Pull this PR now.
5. Re-run CLI commands and see that FATALs are no longer thrown and instead WP_CLI will show an error message to the user (and die gracefully).
