### PR TITLE
Fix #1161: SQL syntax error in CLI command when migrating users to gu…

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -428,7 +428,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		$post_types = implode( "','", $coauthors_plus->supported_post_types() );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ({$post_types})", $user->ID ) );
+		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ('{$post_types}')", $user->ID ) );
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
 			$coauthors = cap_get_coauthor_terms_for_post( $post_id );


### PR DESCRIPTION
…est authors

## Description

See https://github.com/Automattic/co-authors-plus/issues/1161.

## Deploy Notes

No.

## Steps to Test

1. Run the WP CLI command `wp co-authors-plus assign-user-to-coauthor`.
