### PR TITLE
Ensure term is valid before deleting term

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1118,7 +1118,9 @@ class CoAuthors_Plus {
 		if ( is_object( $delete_user ) ) {
 			// Delete term
 			$term = $this->get_author_term( $delete_user );
-			wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
+			if ( $term ) {
+				wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
+			}
 		}
 
 		if ( $this->is_guest_authors_enabled() ) {


### PR DESCRIPTION
Fix an issue where this notice was being thrown:

```
1) /Users/srtfisher/broadway/www/mantle/wp-content/plugins/co-authors-plus/php/class-coauthors-plus.php:1121
Attempt to read property "term_id" on false
```
