### PR TITLE
Use WordPress 6.8 filter to skip heavy, unnecessary query

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -243,6 +243,7 @@ class CoAuthors_Plus {
 
 		// Apply some targeted filters
 		add_action( 'load-edit.php', array( $this, 'load_edit' ) );
+		add_action( 'load-users.php', array( $this, 'load_users_screen' ) );
 	}
 
 	/**
@@ -1507,6 +1508,16 @@ class CoAuthors_Plus {
 		$views        = array_reverse( $views );
 
 		return $views;
+	}
+
+	/**
+	 * Prevent WordPress from counting users' posts for Users table column that
+	 * is removed by the `_filter_manage_users_columns` method.
+	 *
+	 * @return void
+	 */
+	public function load_users_screen(): void {
+		add_filter( 'pre_count_many_users_posts', '__return_false' );
 	}
 
 	/**

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1517,7 +1517,22 @@ class CoAuthors_Plus {
 	 * @return void
 	 */
 	public function load_users_screen(): void {
-		add_filter( 'pre_count_many_users_posts', '__return_false' );
+		add_filter( 'pre_count_many_users_posts', array( $this, 'bypass_user_post_count' ), 10, 2 );
+	}
+
+	/**
+	 * Return empty counts for `count_users_many_posts()`, to bypass the heavy
+	 * and unused query results.
+	 *
+	 * @param string[]|null $counts   Post counts.
+	 * @param array         $user_ids User IDs to return counts for.
+	 * @return array
+	 */
+	public function bypass_user_post_count( $counts, $user_ids ) {
+		return array_fill_keys(
+			array_map( 'absint', $user_ids ),
+			0
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description

When the plugin is active, it replaces the post-count column in the Users list table with its own, which pulls the counts from the author terms. By default, Core uses `count_many_users_posts()`, which is uncached and can be slow when a site has many posts associated with a single user.

Introduced in WordPress 6.8, the `pre_count_many_users_posts` filter can be used to skip the unnecessary query: https://core.trac.wordpress.org/ticket/63004.

## Deploy Notes

N/A

## Steps to Test

1. Install WordPress 6.8
2. Install and activate Query Monitor
3. Load the Users list table, open Query Monitor's Database Queries panel, and select `count_many_users_posts` from the "Caller" filter to confirm that the query is run
4. Activate Co-Authors Plus on this PR's branch, reload the Users list table, and confirm that Query Monitor shows no queries originating from `count_many_users_posts()`