### PR TITLE
Increase composer/installers version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"forum": "https://wordpress.org/support/plugin/co-authors-plus"
 	},
 	"require": {
-		"composer/installers": "~1.0",
+		"composer/installers": "^2",
 		"php": ">=7.4"
 	},
 	"require-dev": {


### PR DESCRIPTION
### Changes in this PR

A small maintenance update which changes composer/installers version to `^2` to make it compatible with later versions of PHP.
