### PR TITLE
refactor: Update create_post method to allow nullable WP_User parameter

### DIFF
--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -65,7 +65,7 @@ class TestCase extends \Yoast\WPTestUtils\WPIntegration\TestCase {
 		);
 	}
 
-	protected function create_post( \WP_User $author = null ) {
+	protected function create_post( ?\WP_User $author = null ) {
 		if ( null === $author ) {
 			$author = $this->create_author();
 		}


### PR DESCRIPTION
## Description

Fixes a PHP 8.1 deprecation notice.