### PR TITLE
Check is_single() when replacing author %%name%% to prevent the wrong title on author archives

### DIFF
--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Generators\Schema\Abstract_Schema_Piece;
 use Yoast\WP\SEO\Presentations\Indexable_Author_Archive_Presentation;
 use WP_User;
+use function __;
 
 /**
  * The main Yoast integration class
@@ -256,7 +257,7 @@ class Yoast {
 		}
 
 		$output = self::get_authors_display_names_output( $author_objects );
-		$data[ \__( 'Written by', 'co-authors-plus' ) ] = $output;
+		$data[ __( 'Written by', 'co-authors-plus' ) ] = $output;
 		return $data;
 	}
 
@@ -339,7 +340,7 @@ class Yoast {
 	 * @return array   Modified $replacements.
 	 */
 	public static function filter_author_name_variable( $replacements, $args ): array {
-		if ( isset( $replacements['%%name%%'], $args->ID ) ) {
+		if ( isset( $replacements['%%name%%'], $args->ID ) && is_single() ) {
 			$author_objects = get_coauthors( $args->ID );
 
 			// Fallback in case of error.


### PR DESCRIPTION
## Description
Fixes https://github.com/Automattic/Co-Authors-Plus/issues/1092

Quoting the Issue I created (above)
> CAP uses this filter, `wpseo_replacements`, to fix Yoast's usage of the `%%name%%` placeholder. However, this filter is also during the rendering of the page <title>. This means that when the page is an author archive, the author's name is being substituted with the display names of all of the authors of the top post on the page. 
> 
> It turns out that in this case, the `$args->ID` found in the `filter_author_name_variable()` method (and passed to `get_coauthors()`) is just defaulting to the first post in the loop, because that's what is set in `$GLOBALS['post']` (the default when `get_the_ID()` is called with no arguments). This issue seems totally fixed by the addition of `is_single()` in the logic for whether to do the replacement.
> 
> I am assuming that this filter is intended to fix the author name strings for the schema/meta on individual posts (things that actually have co-authors), and that this fix won't impact anything negatively, but please chime in if you can think of some reason why this filter would be needed on an archive.

## Steps to Test

I'm not 100% clear on how to write any automated tests for this sort of third party integration in this repo, so if those are needed, I would appreciate some advice on setting that up. But, you can see the issue in an archived version of [one of our pages](https://web.archive.org/web/20250122074639/https://reason.com/people/justin-zuckerman/). Were this functioning properly, it would only show the one name in the <title>.
