### PR TITLE
fix: prevent PHP warning when deleting users without co-author terms

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1124,7 +1124,9 @@ class CoAuthors_Plus {
 		if ( is_object( $delete_user ) ) {
 			// Delete term
 			$term = $this->get_author_term( $delete_user );
-			wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
+			if ( $term ) {
+				wp_delete_term( $term->term_id, $this->coauthor_taxonomy );
+			}
 		}
 
 		if ( $this->is_guest_authors_enabled() ) {

--- a/tests/Integration/CoAuthorsPlusTest.php
+++ b/tests/Integration/CoAuthorsPlusTest.php
@@ -1993,4 +1993,46 @@ class CoAuthorsPlusTest extends TestCase {
 		remove_filter( 'coauthors_supported_post_types', $callback );
 		unregister_post_type( 'foo' );
 	}
+
+	/**
+	 * Tests that deleting a user without a co-author term doesn't cause PHP warnings.
+	 *
+	 * @covers CoAuthors_Plus::delete_user_action()
+	 */
+	public function test_delete_user_without_coauthor_term_should_not_cause_warning(): void {
+		global $coauthors_plus;
+
+		// Create a user
+		$user = $this->create_author( 'test_user_deletion' );
+
+		// Create a post for the user
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_author' => $user->ID,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Add the user as a co-author to ensure the term is created
+		$coauthors_plus->add_coauthors( $post_id, array( $user->user_nicename ), true );
+
+		// Verify the term exists
+		$term = $coauthors_plus->get_author_term( $user );
+		$this->assertNotFalse( $term, 'Co-author term should exist before deletion' );
+
+		// Manually delete the co-author term to simulate the bug scenario
+		// (e.g., term was manually deleted or corrupted)
+		wp_delete_term( $term->term_id, $coauthors_plus->coauthor_taxonomy );
+
+		// Verify the term is gone
+		$term_after_deletion = $coauthors_plus->get_author_term( $user );
+		$this->assertFalse( $term_after_deletion, 'Co-author term should not exist after manual deletion' );
+
+		// Now delete the user - this should not cause a PHP warning
+		// The bug is that the code tries to access $term->term_id when $term is false
+		wp_delete_user( $user->ID );
+
+		// If we get here without warnings, the test passes
+		$this->assertTrue( true, 'User deleted without PHP warnings' );
+	}
 }


### PR DESCRIPTION
Resolves #1165

When WordPress users are deleted, the plugin attempts to remove their associated co-author taxonomy term. However, the code assumes that `get_author_term()` will always return a valid term object, which isn't the case when a user lacks a co-author term (either because the term was manually deleted, data became corrupted, or the user was created outside the co-authors system).

In PHP 8.4, this causes a warning: "Attempt to read property 'term_id' on bool" because the code tries to access `$term->term_id` when `get_author_term()` returns `false`.

This change adds a simple null check before attempting to delete the term. If no term exists for the user, the deletion is skipped gracefully. This mirrors the defensive programming pattern used elsewhere in the codebase and prevents warnings whilst maintaining the correct behaviour: only delete terms that actually exist.

The fix includes an integration test that reproduces the scenario by creating a user with a co-author term, manually deleting the term to simulate the edge case, and then deleting the user. All 149 tests pass.