### PR TITLE
fix: prevent duplicate guest-authors during import

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,6 +53,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
       - name: Install wordpress environment
         run: npm install -g @wordpress/env
 

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -31,6 +31,7 @@ require_once __DIR__ . '/php/class-coauthors-template-filters.php';
 require_once __DIR__ . '/php/class-coauthors-endpoint.php';
 require_once __DIR__ . '/php/integrations/amp.php';
 require_once __DIR__ . '/php/integrations/yoast.php';
+require_once __DIR__ . '/php/integrations/class-wordpress-importer.php';
 require_once __DIR__ . '/php/class-coauthors-plus.php';
 require_once __DIR__ . '/php/class-coauthors-iterator.php';
 
@@ -48,6 +49,9 @@ global $coauthors_plus;
 $coauthors_plus     = new CoAuthors_Plus();
 $coauthors_endpoint = new CoAuthors\API\Endpoints( $coauthors_plus );
 CoAuthors\Blocks::run();
+
+// Initialize integrations.
+( new Automattic\CoAuthorsPlus\Integrations\WordPress_Importer() )->init();
 
 if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 	/**

--- a/php/integrations/class-wordpress-importer.php
+++ b/php/integrations/class-wordpress-importer.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WordPress Importer integration
+ *
+ * Prevents duplicate guest-author posts during imports when posts
+ * differ only by post_date.
+ *
+ * @package CoAuthors
+ * @since 3.6.3
+ */
+
+namespace Automattic\CoAuthorsPlus\Integrations;
+
+/**
+ * WordPress Importer integration class.
+ */
+class WordPress_Importer {
+
+	/**
+	 * The guest-author post type.
+	 */
+	const POST_TYPE = 'guest-author';
+
+	/**
+	 * Initialize the integration by registering hooks.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_filter( 'wp_import_existing_post', array( $this, 'check_existing_guest_author' ), 10, 2 );
+	}
+
+	/**
+	 * Check for existing guest-author posts by title only.
+	 *
+	 * During imports, guest-author posts that differ only by post_date
+	 * should be considered duplicates. This filter modifies the duplicate
+	 * detection to check by title alone for guest-author posts.
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/326
+	 *
+	 * @param int   $post_exists Post ID if the post exists, 0 otherwise.
+	 * @param array $post        Post data being imported.
+	 * @return int Post ID if the post exists, 0 otherwise.
+	 */
+	public function check_existing_guest_author( int $post_exists, array $post ): int {
+		// Only modify behavior for guest-author posts.
+		if ( ! isset( $post['post_type'] ) || self::POST_TYPE !== $post['post_type'] ) {
+			return $post_exists;
+		}
+
+		// If WordPress already found a match, use that.
+		if ( 0 !== $post_exists ) {
+			return $post_exists;
+		}
+
+		// Check for existing post by title only (ignoring post_date).
+		if ( isset( $post['post_title'] ) ) {
+			$post_exists = post_exists( $post['post_title'], '', '', self::POST_TYPE );
+		}
+
+		return $post_exists;
+	}
+}

