### PR TITLE
PHP warning in filter_graph when post is not in Yoast index 

### DIFF
--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -163,6 +163,11 @@ class Yoast {
 			return $data;
 		}
 
+		// Return early if there is no post in the context.
+		if ( empty( $context->post ) || empty( $context->post->ID ) ) {
+			return $data;
+		}
+
 		/**
 		 * Contains the authors from the Co-Authors Plus plugin.
 		 *

--- a/tests/Integration/YoastFilterGraphTest.php
+++ b/tests/Integration/YoastFilterGraphTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use CoAuthors\Integrations\Yoast;
+
+/**
+ * Regression coverage for issue #1113.
+ *
+ * Yoast's `wpseo_schema_graph` filter can run on a singular request whose post
+ * is not present in Yoast's indexable table, in which case the context carries
+ * no post. Before the guard, `filter_graph()` dereferenced `$context->post->ID`
+ * regardless, raising "Attempt to read property ID on null" and falling through
+ * into Yoast-only code. The method must instead return the graph untouched.
+ *
+ * @covers \CoAuthors\Integrations\Yoast::filter_graph
+ */
+class YoastFilterGraphTest extends TestCase {
+
+	public function test_filter_graph_returns_data_unchanged_when_context_post_is_null(): void {
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		$this->assertTrue( is_singular(), 'The guard is only reached on a singular request.' );
+
+		$context       = new \stdClass();
+		$context->post = null;
+
+		$data = array(
+			array(
+				'@type' => 'WebPage',
+				'@id'   => 'https://example.com/#webpage',
+			),
+		);
+
+		$this->assertSame(
+			$data,
+			Yoast::filter_graph( $data, $context ),
+			'filter_graph() must return the graph unchanged when the context has no post.'
+		);
+	}
+
+	public function test_filter_graph_returns_data_unchanged_when_context_post_id_is_empty(): void {
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		$this->assertTrue( is_singular(), 'The guard is only reached on a singular request.' );
+
+		$context           = new \stdClass();
+		$context->post     = new \stdClass();
+		$context->post->ID = 0;
+
+		$data = array(
+			array(
+				'@type' => 'WebPage',
+			),
+		);
+
+		$this->assertSame(
+			$data,
+			Yoast::filter_graph( $data, $context ),
+			'filter_graph() must return the graph unchanged when the context post has no ID.'
+		);
+	}
+}


### PR DESCRIPTION
When a post type is excluded from the Yoast SEO index using the `wpseo_indexable_excluded_post_types` filter, the post may not have a proper indexable object or ID when passed into Yoast’s `filter_graph` hook (using the `$context` argument). Co-Authors Plus currently assumes that a valid `post` object within the `$context` and therefore the `ID` will be available within this filter, which can trigger warnings.

The problematic function is here: https://github.com/Automattic/Co-Authors-Plus/blob/14725a6f877fecd8853f40bf4cc5e9262f71e580/php/integrations/yoast.php#L149-L223

This issue was observed with a custom post type that is excluded via:

```php
add_filter( 'wpseo_indexable_excluded_post_types', function( $post_types ) {
    $post_types[] = 'example-post-type';
    return $post_types;
});
```

The `filter_graph` filter still runs for this post type, even though it is not Yoast-indexable. However, Co-Authors tries to access `get_coauthors( $context->post->ID )`, which can result in an error if `$context->post` is missing due to the post not being indexed.

## Proposed Solution

I propose adding a check to ensure the `post` and the `post->ID` exist within the `$context` that is passed to the filter, before trying to attach co-authors to it.
