### PR TITLE
feat: add Jetpack Subscriber Emails integration for co-authors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/php/class-coauthors-endpoint.php';
 require_once __DIR__ . '/php/integrations/amp.php';
 require_once __DIR__ . '/php/integrations/yoast.php';
 require_once __DIR__ . '/php/integrations/class-wordpress-importer.php';
+require_once __DIR__ . '/php/integrations/class-jetpack-subscriber-emails.php';
 require_once __DIR__ . '/php/class-coauthors-plus.php';
 require_once __DIR__ . '/php/class-coauthors-iterator.php';
 
@@ -52,6 +53,7 @@ CoAuthors\Blocks::run();
 
 // Initialize integrations.
 ( new Automattic\CoAuthorsPlus\Integrations\WordPress_Importer() )->init();
+( new Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails() )->init();
 
 if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 	/**

--- a/php/integrations/class-jetpack-subscriber-emails.php
+++ b/php/integrations/class-jetpack-subscriber-emails.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Integration with Jetpack Subscriber Emails.
+ *
+ * Ensures that subscription emails show the correct co-author information
+ * instead of the WordPress post_author.
+ *
+ * @package CoAuthors
+ * @since 3.8.0
+ * @see https://github.com/Automattic/co-authors-plus/issues/750
+ */
+
+namespace Automattic\CoAuthorsPlus\Integrations;
+
+/**
+ * Jetpack Subscriber Emails Integration.
+ *
+ * Filters the author data synced to WordPress.com for subscription emails
+ * to use the primary co-author instead of the post_author field.
+ *
+ * @since 3.8.0
+ */
+class Jetpack_Subscriber_Emails {
+
+	/**
+	 * Initialize the integration.
+	 *
+	 * @since 3.8.0
+	 */
+	public function init(): void {
+		add_action( 'plugins_loaded', array( $this, 'register_hooks' ) );
+	}
+
+	/**
+	 * Register hooks if Jetpack sync is available.
+	 *
+	 * @since 3.8.0
+	 */
+	public function register_hooks(): void {
+		if ( ! $this->is_jetpack_sync_available() ) {
+			return;
+		}
+
+		add_filter( 'jetpack_published_post_flags', array( $this, 'filter_published_post_flags' ), 10, 2 );
+	}
+
+	/**
+	 * Check if Jetpack sync functionality is available.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return bool True if Jetpack sync is available.
+	 */
+	protected function is_jetpack_sync_available(): bool {
+		return class_exists( 'Jetpack' ) || class_exists( 'Automattic\Jetpack\Sync\Modules\Posts' );
+	}
+
+	/**
+	 * Filter the published post flags to use co-author information.
+	 *
+	 * This ensures that subscription emails display the correct author
+	 * (the primary co-author) instead of the post_author field value.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param array    $flags Post flags being synced to WordPress.com.
+	 * @param \WP_Post $post  The post being published.
+	 * @return array Modified post flags with co-author information.
+	 */
+	public function filter_published_post_flags( array $flags, \WP_Post $post ): array {
+		global $coauthors_plus;
+
+		if ( ! $coauthors_plus || ! $coauthors_plus->is_post_type_enabled( $post->post_type ) ) {
+			return $flags;
+		}
+
+		$coauthors = get_coauthors( $post->ID );
+
+		if ( empty( $coauthors ) ) {
+			return $flags;
+		}
+
+		// Use the primary (first) co-author for the email.
+		$primary_author = $coauthors[0];
+
+		$flags['author'] = $this->build_author_data( $primary_author, $post );
+
+		// Add all co-authors for potential future use.
+		$flags['coauthors'] = array_map(
+			function ( $coauthor ) use ( $post ) {
+				return $this->build_author_data( $coauthor, $post );
+			},
+			$coauthors
+		);
+
+		return $flags;
+	}
+
+	/**
+	 * Build author data array for a co-author.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param object   $coauthor The co-author object (WP_User or guest author).
+	 * @param \WP_Post $post     The post being published.
+	 * @return array Author data formatted for Jetpack sync.
+	 */
+	protected function build_author_data( $coauthor, \WP_Post $post ): array {
+		$author_data = array(
+			'id'           => $coauthor->ID,
+			'display_name' => $coauthor->display_name,
+			'email'        => '',
+			'type'         => isset( $coauthor->type ) ? $coauthor->type : 'wpuser',
+		);
+
+		// Get email - guest authors may have it in a different location.
+		if ( $coauthor instanceof \WP_User ) {
+			$author_data['email']           = $coauthor->user_email;
+			$author_data['wpcom_user_id']   = get_user_meta( $coauthor->ID, 'wpcom_user_id', true );
+			$author_data['translated_role'] = $this->get_translated_role( $coauthor );
+		} elseif ( isset( $coauthor->user_email ) ) {
+			$author_data['email'] = $coauthor->user_email;
+		}
+
+		// Add author URL.
+		$author_data['url'] = get_author_posts_url( $coauthor->ID, $coauthor->user_nicename );
+
+		return $author_data;
+	}
+
+	/**
+	 * Get the translated role for a user.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param \WP_User $user The user object.
+	 * @return string Translated role or empty string.
+	 */
+	protected function get_translated_role( \WP_User $user ): string {
+		if ( class_exists( 'Automattic\Jetpack\Roles' ) ) {
+			$roles = new \Automattic\Jetpack\Roles();
+			return $roles->translate_user_to_role( $user );
+		}
+
+		return '';
+	}
+}

