### PR TITLE
Check is_single() when replacing author %%name%% to prevent the wrong <title> on author archives (via Yoast's Title_Presenter)

### DIFF
--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -339,7 +339,7 @@ class Yoast {
 	 * @return array   Modified $replacements.
 	 */
 	public static function filter_author_name_variable( $replacements, $args ): array {
-		if ( isset( $replacements['%%name%%'], $args->ID ) ) {
+		if ( isset( $replacements['%%name%%'], $args->ID ) && is_single() ) {
 			$author_objects = get_coauthors( $args->ID );
 
 			// Fallback in case of error.


### PR DESCRIPTION
@see https://github.com/Automattic/Co-Authors-Plus/commit/b09e4f49da5d68bceb1b7889bebcae1fd9a90e60 by author @justinmaurerdotdev

## Description

Yoast's SEO tools are picking up the wrong Author Name when viewing Author Archive pages and the first post in the page belongs to multiple authors. This commit fixes the issue by returning the author's name for the Author Archive page that you are viewing.

## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?

## Steps to Test

1. Must have Yoast Premium Enabled.
2. Create a post for Author 1
3. Create another post where you add Author 2 and Author 1.
4. Go to Author 1's archive page.
5. Open up Yoast SEO inspector.
6. Notice that the title of the page is displaying Author 2 and Author 1.
7. Checkout out this branch.
8. Visit the same page and pull out SEO inspector.
9. Notice that now only Author 1's name is displayed.
