### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -12,7 +12,7 @@
 	<!--<rule ref="WordPress-Docs"/>-->
 	<!-- For help in understanding this minimum_supported_wp_version:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿# Co-Authors Plus
 
 Stable tag: 3.7.0  
-Requires at least: 5.9  
+Requires at least: 6.4  
 Tested up to: 6.8  
 Requires PHP: 7.4  
 License: GPLv2 or later  

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
  * Version:           3.7.0
- * Requires at least: 5.9
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
  * Author URI:        https://automattic.com


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.