--- a/tests/Integration/WordPressImporterTest.php
+++ b/tests/Integration/WordPressImporterTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Tests for the WordPress Importer integration.
+ *
+ * @package CoAuthors
+ */
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use Automattic\CoAuthorsPlus\Integrations\WordPress_Importer;
+
+/**
+ * Tests for the WordPress Importer integration class.
+ *
+ * @covers \CoAuthors\Integrations\WordPress_Importer
+ */
+class WordPressImporterTest extends TestCase {
+
+	/**
+	 * The WordPress Importer instance.
+	 *
+	 * @var WordPress_Importer
+	 */
+	private WordPress_Importer $importer;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->importer = new WordPress_Importer();
+	}
+
+	/**
+	 * Test that filter does not modify behavior for non-guest-author posts.
+	 *
+	 * @covers \CoAuthors\Integrations\WordPress_Importer::check_existing_guest_author
+	 */
+	public function test_filter_ignores_non_guest_author_posts(): void {
+		// Create a regular post.
+		$post = array(
+			'post_type'  => 'post',
+			'post_title' => 'Test Regular Post',
+		);
+
+		// Filter should return the original value unchanged.
+		$result = $this->importer->check_existing_guest_author( 0, $post );
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * Test that filter respects existing match from WordPress.
+	 *
+	 * @covers \CoAuthors\Integrations\WordPress_Importer::check_existing_guest_author
+	 */
+	public function test_filter_respects_existing_match(): void {
+		$existing_id = 123;
+
+		$post = array(
+			'post_type'  => 'guest-author',
+			'post_title' => 'Test Guest Author',
+		);
+
+		// If WordPress already found a match, it should be returned.
+		$result = $this->importer->check_existing_guest_author( $existing_id, $post );
+
+		$this->assertSame( $existing_id, $result );
+	}
+
+	/**
+	 * Test that filter finds existing guest-author by title.
+	 *
+	 * @covers \CoAuthors\Integrations\WordPress_Importer::check_existing_guest_author
+	 */
+	public function test_filter_finds_existing_guest_author_by_title(): void {
+		global $coauthors_plus;
+
+		// Create a guest author.
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => 'Existing Guest Author',
+				'user_login'   => 'existing-guest-author',
+			)
+		);
+
+		$this->assertIsInt( $guest_author_id );
+
+		// Get the guest author post to find its title.
+		$guest_author_post = get_post( $guest_author_id );
+		$this->assertInstanceOf( \WP_Post::class, $guest_author_post );
+
+		// Simulate importing the same guest author with a different date.
+		$post = array(
+			'post_type'  => 'guest-author',
+			'post_title' => $guest_author_post->post_title,
+			'post_date'  => '2020-01-01 00:00:00', // Different date.
+		);
+
+		// Filter should find the existing guest author.
+		$result = $this->importer->check_existing_guest_author( 0, $post );
+
+		$this->assertSame( $guest_author_id, $result );
+	}
+
+	/**
+	 * Test that filter returns 0 when guest-author does not exist.
+	 *
+	 * @covers \CoAuthors\Integrations\WordPress_Importer::check_existing_guest_author
+	 */
+	public function test_filter_returns_zero_for_new_guest_author(): void {
+		$post = array(
+			'post_type'  => 'guest-author',
+			'post_title' => 'Brand New Guest Author That Does Not Exist ' . wp_generate_uuid4(),
+		);
+
+		$result = $this->importer->check_existing_guest_author( 0, $post );
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * Test that filter handles missing post_type gracefully.
+	 *
+	 * @covers \CoAuthors\Integrations\WordPress_Importer::check_existing_guest_author
+	 */
+	public function test_filter_handles_missing_post_type(): void {
+		$post = array(
+			'post_title' => 'Test Post Without Type',
+		);
+
+		$result = $this->importer->check_existing_guest_author( 0, $post );
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * Test that filter handles missing post_title gracefully.
+	 *
+	 * @covers \CoAuthors\Integrations\WordPress_Importer::check_existing_guest_author
+	 */
+	public function test_filter_handles_missing_post_title(): void {
+		$post = array(
+			'post_type' => 'guest-author',
+		);
+
+		$result = $this->importer->check_existing_guest_author( 0, $post );
+
+		$this->assertSame( 0, $result );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds WordPress Importer integration that checks for existing guest-author posts by title only, ignoring post_date differences
- Prevents duplicate guest-authors when reimporting content with different timestamps
- Includes comprehensive test coverage

## Background

During imports containing `guest-author` posts (especially staged or chunked imports), posts can fail the `get_post_exists` check when they differ only by `post_date`. This creates duplicate guest-authors that are difficult to remove since their slugs are the same.

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)