### PR TITLE
Add SVN install to integrate workflow

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install SVN (Subversion)
+         run: |
+           sudo apt-get update
+           sudo apt-get install subversion
+           
       - name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Changes in this PR

Installing SVN into the CI. This is because ubuntu-latest removed SVN, but the workflow uses it to pull in WP for tests.

Similar change to https://github.com/Automattic/Co-Authors-Plus/commit/1ef7f31b5c7412a81128d52251b8fd3a719cd69a

After this change, now the tests complete successfully:
<img width="859" alt="Screenshot 2025-03-21 at 10 07 42" src="https://github.com/user-attachments/assets/df5339d0-671a-456a-92a0-023fa4b2c790" />

