### PR TITLE
Avoids Warnings when using the filter ‘coauthors_supported_post_types’ with a unique custom post type. Fix issue #1113

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1590,10 +1590,11 @@ class CoAuthors_Plus {
 
 			foreach ( $this->supported_post_types() as $single ) {
 				$obj = get_post_type_object( $single );
-
-				$this->to_be_filtered_caps[] = $obj->cap->edit_post;
-				$this->to_be_filtered_caps[] = $obj->cap->edit_others_posts; // This as well: http://core.trac.wordpress.org/ticket/22417
-				$this->to_be_filtered_caps[] = $obj->cap->read_post;
+				if( $obj ) {
+					$this->to_be_filtered_caps[] = $obj->cap->edit_post;
+					$this->to_be_filtered_caps[] = $obj->cap->edit_others_posts; // This as well: http://core.trac.wordpress.org/ticket/22417
+					$this->to_be_filtered_caps[] = $obj->cap->read_post;
+				}
 			}
 
 			$this->to_be_filtered_caps = array_unique( $this->to_be_filtered_caps );

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1600,7 +1600,7 @@ class CoAuthors_Plus {
 
 			foreach ( $this->supported_post_types() as $single ) {
 				$obj = get_post_type_object( $single );
-				if( $obj ) {
+				if ( $obj ) {
 					$this->to_be_filtered_caps[] = $obj->cap->edit_post;
 					$this->to_be_filtered_caps[] = $obj->cap->edit_others_posts; // This as well: http://core.trac.wordpress.org/ticket/22417
 					$this->to_be_filtered_caps[] = $obj->cap->read_post;

--- a/tests/Integration/ToBeFilteredCapsTest.php
+++ b/tests/Integration/ToBeFilteredCapsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression coverage for issue #1113.
+ *
+ * The `coauthors_supported_post_types` filter lets a site add post types to the
+ * supported list. If one of those names has no registered post type object
+ * (e.g. a custom type that is conditionally registered, or a typo),
+ * `get_post_type_object()` returns null. Before the guard, get_to_be_filtered_caps()
+ * read `->cap->edit_post` off that null, raising "Attempt to read property cap on
+ * null" and pushing null entries into the caps list. It must skip such types.
+ *
+ * @covers \CoAuthors_Plus::get_to_be_filtered_caps
+ */
+class ToBeFilteredCapsTest extends TestCase {
+
+	public function test_get_to_be_filtered_caps_skips_unregistered_post_type(): void {
+		// Reset the per-request cache so the filter below is actually exercised.
+		$this->_cap->to_be_filtered_caps = array();
+
+		$add_missing_post_type = static function ( $post_types ) {
+			$post_types[] = 'cap_unregistered_cpt';
+			return $post_types;
+		};
+		add_filter( 'coauthors_supported_post_types', $add_missing_post_type );
+
+		try {
+			$caps = $this->_cap->get_to_be_filtered_caps();
+		} finally {
+			remove_filter( 'coauthors_supported_post_types', $add_missing_post_type );
+			$this->_cap->to_be_filtered_caps = array();
+		}
+
+		$this->assertIsArray( $caps );
+		$this->assertContains( 'edit_post', $caps, 'The base post capabilities should still be present.' );
+		$this->assertNotContains( null, $caps, 'An unregistered post type must not contribute null capabilities.' );
+		$this->assertNotContains( '', $caps, 'An unregistered post type must not contribute empty capabilities.' );
+	}
+
+	public function test_get_to_be_filtered_caps_includes_caps_for_registered_post_type(): void {
+		$this->_cap->to_be_filtered_caps = array();
+
+		$caps = $this->_cap->get_to_be_filtered_caps();
+		$this->_cap->to_be_filtered_caps = array();
+
+		$post = get_post_type_object( 'post' );
+		$this->assertContains( $post->cap->edit_post, $caps, 'Registered post types should still contribute their edit_post cap.' );
+	}
+}


### PR DESCRIPTION
## Description

Adds a check to avoid warnings in logfile when using the `coauthors_supported_post_types` filter to restrict the plugin functionalities to a unique custom post type.
For details see issue #1113

The code assumes that the function `get_post_type_object()` returns an object, but it can also return NULL (see [WordPress Developer Resources](https://developer.wordpress.org/reference/functions/get_post_type_object) ).
So before using the returned value we need to check for it.

This is what the added `if` statemen of this PR does.

