### PR TITLE
Fix: Replace undefined WP_TESTS_DOMAIN constant with home_url()

### DIFF
--- a/tests/Integration/TemplateTags/CoauthorsWpListAuthorsTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsWpListAuthorsTest.php
@@ -153,7 +153,7 @@ class CoauthorsWpListAuthorsTest extends TestCase {
 		$author = $this->create_author();
 		$post   = $this->create_post( $author );
 
-		$feed_image = WP_TESTS_DOMAIN . '/path/to/a/graphic.png';
+		$feed_image = home_url( '/path/to/a/graphic.png' );
 		$coauthors  = coauthors_wp_list_authors(
 			array(
 				'echo'       => false,


### PR DESCRIPTION
## Summary

This pull request resolves a failing integration test that was broken following the migration of the integration test suite to wp-env. The test `test_list_authors_with_feed_image_arg_enabled` was failing because it referenced an undefined `WP_TESTS_DOMAIN` constant, which does not exist in the wp-env environment.

## Problem

When the integration tests were migrated to wp-env (commit e193f00), the test suite no longer had access to the `WP_TESTS_DOMAIN` constant that was previously defined in the legacy testing environment. The test was constructing a feed image URL by concatenating this undefined constant with a path string. When PHP encountered the undefined constant, it treated it as a literal string 'WP_TESTS_DOMAIN', which then failed URL validation in `esc_url()`, ultimately resulting in an empty string being rendered in the image source attribute (`<img src="">`). This caused the test assertion to fail.

**Failing test:** https://github.com/Automattic/co-authors-plus/actions/runs/19638180654/job/56234200038

## Solution

The fix replaces the undefined constant with WordPress's built-in `home_url()` function, which generates a proper, valid URL based on the current site configuration. This approach is both compatible with the wp-env environment and semantically more appropriate for constructing WordPress URLs within tests.

The change was made in `/tests/Integration/TemplateTags/CoauthorsWpListAuthorsTest.php` on line 156, changing from:
```php
$feed_image = WP_TESTS_DOMAIN . '/path/to/a/graphic.png';
```

to:
```php
$feed_image = home_url( '/path/to/a/graphic.png' );
```

## Test Plan

- [x] Run the integration test suite to verify that `test_list_authors_with_feed_image_arg_enabled` now passes
- [x] Verify that the feed image URL is correctly rendered with a valid URL in the test output
- [ ] CI tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)