### PR TITLE
Fix SQL Syntax Error in assign_user_to_coauthor

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -429,8 +429,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$post_types = implode(
 			', ',
 			array_map(
-				function ( $type ) {
-					return "'{$type}'";
+				function ( $post_type ) {
+					return "'{$post_type}'";
 				},
 				$coauthors_plus->supported_post_types()
 			)

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -426,7 +426,16 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			WP_CLI::error( __( 'Please specify a valid co-author login', 'co-authors-plus' ) );
 		}
 
-		$post_types = implode( "','", $coauthors_plus->supported_post_types() );
+		$post_types = implode(
+			', ',
+			array_map(
+				function ( $type ) {
+					return "'{$type}'";
+				},
+				$coauthors_plus->supported_post_types()
+			)
+		);
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ({$post_types})", $user->ID ) );
 		$affected = 0;


### PR DESCRIPTION
## Description

This PR resolves a SQL syntax error in the `assign_user_to_coauthor` method. The previous implementation was missing the required single quotes around values, causing a syntax error. 

## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?

## Steps to Test

Run `wp co-authors-plus assign-user-to-coauthor` command and make sure it works find