--- a/tests/Integration/JetpackSubscriberEmailsTest.php
+++ b/tests/Integration/JetpackSubscriberEmailsTest.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tests for Jetpack Subscriber Emails integration.
+ *
+ * @package CoAuthors
+ */
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails;
+
+/**
+ * Tests for the Jetpack Subscriber Emails integration.
+ *
+ * @covers \Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails
+ */
+class JetpackSubscriberEmailsTest extends TestCase {
+
+	/**
+	 * The integration instance.
+	 *
+	 * @var Jetpack_Subscriber_Emails
+	 */
+	private $integration;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->integration = new Jetpack_Subscriber_Emails();
+	}
+
+	/**
+	 * Test that published post flags are modified for posts with co-authors.
+	 *
+	 * @covers \Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails::filter_published_post_flags
+	 */
+	public function test_filter_published_post_flags_with_coauthor(): void {
+		global $coauthors_plus;
+
+		$author = $this->create_author( 'test-author' );
+		$post   = $this->create_post( $author );
+
+		// Assign the author as a co-author.
+		$coauthors_plus->add_coauthors( $post->ID, array( $author->user_login ) );
+
+		$flags = array(
+			'post_type' => 'post',
+			'author'    => array(
+				'id'           => 999, // Different from actual author.
+				'display_name' => 'Wrong Name',
+				'email'        => 'wrong@example.com',
+			),
+		);
+
+		$result = $this->integration->filter_published_post_flags( $flags, $post );
+
+		$this->assertSame( $author->ID, $result['author']['id'] );
+		$this->assertSame( $author->display_name, $result['author']['display_name'] );
+		$this->assertSame( $author->user_email, $result['author']['email'] );
+		$this->assertArrayHasKey( 'coauthors', $result );
+		$this->assertCount( 1, $result['coauthors'] );
+	}
+
+	/**
+	 * Test that published post flags include guest author information.
+	 *
+	 * @covers \Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails::filter_published_post_flags
+	 */
+	public function test_filter_published_post_flags_with_guest_author(): void {
+		global $coauthors_plus;
+
+		$author          = $this->create_author( 'test-author' );
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => 'Guest Writer',
+				'user_login'   => 'guest-writer',
+				'user_email'   => 'guest@example.com',
+			)
+		);
+		$guest_author    = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
+
+		$post = $this->create_post( $author );
+
+		// Replace author with guest author.
+		$coauthors_plus->add_coauthors( $post->ID, array( $guest_author->user_login ), false );
+
+		$flags = array(
+			'post_type' => 'post',
+			'author'    => array(
+				'id'           => $author->ID,
+				'display_name' => $author->display_name,
+				'email'        => $author->user_email,
+			),
+		);
+
+		$result = $this->integration->filter_published_post_flags( $flags, $post );
+
+		$this->assertSame( 'Guest Writer', $result['author']['display_name'] );
+		$this->assertSame( 'guest@example.com', $result['author']['email'] );
+		$this->assertSame( 'guest-author', $result['author']['type'] );
+	}
+
+	/**
+	 * Test that published post flags include multiple co-authors.
+	 *
+	 * @covers \Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails::filter_published_post_flags
+	 */
+	public function test_filter_published_post_flags_with_multiple_coauthors(): void {
+		global $coauthors_plus;
+
+		$author1 = $this->create_author( 'author-one' );
+		$author2 = $this->create_author( 'author-two' );
+		$post    = $this->create_post( $author1 );
+
+		// Add both as co-authors.
+		$coauthors_plus->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		$flags = array(
+			'post_type' => 'post',
+			'author'    => array(),
+		);
+
+		$result = $this->integration->filter_published_post_flags( $flags, $post );
+
+		// Primary author should be the first one.
+		$this->assertSame( $author1->display_name, $result['author']['display_name'] );
+
+		// All co-authors should be included.
+		$this->assertArrayHasKey( 'coauthors', $result );
+		$this->assertCount( 2, $result['coauthors'] );
+		$this->assertSame( $author1->display_name, $result['coauthors'][0]['display_name'] );
+		$this->assertSame( $author2->display_name, $result['coauthors'][1]['display_name'] );
+	}
+
+	/**
+	 * Test that flags are returned unchanged for unsupported post types.
+	 *
+	 * @covers \Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails::filter_published_post_flags
+	 */
+	public function test_filter_published_post_flags_unsupported_post_type(): void {
+		register_post_type( 'unsupported_type', array( 'public' => true ) );
+
+		$author  = $this->create_author( 'test-author' );
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'unsupported_type',
+			)
+		);
+		$post    = get_post( $post_id );
+
+		$flags = array(
+			'post_type' => 'unsupported_type',
+			'author'    => array(
+				'id'           => 999,
+				'display_name' => 'Original',
+			),
+		);
+
+		$result = $this->integration->filter_published_post_flags( $flags, $post );
+
+		// Flags should be unchanged.
+		$this->assertSame( 999, $result['author']['id'] );
+		$this->assertSame( 'Original', $result['author']['display_name'] );
+		$this->assertArrayNotHasKey( 'coauthors', $result );
+
+		unregister_post_type( 'unsupported_type' );
+	}
+
+	/**
+	 * Test that flags use post_author when no co-author terms exist.
+	 *
+	 * When no co-author terms exist, get_coauthors() falls back to post_author,
+	 * so the integration should still provide the correct author data.
+	 *
+	 * @covers \Automattic\CoAuthorsPlus\Integrations\Jetpack_Subscriber_Emails::filter_published_post_flags
+	 */
+	public function test_filter_published_post_flags_no_coauthor_terms(): void {
+		$author = $this->create_author( 'test-author' );
+		$post   = $this->create_post( $author );
+
+		// Remove all co-author terms - get_coauthors() will fall back to post_author.
+		wp_delete_object_term_relationships( $post->ID, 'author' );
+
+		$flags = array(
+			'post_type' => 'post',
+			'author'    => array(
+				'id'           => 999,
+				'display_name' => 'Original',
+			),
+		);
+
+		$result = $this->integration->filter_published_post_flags( $flags, $post );
+
+		// Even without terms, get_coauthors falls back to post_author.
+		$this->assertSame( $author->ID, $result['author']['id'] );
+		$this->assertSame( $author->display_name, $result['author']['display_name'] );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds new `Jetpack_Subscriber_Emails` integration class that hooks into `jetpack_published_post_flags` filter
- Overrides synced author data with the primary co-author's information (including guest authors)
- Includes all co-authors in the sync data for potential future use
- Adds comprehensive integration tests

## Background

When Jetpack syncs post data to WordPress.com for subscription emails, it reads author information from the `post_author` field. This doesn't reflect co-author assignments, causing subscription emails to display the publishing user's name instead of the actual co-author (including guest authors).

This integration ensures the correct author information is synced by hooking into the `jetpack_published_post_flags` filter and providing co-author data.

## Test plan

- [ ] Verify integration is loaded when Jetpack is active
- [ ] Publish a post with a guest author and confirm Jetpack sync includes correct author data
- [ ] Publish a post with multiple co-authors and confirm primary author is used
- [ ] Verify posts with unsupported post types are not affected

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)