### PR TITLE
Adjust import of PluginDocumentSettingPanel to resolve deprecation notice

### DIFF
--- a/src/__tests__/plugin-document-setting-panel.test.js
+++ b/src/__tests__/plugin-document-setting-panel.test.js
@@ -1,0 +1,66 @@
+/**
+ * Tests for PluginDocumentSettingPanel backwards compatibility.
+ *
+ * The component moved from @wordpress/edit-post to @wordpress/editor in WP 6.6.
+ * We use a runtime fallback to support both WP 6.4-6.5 (edit-post) and WP 6.6+ (editor).
+ */
+
+describe( 'PluginDocumentSettingPanel compatibility', () => {
+	const MockComponent = () => 'MockPluginDocumentSettingPanel';
+
+	beforeEach( () => {
+		// Reset the wp global before each test
+		global.wp = {};
+	} );
+
+	afterEach( () => {
+		// Clean up
+		delete global.wp;
+	} );
+
+	it( 'should use wp.editor.PluginDocumentSettingPanel when available (WP 6.6+)', () => {
+		global.wp = {
+			editor: {
+				PluginDocumentSettingPanel: MockComponent,
+			},
+			editPost: {
+				PluginDocumentSettingPanel: () => 'OldComponent',
+			},
+		};
+
+		const PluginDocumentSettingPanel =
+			wp.editor?.PluginDocumentSettingPanel ||
+			wp.editPost?.PluginDocumentSettingPanel;
+
+		expect( PluginDocumentSettingPanel ).toBe( MockComponent );
+	} );
+
+	it( 'should fall back to wp.editPost.PluginDocumentSettingPanel (WP 6.4-6.5)', () => {
+		global.wp = {
+			editor: {},
+			editPost: {
+				PluginDocumentSettingPanel: MockComponent,
+			},
+		};
+
+		const PluginDocumentSettingPanel =
+			wp.editor?.PluginDocumentSettingPanel ||
+			wp.editPost?.PluginDocumentSettingPanel;
+
+		expect( PluginDocumentSettingPanel ).toBe( MockComponent );
+	} );
+
+	it( 'should handle wp.editor being undefined (WP 6.4-6.5)', () => {
+		global.wp = {
+			editPost: {
+				PluginDocumentSettingPanel: MockComponent,
+			},
+		};
+
+		const PluginDocumentSettingPanel =
+			wp.editor?.PluginDocumentSettingPanel ||
+			wp.editPost?.PluginDocumentSettingPanel;
+
+		expect( PluginDocumentSettingPanel ).toBe( MockComponent );
+	} );
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { select, subscribe } from "@wordpress/data";
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,14 @@
  * WordPress dependencies
  */
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { select, subscribe } from "@wordpress/data";
+
+// PluginDocumentSettingPanel moved from @wordpress/edit-post to @wordpress/editor in WP 6.6.
+// Use fallback for backwards compatibility with WP 6.4-6.5.
+const PluginDocumentSettingPanel =
+	wp.editor?.PluginDocumentSettingPanel ||
+	wp.editPost?.PluginDocumentSettingPanel;
 
 /**
  * Components


### PR DESCRIPTION
## Description

Resolves a console warning encountered when using the current version of the plugin, encountered since this component was moved from the "editPost" to "editor" package within Gutenberg.

> wp.editPost.PluginDocumentSettingPanel is deprecated since version 6.6. Please use wp.editor.PluginDocumentSettingPanel instead.

Documentation for PluginDocumentSettingPanel: https://developer.wordpress.org/block-editor/reference-guides/slotfills/plugin-document-setting-panel/

## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?

- None

## Steps to Test

- Activate this plugin on a WordPress 6.6.x or 6.7.x website
- Set SCRIPT_DEBUG to `true` in wp-config (otherwise these warnings will not be shown)
- Load the editor
- Verify no deprecation notice is shown relating to this plugin's code