### PR TITLE
Add bulk editing support for Co-Authors in the admin interface

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
  * Version:           3.6.6
- * Requires at least: 6.3
+ * Requires at least: 5.9
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
  * Author URI:        https://automattic.com

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
  * Version:           3.6.6
- * Requires at least: 5.9
+ * Requires at least: 6.3
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
  * Author URI:        https://automattic.com

--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -8,12 +8,11 @@
 
 #bulk-edit label.bulk-edit-group {
 	clear: both;
-	padding: 0 .5em;
 	margin-top: .5em;
 }
 
-#bulk-edit label.bulk-edit-group #coauthors-list {
-	margin-left: 5.6em;
+#bulk-edit #coauthors-list {
+	padding: 0;
 }
 
 #coauthors-list {

--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -6,6 +6,16 @@
 	margin-left: 5em;
 }
 
+#bulk-edit label.bulk-edit-group {
+	clear: both;
+	padding: 0 .5em;
+	margin-top: .5em;
+}
+
+#bulk-edit label.bulk-edit-group #coauthors-list {
+	margin-left: 5.6em;
+}
+
 #coauthors-list {
 	width: 100%;
 	padding: 0 5px;

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -186,6 +186,13 @@ jQuery( document ).ready(function () {
 				.on( 'blur', function(){ $co.val( coAuthorsPlusStrings.search_box_text ) } )
 				;
 
+		if ( coauthors_initialized_on_bulk_edit )
+			$co.attr({
+				'aria-labelledby': 'coauthors-bulk-edit-label',
+				'aria-describedby': 'coauthors-bulk-edit-desc'
+			})
+			;
+
 		return $co;
 
 	}
@@ -452,8 +459,8 @@ jQuery( document ).ready(function () {
 				// Move the autosuggest input box under the Co-Authors label.
 				jQuery( '#coauthors-edit' ).appendTo( coauthors_authors_label );
 
-				coauthors_initialize( [] );
 				coauthors_initialized_on_bulk_edit = true;
+				coauthors_initialize( [] );
 			}
 		}
 	}

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -446,7 +446,7 @@ jQuery( document ).ready(function () {
 
 				// Move the Co-Authors section to the right-hand column of the Bulk section.
 				coauthors_authors_label.appendTo( bulk_right_column );
-				// Give the right-hand column its 'real' height because the float:left;
+				// Give the right-hand column its 'real' height because of float:left;
 				// The Post Format dropdown does not help positioning the Co-Authors section.
 				bulk_right_column.find( 'div.inline-edit-col' ).addClass( 'wp-clearfix' );
 				// Move the autosuggest input box under the Co-Authors label.

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -395,6 +395,7 @@ jQuery( document ).ready(function () {
 
 		var wpInlineEdit = inlineEditPost.edit;
 
+		// Inline editing
 		inlineEditPost.edit = function( id ) {
 
 			wpInlineEdit.apply( this, arguments )
@@ -427,6 +428,29 @@ jQuery( document ).ready(function () {
 
 				coauthors_initialize( post_coauthors );
 
+			}
+		}
+
+		// Bulk editing
+		var coauthors_initialized_on_bulk_edit = false;
+		var wpBulkEdit = inlineEditPost.setBulk;
+
+		inlineEditPost.setBulk = function() {
+
+			wpBulkEdit.apply( this, arguments );
+
+			// Initialize co-authors, but only on the first 'Bulk edit' interaction.
+			if ( ! coauthors_initialized_on_bulk_edit ) {
+				var bulk_right_column = jQuery( '#bulk-edit .inline-edit-col-right' );
+
+				// Move the Co-Authors section in the right column of the Bulk section.
+				jQuery( '#bulk-edit .bulk-edit-coauthors' ).appendTo( bulk_right_column );
+				// Give the last column its 'real' height because the float:left; for the
+				// Post Format dropdown does not help positioning the Co-Authors section
+				bulk_right_column.find( 'div.inline-edit-col' ).addClass( 'wp-clearfix' );
+
+				coauthors_initialize( [] );
+				coauthors_initialized_on_bulk_edit = true;
 			}
 		}
 	}

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -442,12 +442,15 @@ jQuery( document ).ready(function () {
 			// Initialize co-authors, but only on the first 'Bulk edit' interaction.
 			if ( ! coauthors_initialized_on_bulk_edit ) {
 				var bulk_right_column = jQuery( '#bulk-edit .inline-edit-col-right' );
+				var coauthors_authors_label = jQuery( '#bulk-edit .bulk-edit-coauthors' );
 
-				// Move the Co-Authors section in the right column of the Bulk section.
-				jQuery( '#bulk-edit .bulk-edit-coauthors' ).appendTo( bulk_right_column );
-				// Give the last column its 'real' height because the float:left; for the
-				// Post Format dropdown does not help positioning the Co-Authors section
+				// Move the Co-Authors section to the right-hand column of the Bulk section.
+				coauthors_authors_label.appendTo( bulk_right_column );
+				// Give the right-hand column its 'real' height because the float:left;
+				// The Post Format dropdown does not help positioning the Co-Authors section.
 				bulk_right_column.find( 'div.inline-edit-col' ).addClass( 'wp-clearfix' );
+				// Move the autosuggest input box under the Co-Authors label.
+				jQuery( '#coauthors-edit' ).appendTo( coauthors_authors_label );
 
 				coauthors_initialize( [] );
 				coauthors_initialized_on_bulk_edit = true;

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -108,11 +108,15 @@ class CoAuthors_Plus {
 		// REST API: Depending on user capabilities, hide author term description.
 		add_action( 'rest_prepare_author', array( $this, 'conditionally_hide_author_term_description' ) );
 
-		// Add Co-Author select field to the Bulk Edit actions form.
-		add_action( 'bulk_edit_custom_box', array( $this, '_action_bulk_edit_custom_box' ), 10, 2 );
+		// Add Bulk Edit support on supported versions of WordPress.
+		global $wp_version;
+		if ( version_compare( $wp_version, '6.3', '>=' ) ) {
+			// Add Co-Author select field to the Bulk Edit actions form.
+			add_action( 'bulk_edit_custom_box', array( $this, '_action_bulk_edit_custom_box' ), 10, 2 );
 
-		// Update Co-Authors when bulk editing posts.
-		add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
+			// Update Co-Authors when bulk editing posts.
+			add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
+		}
 	}
 
 	/**

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -112,13 +112,7 @@ class CoAuthors_Plus {
 		add_action( 'bulk_edit_custom_box', array( $this, '_action_bulk_edit_custom_box' ), 10, 2 );
 
 		// Update Co-Authors when bulk editing posts.
-		// bulk_edit_posts was introduced in WordPress 6.3, so we need to check the version.
-		global $wp_version;
-		if ( version_compare( $wp_version, '6.3', '>=' ) ) {
-			add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
-		} else {
-			add_action( 'wp_insert_post_data', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
-		}
+		add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
 	}
 
 	/**

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2026,13 +2026,13 @@ class CoAuthors_Plus {
 			return;
 		}
 		?>
-		<label class="bulk-edit-group bulk-edit-coauthors">
+		<label class="bulk-edit-group bulk-edit-coauthors" aria-labelledby="coauthors-edit-desc">
 			<span class="title"><?php esc_html_e( 'Authors', 'co-authors-plus' ) ?></span>
-			<div id="coauthors-edit" class="hide-if-no-js">
-				<p><?php echo wp_kses( __( 'Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors.', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
-			</div>
-			<?php wp_nonce_field( 'coauthors-edit', 'coauthors-nonce' ); ?>
 		</label>
+		<div id="coauthors-edit" class="inline-edit-group wp-clearfix hide-if-no-js">
+			<p id="coauthors-edit-desc"><?php echo wp_kses( __( 'Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors.', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
+			<?php wp_nonce_field( 'coauthors-edit', 'coauthors-nonce' ); ?>
+		</div>
 		<?php
 	}
 

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2022,7 +2022,7 @@ class CoAuthors_Plus {
 	 * @return void
 	 */
 	public function _action_bulk_edit_custom_box( string $column_name, string $post_type ): void {
-		if ( 'coauthors' != $column_name || ! $this->is_post_type_enabled( $post_type ) || ! $this->current_user_can_set_authors() ) {
+		if ( 'coauthors' !== $column_name || ! $this->is_post_type_enabled( $post_type ) || ! $this->current_user_can_set_authors() ) {
 			return;
 		}
 		?>

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -107,6 +107,18 @@ class CoAuthors_Plus {
 
 		// REST API: Depending on user capabilities, hide author term description.
 		add_action( 'rest_prepare_author', array( $this, 'conditionally_hide_author_term_description' ) );
+
+		// Add Co-Author select field to the Bulk Edit actions form.
+		add_action( 'bulk_edit_custom_box', array( $this, '_action_bulk_edit_custom_box' ), 10, 2 );
+
+		// Update Co-Authors when bulk editing posts.
+		// bulk_edit_posts was introduced in WordPress 6.3, so we need to check the version.
+		global $wp_version;
+		if ( version_compare( $wp_version, '6.3', '>=' ) ) {
+			add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
+		} else {
+			add_action( 'wp_insert_post_data', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
+		}
 	}
 
 	/**
@@ -1998,5 +2010,67 @@ class CoAuthors_Plus {
 		$response->set_data( $data );
 
 		return $response;
+	}
+
+	/**
+	 * Create Bulk Edit Co-Authors box.
+	 *
+	 * This is used in the Bulk Edit screen to allow users to set Co-Authors
+	 * for multiple posts at once.
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/551
+	 * @param string $column_name The name of the column being edited.
+	 * @param string $post_type The post type being edited.
+	 * @return void
+	 */
+	public function _action_bulk_edit_custom_box( string $column_name, string $post_type ): void {
+		if ( 'coauthors' != $column_name || ! $this->is_post_type_enabled( $post_type ) || ! $this->current_user_can_set_authors() ) {
+			return;
+		}
+		?>
+		<label class="bulk-edit-group bulk-edit-coauthors">
+			<span class="title"><?php esc_html_e( 'Authors', 'co-authors-plus' ) ?></span>
+			<div id="coauthors-edit" class="hide-if-no-js">
+				<p><?php echo wp_kses( __( 'Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors.', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
+			</div>
+			<?php wp_nonce_field( 'coauthors-edit', 'coauthors-nonce' ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Assign Co-Authors from the bulk edit screen.
+	 *
+	 * This function is called when the Bulk Edit form is submitted.
+	 * It processes the submitted data and updates the Co-Authors for each post.
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/551
+	 * @param array $post_data The post data from the bulk edit form.
+	 * @param array $postarr The post array containing the posts being edited.
+	 * @return array $post_data The modified post data.
+	 */
+	public function action_bulk_edit_update_coauthors( array $post_data, array $postarr ): array {
+		if ( ( ! isset( $postarr['post'] ) ) || ( ! $this->is_post_type_enabled( $post_data['post_type'] ) ) ) {
+			return $post_data;
+		}
+
+		foreach( $postarr['post'] as $post_id ) {
+			$post = get_post( $post_id );
+
+			if ( $this->current_user_can_set_authors( $post ) && isset( $postarr['coauthors'] ) ) {
+					$coauthors = array_map( 'sanitize_title', (array) $postarr['coauthors'] );
+					$this->add_coauthors( $post_id, $coauthors );
+			} else {
+				// If a Co-Author isn't currently set, explicitly set one.
+				if ( ! $this->has_author_terms( $post_id ) ) {
+					$user = get_userdata( $post->post_author );
+					if ( $user ) {
+						$this->add_coauthors( $post_id, array( $user->user_nicename ) );
+					}
+				}
+			}
+		}
+
+		return $post_data;
 	}
 }

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2026,7 +2026,7 @@ class CoAuthors_Plus {
 			return;
 		}
 		?>
-		<label class="bulk-edit-group bulk-edit-coauthors" aria-labelledby="coauthors-edit-desc">
+		<label class="bulk-edit-group bulk-edit-coauthors">
 			<span class="title"><?php esc_html_e( 'Authors', 'co-authors-plus' ) ?></span>
 		</label>
 		<div id="coauthors-edit" class="inline-edit-group wp-clearfix hide-if-no-js">

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2027,10 +2027,10 @@ class CoAuthors_Plus {
 		}
 		?>
 		<label class="bulk-edit-group bulk-edit-coauthors">
-			<span class="title"><?php esc_html_e( 'Authors', 'co-authors-plus' ) ?></span>
+			<span id="coauthors-bulk-edit-label" class="title"><?php esc_html_e( 'Authors', 'co-authors-plus' ) ?></span>
 		</label>
 		<div id="coauthors-edit" class="inline-edit-group wp-clearfix hide-if-no-js">
-			<p id="coauthors-edit-desc"><?php echo wp_kses( __( 'Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors.', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
+			<p id="coauthors-bulk-edit-desc"><?php echo wp_kses( __( 'Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors.', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
 			<?php wp_nonce_field( 'coauthors-edit', 'coauthors-nonce' ); ?>
 		</div>
 		<?php

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2044,24 +2044,15 @@ class CoAuthors_Plus {
 	 * @return array $post_data The modified post data.
 	 */
 	public function action_bulk_edit_update_coauthors( array $post_data, array $postarr ): array {
-		if ( ( ! isset( $postarr['post'] ) ) || ( ! $this->is_post_type_enabled( $post_data['post_type'] ) ) ) {
+		if ( empty( $postarr['post'] ) || ! $this->is_post_type_enabled( $postarr['post_type'] ) ) {
 			return $post_data;
 		}
 
 		foreach( $postarr['post'] as $post_id ) {
 			$post = get_post( $post_id );
-
-			if ( $this->current_user_can_set_authors( $post ) && isset( $postarr['coauthors'] ) ) {
-					$coauthors = array_map( 'sanitize_title', (array) $postarr['coauthors'] );
-					$this->add_coauthors( $post_id, $coauthors );
-			} else {
-				// If a Co-Author isn't currently set, explicitly set one.
-				if ( ! $this->has_author_terms( $post_id ) ) {
-					$user = get_userdata( $post->post_author );
-					if ( $user ) {
-						$this->add_coauthors( $post_id, array( $user->user_nicename ) );
-					}
-				}
+			if ( $this->current_user_can_set_authors( $post ) && ! empty( $postarr['coauthors'] ) ) {
+				$coauthors = array_map( 'sanitize_title', (array) $postarr['coauthors'] );
+				$this->add_coauthors( $post_id, $coauthors );
 			}
 		}
 


### PR DESCRIPTION
## Description

This PR adds Bulk Editing support to Co-Authors.

It finishes work started in https://github.com/psaikali/Co-Authors-Plus/commit/2ac1afbacaec965bbd35bbdd569b8eeb3c160c03 and https://github.com/Automattic/Co-Authors-Plus/pull/747.

It fixes https://github.com/Automattic/Co-Authors-Plus/issues/551.

Props to: @psaikali and @TheCrowned

## Deploy Notes

None.

## Steps to Test

Bulk editing needs to be tested on standard Posts and CPTs with WordPress versions >=6.3.
 - `bulk_edit_posts` was [introduced in 6.3](https://developer.wordpress.org/reference/functions/bulk_edit_posts/).

1. Check out the PR.
2. Ensure you have multiple users with roles capable of [editing other users' posts](https://wordpress.org/documentation/article/roles-and-capabilities/#editor).
3. Bulk edit Posts and assign new users.
4. No errors or warnings should be present either in the admin or in the error log.
5. Repeat these tests using: 
* a CPT.
* setting one Author.
* not changing the Author(s).

### Notes

* The fatal error [noted in a previous PR](https://github.com/Automattic/Co-Authors-Plus/pull/747#issuecomment-721961415) could not be replicated.
