### PR TITLE
fix: support custom post types in count_user_posts filter

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1226,6 +1226,14 @@ class CoAuthors_Plus {
 			return $count;
 		}
 
+		// For backwards compatibility: when WordPress passes the default 'post' type,
+		// apply the coauthors_count_published_post_types filter to allow overriding.
+		// WordPress may pass as string 'post' or array ['post'] depending on version.
+		$is_default_post_type = ( 'post' === $post_type || ( is_array( $post_type ) && array( 'post' ) === $post_type ) );
+		if ( $is_default_post_type ) {
+			$post_type = apply_filters( 'coauthors_count_published_post_types', array( 'post' ) );
+		}
+
 		// Query actual post count for the specified post types.
 		$coauthor_count = $this->get_post_count_for_author_term( $term, $post_type, $public_only );
 

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -53,7 +53,7 @@ class CoAuthors_Plus {
 		// Action to reassign posts when a guest author is deleted
 		add_action( 'delete_user', array( $this, 'delete_user_action' ) );
 
-		add_filter( 'get_usernumposts', array( $this, 'filter_count_user_posts' ), 10, 2 );
+		add_filter( 'get_usernumposts', array( $this, 'filter_count_user_posts' ), 10, 4 );
 
 		// Action to set up co-author auto-suggest
 		add_action( 'wp_ajax_coauthors_ajax_suggest', array( $this, 'ajax_suggest' ) );
@@ -1195,14 +1195,24 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Filter the count_users_posts() core function to include our correct count.
+	 * Filter the count_user_posts() core function to include correct count for co-authors.
 	 *
-	 * @param int $count Post count
-	 * @param int $user_id WP user ID
-	 * @return int Post count
+	 * @since 2.6.4
+	 * @since 3.6.3 Added support for custom post types via $post_type parameter.
+	 *
+	 * @param int          $count       Post count.
+	 * @param int          $user_id     WP user ID.
+	 * @param string|array $post_type   Post type(s) to count. Default 'post'.
+	 * @param bool         $public_only Whether to only count public posts. Default false.
+	 * @return int Post count.
 	 */
-	public function filter_count_user_posts( $count, $user_id ): int {
-		$user     = get_userdata( $user_id );
+	public function filter_count_user_posts( $count, $user_id, $post_type = 'post', $public_only = false ): int {
+		$user = get_userdata( $user_id );
+
+		if ( ! $user ) {
+			return $count;
+		}
+
 		$coauthor = $this->get_coauthor_by( 'user_nicename', $user->user_nicename );
 
 		// Return $count if no co-author exists.
@@ -1212,18 +1222,58 @@ class CoAuthors_Plus {
 
 		$term = $this->get_author_term( $coauthor );
 
-		if ( is_object( $term ) ) {
-			// Return combined post count, if account is linked.
-			if ( strlen( $coauthor->linked_account ) > 2 ) {
-				return $count + $term->count;
-			}
-
-			// Otherwise, return the term count.
-			return $term->count;
+		if ( ! is_object( $term ) ) {
+			return $count;
 		}
 
-		// Return $count as fallback.
-		return $count;
+		// Query actual post count for the specified post types.
+		$coauthor_count = $this->get_post_count_for_author_term( $term, $post_type, $public_only );
+
+		// If account is linked, add the original count (which covers post_author field).
+		if ( ! empty( $coauthor->linked_account ) && strlen( $coauthor->linked_account ) > 2 ) {
+			return $count + $coauthor_count;
+		}
+
+		return $coauthor_count;
+	}
+
+	/**
+	 * Get the post count for an author term with specific post types.
+	 *
+	 * @since 3.6.3
+	 *
+	 * @param WP_Term      $term        Author term object.
+	 * @param string|array $post_type   Post type(s) to count.
+	 * @param bool         $public_only Whether to only count public posts.
+	 * @return int Post count.
+	 */
+	private function get_post_count_for_author_term( $term, $post_type = 'post', $public_only = false ): int {
+		$post_types = (array) $post_type;
+
+		$args = array(
+			'tax_query'              => array(
+				array(
+					'taxonomy' => $this->coauthor_taxonomy,
+					'field'    => 'term_id',
+					'terms'    => $term->term_id,
+				),
+			),
+			'post_type'              => $post_types,
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		);
+
+		if ( $public_only ) {
+			$args['post_status'] = 'publish';
+		} else {
+			$args['post_status'] = array( 'publish', 'private' );
+		}
+
+		$query = new \WP_Query( $args );
+
+		return $query->found_posts;
 	}
 
 	/**

--- a/tests/Integration/CountUserPostsTest.php
+++ b/tests/Integration/CountUserPostsTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Tests for the count_user_posts filter.
+ *
+ * @package CoAuthors
+ */
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Tests for filter_count_user_posts().
+ *
+ * @covers CoAuthors_Plus::filter_count_user_posts
+ */
+class CountUserPostsTest extends TestCase {
+
+	/**
+	 * Test that count_user_posts works with default post type.
+	 */
+	public function test_count_user_posts_default_post_type(): void {
+		$author = $this->create_author();
+
+		// Create posts for the author.
+		$this->factory()->post->create_many(
+			3,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$count = count_user_posts( $author->ID );
+
+		$this->assertSame( 3, $count );
+	}
+
+	/**
+	 * Test that count_user_posts works with custom post types.
+	 *
+	 * @covers CoAuthors_Plus::filter_count_user_posts
+	 * @covers CoAuthors_Plus::get_post_count_for_author_term
+	 */
+	public function test_count_user_posts_custom_post_type(): void {
+		global $coauthors_plus;
+
+		// Register a custom post type with author support.
+		register_post_type(
+			'custom_cpt',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor', 'author' ),
+			)
+		);
+
+		// Add the custom post type to supported types.
+		add_filter(
+			'coauthors_supported_post_types',
+			function ( $post_types ) {
+				$post_types[] = 'custom_cpt';
+				return $post_types;
+			}
+		);
+
+		$author = $this->create_author();
+
+		// Create posts of different types and assign coauthors.
+		$post_ids = $this->factory()->post->create_many(
+			2,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		foreach ( $post_ids as $post_id ) {
+			$coauthors_plus->add_coauthors( $post_id, array( $author->user_login ) );
+		}
+
+		$cpt_ids = $this->factory()->post->create_many(
+			3,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'custom_cpt',
+			)
+		);
+
+		foreach ( $cpt_ids as $post_id ) {
+			$coauthors_plus->add_coauthors( $post_id, array( $author->user_login ) );
+		}
+
+		// Count only 'post' type.
+		$post_count = count_user_posts( $author->ID, 'post' );
+		$this->assertSame( 2, $post_count );
+
+		// Count only custom post type.
+		$cpt_count = count_user_posts( $author->ID, 'custom_cpt' );
+		$this->assertSame( 3, $cpt_count );
+
+		// Count both types.
+		$both_count = count_user_posts( $author->ID, array( 'post', 'custom_cpt' ) );
+		$this->assertSame( 5, $both_count );
+
+		// Clean up.
+		unregister_post_type( 'custom_cpt' );
+	}
+
+	/**
+	 * Test that count_user_posts respects public_only parameter.
+	 *
+	 * @covers CoAuthors_Plus::filter_count_user_posts
+	 * @covers CoAuthors_Plus::get_post_count_for_author_term
+	 */
+	public function test_count_user_posts_public_only(): void {
+		$author = $this->create_author();
+
+		// Create published posts.
+		$this->factory()->post->create_many(
+			2,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// Create private posts.
+		$this->factory()->post->create_many(
+			3,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'private',
+				'post_type'   => 'post',
+			)
+		);
+
+		// Count all (public and private).
+		$all_count = count_user_posts( $author->ID, 'post', false );
+		$this->assertSame( 5, $all_count );
+
+		// Count only public.
+		$public_count = count_user_posts( $author->ID, 'post', true );
+		$this->assertSame( 2, $public_count );
+	}
+
+	/**
+	 * Test count for guest authors with custom post types.
+	 *
+	 * @covers CoAuthors_Plus::filter_count_user_posts
+	 * @covers CoAuthors_Plus::get_post_count_for_author_term
+	 */
+	public function test_count_guest_author_posts_custom_post_type(): void {
+		global $coauthors_plus;
+
+		// Register a custom post type.
+		register_post_type(
+			'custom_cpt',
+			array(
+				'public' => true,
+			)
+		);
+
+		// Create an author and guest author.
+		$author          = $this->create_author();
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => 'Test Guest',
+				'user_login'   => 'test-guest',
+			)
+		);
+
+		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
+
+		// Create posts and assign the guest author.
+		$post1 = $this->factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$post2 = $this->factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'custom_cpt',
+			)
+		);
+
+		// Assign guest author to both posts.
+		$coauthors_plus->add_coauthors( $post1, array( $guest_author->user_login ), true );
+		$coauthors_plus->add_coauthors( $post2, array( $guest_author->user_login ), true );
+
+		// Get the guest author term.
+		$term = $coauthors_plus->get_author_term( $guest_author );
+		$this->assertInstanceOf( \WP_Term::class, $term );
+
+		// Use the private method to count posts.
+		$reflection = new \ReflectionClass( $coauthors_plus );
+		$method     = $reflection->getMethod( 'get_post_count_for_author_term' );
+		$method->setAccessible( true );
+
+		// Count only 'post' type.
+		$post_count = $method->invoke( $coauthors_plus, $term, 'post', false );
+		$this->assertSame( 1, $post_count );
+
+		// Count only custom post type.
+		$cpt_count = $method->invoke( $coauthors_plus, $term, 'custom_cpt', false );
+		$this->assertSame( 1, $cpt_count );
+
+		// Count both types.
+		$both_count = $method->invoke( $coauthors_plus, $term, array( 'post', 'custom_cpt' ), false );
+		$this->assertSame( 2, $both_count );
+
+		// Clean up.
+		unregister_post_type( 'custom_cpt' );
+	}
+}


### PR DESCRIPTION
## Summary

- Updates `filter_count_user_posts()` to accept all 4 parameters from the `get_usernumposts` filter (added in WP 4.1)
- Queries actual posts with the specified post types instead of using the taxonomy term count
- Properly handles the `$public_only` parameter for filtering by post status
- Adds new private method `get_post_count_for_author_term()` for reusable post counting

## Background

The `get_usernumposts` filter has passed `$post_type` since WordPress 4.1, but Co-Authors Plus was only listening to 2 parameters. Additionally, `$term->count` from the taxonomy only tracks 'post' type, not custom post types.

This fix queries actual posts using `WP_Query` with the correct taxonomy and post types.

Fixes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)