### PR TITLE
Protect against pattern edits

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -150,12 +150,12 @@ class Endpoints {
 	 * @return WP_REST_Response
 	 */
 	public function get_coauthors( $request ): WP_REST_Response {
-		if ( $this->request_is_for_wp_block_post_type( $request ) || $this->is_pattern_sync_operation() ) {
-			return rest_ensure_response( array() );
+		$response = array();
+
+		if ( ! $this->request_is_for_wp_block_post_type( $request ) && ! $this->is_pattern_sync_operation() ) {
+			$this->_build_authors_response( $response, $request );
 		}
 
-		$response = array();
-		$this->_build_authors_response( $response, $request );
 		return rest_ensure_response( $response );
 	}
 

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -150,10 +150,28 @@ class Endpoints {
 	 * @return WP_REST_Response
 	 */
 	public function get_coauthors( $request ): WP_REST_Response {
+		$post_id   = $request->get_param( 'post_id' );
+		$post_type = get_post_type( $post_id );
+
+		// Return empty array for patterns
+		if ( 'wp_block' === $post_type ) {
+			return rest_ensure_response( array() );
+		}
+
+		// Check if this is a pattern sync operation
+		$referer = wp_get_referer();
+		if ( $referer ) {
+			$query_string = wp_parse_url( $referer, PHP_URL_QUERY );
+			if ( $query_string ) {
+				parse_str( $query_string, $query_vars );
+				if ( ! empty( $query_vars['post'] ) && 'wp_block' === get_post_type( $query_vars['post'] ) ) {
+					return rest_ensure_response( array() );
+				}
+			}
+		}
+
 		$response = array();
-
 		$this->_build_authors_response( $response, $request );
-
 		return rest_ensure_response( $response );
 	}
 

--- a/tests/Integration/EndpointsTest.php
+++ b/tests/Integration/EndpointsTest.php
@@ -181,6 +181,35 @@ class EndpointsTest extends TestCase {
 	}
 
 	/**
+	 * @covers CoAuthors\API\Endpoints::get_coauthors
+	 */
+	public function test_get_coauthors_wp_block_post_type(): void {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'wp_block' ) );
+		$request = new \WP_REST_Request( 'GET', '/coauthors/v1/authors/' . $post_id );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = $this->_api->get_coauthors( $request );
+		$this->assertEmpty( $response->get_data() );
+	}
+
+	/**
+	 * @covers CoAuthors\API\Endpoints::get_coauthors
+	 */
+	public function test_get_coauthors_pattern_sync(): void {
+		$post_id = self::factory()->post->create();
+		$block_id = self::factory()->post->create( array( 'post_type' => 'wp_block' ) );
+		$_SERVER['HTTP_REFERER'] = admin_url( sprintf( 'post.php?post=%d&action=edit', $block_id ) );
+
+		$request = new \WP_REST_Request( 'GET', '/coauthors/v1/authors/' . $post_id );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = $this->_api->get_coauthors( $request );
+		$this->assertEmpty( $response->get_data() );
+
+		unset( $_SERVER['HTTP_REFERER'] );
+	}
+
+	/**
 	 * @covers \CoAuthors\API\Endpoints::update_coauthors
 	 */
 	public function test_update_coauthors(): void {


### PR DESCRIPTION
## Description

Adding protection against duplicate authors being added to patterns and parent posts when a synced pattern is edited.

## Related Issue

The problem is fully explained in this related issue https://github.com/Automattic/Co-Authors-Plus/issues/1101

## Steps to Test

1. Create a post
2. Create a synced pattern from within that post's editor and add it to the post's content
4. "Edit the original" pattern from within that post
5. Observe that the pattern has duplicate author entries (e.g., "Author A, Author A")

(This also happens with different authors when multiple people edit it)

Now apply fix, and see that this doesn't occur.

## Notes

The reason we need both checks is because of how patterns work in WordPress.

1. Checking the post type catches when we're directly editing a pattern.
2. Checking the referer catches when we're editing a regular post (like a page) through a pattern editor. In this case, the post_type is 'page', but we're actually editing it through a pattern interface (the "Edit original" feature), so we need to check where the request came from.

Without the referer check, we wouldn't be able to detect when a regular post is being edited through a pattern interface, which is when the duplicate author issue occurs.
