### PR TITLE
Add id and user type to store formatted author data

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -216,7 +216,7 @@ class Endpoints {
 			'email'        => sanitize_email( $author->user_email ),
 			'displayName'  => esc_html( str_replace( '∣', '|', $author->display_name ) ),
 			'avatar'       => esc_url( get_avatar_url( $author->ID ) ),
-			'userType'     => $author->type,
+			'userType'     => esc_html( $author->type ),
 		);
 	}
 

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -216,6 +216,7 @@ class Endpoints {
 			'email'        => sanitize_email( $author->user_email ),
 			'displayName'  => esc_html( str_replace( '∣', '|', $author->display_name ) ),
 			'avatar'       => esc_url( get_avatar_url( $author->ID ) ),
+			'userType'     => $author->type,
 		);
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,9 +66,10 @@ export const addItemByValue = (
  * Format the author option object.
  *
  * @param {Object} root0              An author object from the API endpoint.
- * @param {Object} root0.displayName  Name to display in the UI.
- * @param {Object} root0.userNicename The unique username.
- * @param {Object} root0.email
+ * @param {string} root0.id           The author ID.
+ * @param {string} root0.displayName  Name to display in the UI.
+ * @param {string} root0.userNicename The unique username.
+ * @param {string} root0.email        The author's email address.
  *
  * @return {Object} The object containing data relevant to the Coauthors component.
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,14 +70,16 @@ export const addItemByValue = (
  * @param {string} root0.displayName  Name to display in the UI.
  * @param {string} root0.userNicename The unique username.
  * @param {string} root0.email        The author's email address.
+ * @param {string} root0.userType     The entity type, either 'wp-user' or 'guest-user'.
  *
  * @return {Object} The object containing data relevant to the Coauthors component.
  */
-export const formatAuthorData = ( { id, displayName, userNicename, email } ) => {
+export const formatAuthorData = ( { id, displayName, userNicename, email, userType } ) => {
 	return {
 		id,
 		label: `${ displayName } | ${ email }`,
 		display: displayName,
 		value: userNicename,
+		userType,
 	};
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,7 @@ export const addItemByValue = (
  * @param {string} root0.displayName  Name to display in the UI.
  * @param {string} root0.userNicename The unique username.
  * @param {string} root0.email        The author's email address.
- * @param {string} root0.userType     The entity type, either 'wp-user' or 'guest-user'.
+ * @param {string} root0.userType     The entity type, either 'wpuser' or 'guest-user'.
  *
  * @return {Object} The object containing data relevant to the Coauthors component.
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,8 +72,9 @@ export const addItemByValue = (
  *
  * @return {Object} The object containing data relevant to the Coauthors component.
  */
-export const formatAuthorData = ( { displayName, userNicename, email } ) => {
+export const formatAuthorData = ( { id, displayName, userNicename, email } ) => {
 	return {
+		id,
 		label: `${ displayName } | ${ email }`,
 		display: displayName,
 		value: userNicename,


### PR DESCRIPTION
## Description

Add the author ID and user type to the store's formatted data. This is useful for 3rd parties that need to read from the edited post authors' data.

Usage example: https://github.com/Automattic/newspack-plugin/pull/3906

## Deploy Notes

Just a js build.

## Steps to Test

There should be no impact on the plugin behavior. Make sure the "Authors" panel continues to work as expected.