### PR TITLE
refactor: replace suggest library with jQuery UI autocomplete

### DIFF
--- a/css/co-authors-plus.css
+++ b/css/co-authors-plus.css
@@ -127,3 +127,30 @@
 .cap-author .cap-author-flex-item:first-child {
     overflow-wrap: break-word;
 }
+
+/* Autocomplete dropdown styles */
+.ui-autocomplete {
+	max-height: 300px;
+	overflow-y: auto;
+	overflow-x: hidden;
+	z-index: 100001; /* Above WordPress admin elements */
+}
+
+.ui-autocomplete .ui-menu-item-wrapper {
+	display: flex;
+	align-items: center;
+}
+
+.coauthor-autocomplete-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.coauthor-autocomplete-avatar {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	vertical-align: middle;
+}

--- a/js/co-authors-plus.js
+++ b/js/co-authors-plus.js
@@ -1,154 +1,124 @@
-jQuery( document ).ready(function () {
+jQuery( document ).ready( function( $ ) {
 
 	/*
 	 * Click handler for the delete button
-	 * @param event
 	 */
-	var coauthors_delete_onclick = function( e ) {
+	var coauthors_delete_onclick = function() {
 		if ( confirm( coAuthorsPlusStrings.confirm_delete ) ) {
 			return coauthors_delete( this );
 		}
 		return false;
 	};
 
-	var $coauthors_loading = jQuery("<span id='ajax-loading'></span>");
+	var $coauthors_loading = $( '<span id="ajax-loading"></span>' );
 
 	function coauthors_delete( elem ) {
-
-		var $coauthor_row = jQuery( elem ).closest( '.coauthor-row' );
+		var $coauthor_row = $( elem ).closest( '.coauthor-row' );
 		$coauthor_row.remove();
 
 		// Hide the delete button when there's only one Co-Author
-		if ( jQuery( '#coauthors-list .coauthor-row .coauthor-tag' ).length <= 1 )
-			jQuery( '#coauthors-list .coauthor-row .coauthors-author-options' ).addClass( 'hidden' );
+		if ( $( '#coauthors-list .coauthor-row .coauthor-tag' ).length <= 1 ) {
+			$( '#coauthors-list .coauthor-row .coauthors-author-options' ).addClass( 'hidden' );
+		}
 
 		return true;
 	}
 
-	var coauthors_edit_onclick = function( event ) {
-		var $tag = jQuery( this );
-
+	var coauthors_edit_onclick = function() {
+		var $tag = $( this );
 		var $co = $tag.prev();
 
 		$tag.hide();
-		$co.show()
-			.on( 'focus' )
-			;
-
-		$co.previousAuthor = $tag.text();
-	}
+		$co.show().trigger( 'focus' );
+		$co.data( 'previousAuthor', $tag.text() );
+	};
 
 	/*
-	 * Save co-author
-	 * @param int Co-Author ID
-	 * @param string Co-Author Name
-	 * @param object The autosuggest input box
+	 * Save co-author (when editing an existing one)
 	 */
-	function coauthors_save_coauthor( author, co ) {
-
-		// get sibling <span> and update
-		co.siblings( '.coauthor-tag' )
-			.html( author.name )
+	function coauthors_save_coauthor( author, $co ) {
+		// Get sibling <span> and update
+		$co.siblings( '.coauthor-tag' )
+			.html( author.label )
 			.append( coauthors_create_author_gravatar( author ) )
-			.show()
-			;
+			.show();
 
 		// Update the value of the hidden input
-		co.siblings( 'input[name="coauthors[]"]' ).val( author.nicename );
+		$co.siblings( 'input[name="coauthors[]"]' ).val( author.nicename );
 	}
-
 
 	/*
 	 * Add co-author
-	 * @param string Co-Author Name
-	 * @param object The autosuggest input box
-	 * @param boolean Initial set up or not?
 	 */
-	function coauthors_add_coauthor( author, co, init, count ){
-
+	function coauthors_add_coauthor( author, $co, init, count ) {
 		// Check if editing
-		if ( co && co.siblings( '.coauthor-tag' ).length ) {
-			coauthors_save_coauthor( author, co );
+		if ( $co && $co.siblings( '.coauthor-tag' ).length ) {
+			coauthors_save_coauthor( author, $co );
 		} else {
 			// Not editing, so we create a new co-author entry
-			if ( count == 0 ) {
-				var coName = ( count == 0 ) ? 'coauthors-main' : '';
-				// Add new co-author to <select>
-				//coauthors_select_author( co-author );
-			}
+			var coName = ( count === 0 ) ? 'coauthors-main' : '';
 			var options = { addDelete: true, addEdit: false };
 
-			// Create autosuggest box and text tag
-			if ( ! co ) var co = coauthors_create_autosuggest( author.name, coName )
-			var tag = coauthors_create_author_tag( author );
-			var input = coauthors_create_author_hidden_input( author );
+			// Create autocomplete box and text tag
+			if ( ! $co ) {
+				$co = coauthors_create_autocomplete( author.label, coName );
+			}
+			var $tag = coauthors_create_author_tag( author );
+			var $input = coauthors_create_author_hidden_input( author );
 			var $gravatar = coauthors_create_author_gravatar( author );
 
-			tag.append( $gravatar );
-
-			coauthors_add_to_table( co, tag, input, options );
+			$tag.append( $gravatar );
+			coauthors_add_to_table( $co, $tag, $input, options );
 
 			if ( ! init ) {
-				// Create new author-suggest and append it to a new row
-				var newCO = coauthors_create_autosuggest( '', false );
-				coauthors_add_to_table( newCO );
-				move_loading( newCO );
+				// Create new autocomplete and append it to a new row
+				var $newCO = coauthors_create_autocomplete( '', false );
+				coauthors_add_to_table( $newCO );
+				move_loading( $newCO );
 			}
 		}
 
-		co.on( 'blur', coauthors_stop_editing );
+		$co.on( 'blur', coauthors_stop_editing );
 
-		// Set the value for the auto-suggest box to the co-author's name and hide it
-		// unescape() is deprecated, so replacing it with decodeURIComponent() here and every places.
-		co.val( decodeURIComponent( author.name ) )
-			.hide()
-			.off( 'focus' )
-			;
+		// Set the value for the autocomplete box to the co-author's name and hide it
+		$co.val( decodeURIComponent( author.label || author.name ) ).hide().off( 'focus' );
 
 		return true;
 	}
 
-
 	/*
-	 * Add the autosuggest box and text tag to the Co-Authors table
-	 * @param object Autosuggest input box
-	 * @param object Text tag
-	 * @param
+	 * Add the autocomplete box and text tag to the Co-Authors table
 	 */
-	function coauthors_add_to_table( co, tag, input, options ) {
-		if ( co ) {
-			var $div = jQuery( '<div/>' )
-						.addClass( 'suggest' )
-						.addClass( 'coauthor-row' )
-						.append( co )
-						.append( tag )
-						.append( input )
-						;
+	function coauthors_add_to_table( $co, $tag, $input, options ) {
+		if ( $co ) {
+			var $div = $( '<div/>' )
+				.addClass( 'suggest' )
+				.addClass( 'coauthor-row' )
+				.append( $co )
+				.append( $tag )
+				.append( $input );
 
-			//Add buttons to row
-			if ( tag ) coauthors_insert_author_edit_cells( $div, options );
+			// Add buttons to row
+			if ( $tag ) {
+				coauthors_insert_author_edit_cells( $div, options );
+			}
 
-			jQuery( '#coauthors-list' ).append( $div );
+			$( '#coauthors-list' ).append( $div );
 		}
 	}
 
 	/*
-	 * Adds a delete and edit button next to a co-author
-	 * @param object The row to which the new co-author should be added
+	 * Adds a delete button next to a co-author
 	 */
-	function coauthors_insert_author_edit_cells( $div, options ){
-
-		var $options = jQuery( '<div/>' )
-			.addClass( 'coauthors-author-options' )
-			;
+	function coauthors_insert_author_edit_cells( $div, options ) {
+		var $options = $( '<div/>' ).addClass( 'coauthors-author-options' );
 
 		if ( options.addDelete ) {
-			var deleteBtn = jQuery( '<span/>' )
-								.addClass( 'delete-coauthor' )
-								.text( coAuthorsPlusStrings.delete_label )
-								.on( 'click', coauthors_delete_onclick )
-								;
-			$options.append( deleteBtn );
+			var $deleteBtn = $( '<span/>' )
+				.addClass( 'delete-coauthor' )
+				.text( coAuthorsPlusStrings.delete_label )
+				.on( 'click', coauthors_delete_onclick );
+			$options.append( $deleteBtn );
 		}
 
 		$div.append( $options );
@@ -156,316 +126,285 @@ jQuery( document ).ready(function () {
 	}
 
 	/*
-	 * Creates autosuggest input box
-	 * @param string [optional] Name of the co-author
-	 * @param string [optional] Name to be applied to the input box
+	 * Creates autocomplete input box
 	 */
-	function coauthors_create_autosuggest( authorName, inputName ) {
+	function coauthors_create_autocomplete( authorName, inputName ) {
+		if ( ! inputName ) {
+			inputName = 'coauthorsinput[]';
+		}
 
-		if ( ! inputName ) inputName = 'coauthorsinput[]';
+		var $co = $( '<input/>' ).attr( {
+			'class': 'coauthor-suggest',
+			'name': inputName
+		} ).appendTo( $coauthors_div );
 
-		var $co = jQuery( '<input/>' );
+		// Build the AJAX URL with existing authors filter
+		var getAutocompleteUrl = function() {
+			var existing = $( 'input[name="coauthors[]"]' ).map( function() {
+				return $( this ).val();
+			} ).get();
+			return coAuthorsPlus_ajax_suggest_link + '&existing_authors=' + existing.join( ',' );
+		};
 
-		$co.attr({
-			'class': 'coauthor-suggest'
-			, 'name': inputName
-			})
-			.appendTo( $coauthors_div )
-			.suggest( coAuthorsPlus_ajax_suggest_link, {
-				onSelect: coauthors_autosuggest_select,
-				delay: 1000
-			})
-			.on( 'keydown', coauthors_autosuggest_keydown )
-			;
+		$co.autocomplete( {
+			source: function( request, response ) {
+				show_loading();
+				$.getJSON( getAutocompleteUrl(), { term: request.term }, function( data ) {
+					hide_loading();
+					response( data );
+				} );
+			},
+			minLength: 1,
+			delay: 500,
+			select: function( event, ui ) {
+				coauthors_add_coauthor( ui.item, $co );
 
-		if ( authorName )
-			$co.attr( 'value', decodeURIComponent( authorName ) );
-		else
-			$co.attr( 'value', coAuthorsPlusStrings.search_box_text )
-				.on( 'focus', function(){ $co.val( '' ) } )
-				.on( 'blur', function(){ $co.val( coAuthorsPlusStrings.search_box_text ) } )
-				;
+				// Show the delete button if we now have more than one co-author
+				if ( $( '#coauthors-list .coauthor-row .coauthor-tag' ).length > 1 ) {
+					$( '#coauthors-list .coauthor-row .coauthors-author-options' ).removeClass( 'hidden' );
+				}
 
-		if ( coauthors_initialized_on_bulk_edit )
-			$co.attr({
+				return false;
+			},
+			focus: function( event, ui ) {
+				$co.val( ui.item.label );
+				return false;
+			}
+		} );
+
+		// Custom rendering to show avatar alongside name
+		var autocompleteInstance = $co.data( 'ui-autocomplete' );
+		if ( autocompleteInstance ) {
+			autocompleteInstance._renderItem = function( ul, item ) {
+				var $li = $( '<li>' );
+				var $wrapper = $( '<div>' ).addClass( 'coauthor-autocomplete-item' );
+
+				if ( item.avatar ) {
+					$wrapper.append( $( '<img>' ).attr( 'src', item.avatar ).addClass( 'coauthor-autocomplete-avatar' ) );
+				}
+				$wrapper.append( $( '<span>' ).text( item.label ) );
+
+				return $li.append( $wrapper ).appendTo( ul );
+			};
+		}
+
+		$co.on( 'keydown', function( e ) {
+			// Prevent enter key from submitting form
+			if ( e.keyCode === 13 ) {
+				return false;
+			}
+		} );
+
+		if ( authorName ) {
+			$co.val( decodeURIComponent( authorName ) );
+		} else {
+			$co.val( coAuthorsPlusStrings.search_box_text )
+				.on( 'focus', function() { $co.val( '' ); } )
+				.on( 'blur', function() {
+					if ( $co.val() === '' ) {
+						$co.val( coAuthorsPlusStrings.search_box_text );
+					}
+				} );
+		}
+
+		if ( coauthors_initialized_on_bulk_edit ) {
+			$co.attr( {
 				'aria-labelledby': 'coauthors-bulk-edit-label',
 				'aria-describedby': 'coauthors-bulk-edit-desc'
-			})
-			;
+			} );
+		}
 
 		return $co;
-
-	}
-
-	// Callback for when a user selects a co-author
-	function coauthors_autosuggest_select() {
-		$this = jQuery( this );
-		var vals = this.value.split( '∣' );
-
-		var author = {}
-		author.id = vals[0].trim();
-		author.login = vals[1].trim();
-		author.name = vals[2].trim();
-		author.email = vals[3].trim();
-		if( author.avatar !== '' ){
-			author.avatar = vals[5].trim();
-		}
-
-		// Decode user-nicename if it has special characters in it.
-		author.nicename = decodeURIComponent( vals[4].trim() );
-
-		if ( author.id=='New' ) {
-			coauthors_new_author_display( name );
-		} else {
-			coauthors_add_coauthor( author, $this );
-			// Show the delete button if we now have more than one co-author
-			if ( jQuery( '#coauthors-list .coauthor-row .coauthor-tag' ).length > 1 )
-				jQuery( '#coauthors-list .coauthor-row .coauthors-author-options' ).removeClass( 'hidden' );
-		}
-	}
-
-	// Prevent the enter key from triggering a submit
-	function coauthors_autosuggest_keydown( e ) {
-		if ( e.keyCode == 13 ) {return false;}
 	}
 
 	/*
-	 * Blur handler for autosuggest input box
-	 * @param event
+	 * Blur handler for autocomplete input box
 	 */
-	function coauthors_stop_editing( event ) {
+	function coauthors_stop_editing() {
+		var $co = $( this );
+		var $tag = $co.next();
 
-		var co = jQuery( this );
-		var tag = jQuery( co.next() );
-
-		co.attr( 'value',tag.text() );
-
-		co.hide();
-		tag.show();
-
-	//	editing = false;
+		$co.val( $tag.text() );
+		$co.hide();
+		$tag.show();
 	}
 
 	/*
 	 * Creates the text tag for a co-author
-	 * @param string Name of the co-author
 	 */
 	function coauthors_create_author_tag( author ) {
-
-		var $tag = jQuery( '<span></span>' )
-							.text( decodeURIComponent( author.name ) )
-							.attr( 'title', coAuthorsPlusStrings.input_box_title )
-							.addClass( 'coauthor-tag' )
-							// Add Click event to edit
-							.on( 'click', coauthors_edit_onclick );
-		return $tag;
+		var displayName = author.label || author.name;
+		return $( '<span></span>' )
+			.text( decodeURIComponent( displayName ) )
+			.attr( 'title', coAuthorsPlusStrings.input_box_title )
+			.addClass( 'coauthor-tag' )
+			.on( 'click', coauthors_edit_onclick );
 	}
 
 	function coauthors_create_author_gravatar( author ) {
-
-		var $gravatar = jQuery( '<img/>' )
-							.attr( 'alt', author.name )
-							.attr( 'src', author.avatar )
-							.addClass( 'coauthor-gravatar' )
-							;
-		return $gravatar;
+		return $( '<img/>' )
+			.attr( 'alt', author.label || author.name )
+			.attr( 'src', author.avatar )
+			.addClass( 'coauthor-gravatar' );
 	}
 
 	/*
-	 * Creates the text tag for a co-author
-	 * @param string Name of the co-author
+	 * Creates the hidden input for a co-author
 	 */
-	function coauthors_create_author_hidden_input ( author ) {
-		var input = jQuery( '<input />' )
-						.attr({
-							'type': 'hidden',
-							'id': 'coauthors_hidden_input',
-							'name': 'coauthors[]',
-							'value': decodeURIComponent( author.nicename )
-							})
-						;
-
-		return input;
+	function coauthors_create_author_hidden_input( author ) {
+		return $( '<input />' ).attr( {
+			'type': 'hidden',
+			'id': 'coauthors_hidden_input',
+			'name': 'coauthors[]',
+			'value': decodeURIComponent( author.nicename )
+		} );
 	}
 
 	var $coauthors_div = null;
+	var coauthors_initialized_on_bulk_edit = false;
 
 	/**
 	 * Initialize the Coauthors UI.
-	 *
-	 * @param array List of coauthors objects.
-	 *  Each coauthor object should have the (string) properties:
-	 *    login
-	 *    email
-	 *    name
-	 *    nicename
 	 */
 	function coauthors_initialize( post_coauthors ) {
-		// Add the controls to add co-authors
-
-		$coauthors_div = jQuery( '#coauthors-edit' );
+		$coauthors_div = $( '#coauthors-edit' );
 
 		if ( $coauthors_div.length ) {
-			// Create the co-authors table
-			var table = jQuery( '<div/>' )
-				.attr( 'id', 'coauthors-list' )
-				;
-			$coauthors_div.append( table );
+			var $table = $( '<div/>' ).attr( 'id', 'coauthors-list' );
+			$coauthors_div.append( $table );
 		}
 
-		// Select co-authors already added to the post
-		var addedAlready = [];
-		//jQuery('#the-list tr').each(function(){
+		// Add existing co-authors
 		var count = 0;
-		jQuery.each( post_coauthors, function() {
-			coauthors_add_coauthor( this, undefined, true, count );
+		$.each( post_coauthors, function() {
+			// Map legacy property names to new format
+			var author = {
+				id: this.id,
+				login: this.login,
+				label: this.name,
+				email: this.email,
+				nicename: this.nicename,
+				avatar: this.avatar
+			};
+			coauthors_add_coauthor( author, undefined, true, count );
 			count++;
-		});
+		} );
 
 		// Hide the delete button if there's only one co-author
-		if ( jQuery( '#coauthors-list .coauthor-row .coauthor-tag' ).length < 2 )
-			jQuery( '#coauthors-list .coauthor-row .coauthors-author-options' ).addClass( 'hidden' );
+		if ( $( '#coauthors-list .coauthor-row .coauthor-tag' ).length < 2 ) {
+			$( '#coauthors-list .coauthor-row .coauthors-author-options' ).addClass( 'hidden' );
+		}
 
+		// Create new autocomplete and append it to a new row
+		var $newCO = coauthors_create_autocomplete( '', false );
+		coauthors_add_to_table( $newCO );
 
-		// Create new author-suggest and append it to a new row
-		var newCO = coauthors_create_autosuggest( '', false );
-		coauthors_add_to_table( newCO );
+		$coauthors_loading = $( '#publishing-action .spinner' ).clone().attr( 'id', 'coauthors-loading' );
+		move_loading( $newCO );
 
-		$coauthors_loading = jQuery( '#publishing-action .spinner' ).clone().attr( 'id', 'coauthors-loading' );
-		move_loading( newCO );
-
-
-		// Make co-authors sortable so an editor can control the order of the co-authors
-		jQuery( '#coauthors-list' ).sortable({
+		// Make co-authors sortable
+		$( '#coauthors-list' ).sortable( {
 			axis: 'y',
 			handle: '.coauthor-tag',
 			placeholder: 'ui-state-highlight',
 			items: 'div.coauthor-row:not(div.coauthor-row:last)',
-			containment: 'parent',
-		});
-
+			containment: 'parent'
+		} );
 	}
-
 
 	function show_loading() {
 		$coauthors_loading.css( 'visibility', 'visible' );
 	}
+
 	function hide_loading() {
 		$coauthors_loading.css( 'visibility', 'hidden' );
 	}
+
 	function move_loading( $input ) {
 		$coauthors_loading.insertAfter( $input );
 	}
-	// Show loading cursor for autocomplete ajax requests
-	jQuery( document ).ajaxSend(function( e, xhr, settings ) {
-		if ( settings.url.indexOf( coAuthorsPlus_ajax_suggest_link ) != -1 ) {
-			// Including existing authors on the AJAX suggest link
-			// allows us to filter them out of the search request
-			var existing_authors = jQuery( 'input[name="coauthors[]"]' ).map(function(){return jQuery( this ).val();}).get();
-			settings.url = settings.url.split( '&existing_authors' )[0];
-			settings.url += '&existing_authors=' + existing_authors.join( ',' );
-			show_loading();
-		}
-	});
-	// Hide loading cursor when autocomplete ajax requests are finished
-	jQuery( document ).ajaxComplete(function( e, xhr, settings ) {
-		if ( settings.url.indexOf( coAuthorsPlus_ajax_suggest_link ) != -1 )
-			hide_loading();
-	});
 
-	if ( 'post-php' == adminpage || 'post-new-php' == adminpage ) {
-		var $post_coauthor_logins = jQuery( 'input[name="coauthors[]"]' );
-		var $post_coauthor_names = jQuery( 'input[name="coauthorsinput[]"]' );
-		var $post_coauthor_emails = jQuery( 'input[name="coauthorsemails[]"]' );
-		var $post_coauthor_nicenames = jQuery( 'input[name="coauthorsnicenames[]"]' );
-		var $post_coauthoravatars = jQuery( 'input[name="coauthorsavatars[]"]' );
+	// Initialize on post edit screen
+	if ( 'post-php' === adminpage || 'post-new-php' === adminpage ) {
+		var $post_coauthor_logins = $( 'input[name="coauthors[]"]' );
+		var $post_coauthor_names = $( 'input[name="coauthorsinput[]"]' );
+		var $post_coauthor_emails = $( 'input[name="coauthorsemails[]"]' );
+		var $post_coauthor_nicenames = $( 'input[name="coauthorsnicenames[]"]' );
+		var $post_coauthoravatars = $( 'input[name="coauthorsavatars[]"]' );
 
 		var post_coauthors = [];
 
 		for ( var i = 0; i < $post_coauthor_logins.length; i++ ) {
-			post_coauthors.push({
-				login: $post_coauthor_logins[i].value,
-				name: $post_coauthor_names[i].value,
-				email: $post_coauthor_emails[i].value,
-				nicename: $post_coauthor_nicenames[i].value,
-				avatar: $post_coauthoravatars[i].value,
-			});
+			post_coauthors.push( {
+				login: $post_coauthor_logins[ i ].value,
+				name: $post_coauthor_names[ i ].value,
+				email: $post_coauthor_emails[ i ].value,
+				nicename: $post_coauthor_nicenames[ i ].value,
+				avatar: $post_coauthoravatars[ i ].value
+			} );
 		}
 
-		// Remove the read-only co-authors so we don't get craziness
-		jQuery( '#coauthors-readonly' ).remove();
+		// Remove the read-only co-authors
+		$( '#coauthors-readonly' ).remove();
 		coauthors_initialize( post_coauthors );
-	}
-	else if ( 'edit-php' == adminpage ) {
-
+	} else if ( 'edit-php' === adminpage ) {
+		// Quick Edit
 		var wpInlineEdit = inlineEditPost.edit;
 
-		// Inline editing
 		inlineEditPost.edit = function( id ) {
+			wpInlineEdit.apply( this, arguments );
 
-			wpInlineEdit.apply( this, arguments )
-
-			// get the post ID
-			var postId = 0
-			if ( typeof( id ) == 'object' )
-				postId = parseInt( this.getId( id ) )
+			var postId = 0;
+			if ( typeof id === 'object' ) {
+				postId = parseInt( this.getId( id ), 10 );
+			}
 
 			if ( postId > 0 ) {
+				var $postRow = $( '#post-' + postId );
 
-				var $postRow = jQuery( '#post-' + postId )
+				// Move the element to the appropriate position
+				$( '.quick-edit-row .inline-edit-col-left .inline-edit-col' ).find( '.inline-edit-coauthors' ).remove();
+				var $el = $( '.inline-edit-group.inline-edit-coauthors', '#edit-' + postId );
+				$el.detach().appendTo( '.quick-edit-row .inline-edit-col-left .inline-edit-col' ).show();
 
-				// Move the element to the appropriate position in the view
-				// JS hack for core bug: https://core.trac.wordpress.org/ticket/26982
-				jQuery( '.quick-edit-row .inline-edit-col-left .inline-edit-col' ).find( '.inline-edit-coauthors' ).remove() // remove any previously added elements
-				var el = jQuery( '.inline-edit-group.inline-edit-coauthors', '#edit-' + postId );
-				el.detach().appendTo( '.quick-edit-row .inline-edit-col-left .inline-edit-col' ).show();
-
-				// initialize co-authors
-				var post_coauthors = jQuery.map( jQuery( '.column-coauthors a', $postRow ), function( el ) {
+				// Initialize co-authors
+				var post_coauthors = $.map( $( '.column-coauthors a', $postRow ), function( el ) {
 					return {
-						login: jQuery( el ).data( 'user_login' ),
-						name: jQuery( el ).data( 'display_name' ),
-						email: jQuery( el ).data( 'user_email' ),
-						nicename: jQuery( el ).data( 'user_nicename' ),
-						avatar: jQuery( el ).data( 'avatar' ),
-					}
-				});
+						login: $( el ).data( 'user_login' ),
+						name: $( el ).data( 'display_name' ),
+						email: $( el ).data( 'user_email' ),
+						nicename: $( el ).data( 'user_nicename' ),
+						avatar: $( el ).data( 'avatar' )
+					};
+				} );
 
 				coauthors_initialize( post_coauthors );
-
 			}
-		}
+		};
 
-		// Bulk editing
-		var coauthors_initialized_on_bulk_edit = false;
+		// Bulk Edit
 		var wpBulkEdit = inlineEditPost.setBulk;
 
 		inlineEditPost.setBulk = function() {
-
 			wpBulkEdit.apply( this, arguments );
 
-			// Initialize co-authors, but only on the first 'Bulk edit' interaction.
 			if ( ! coauthors_initialized_on_bulk_edit ) {
-				var bulk_right_column = jQuery( '#bulk-edit .inline-edit-col-right' );
-				var coauthors_authors_label = jQuery( '#bulk-edit .bulk-edit-coauthors' );
+				var $bulk_right_column = $( '#bulk-edit .inline-edit-col-right' );
+				var $coauthors_label = $( '#bulk-edit .bulk-edit-coauthors' );
 
-				// Move the Co-Authors section to the right-hand column of the Bulk section.
-				coauthors_authors_label.appendTo( bulk_right_column );
-				// Give the right-hand column its 'real' height because of float:left;
-				// The Post Format dropdown does not help positioning the Co-Authors section.
-				bulk_right_column.find( 'div.inline-edit-col' ).addClass( 'wp-clearfix' );
-				// Move the autosuggest input box under the Co-Authors label.
-				jQuery( '#coauthors-edit' ).appendTo( coauthors_authors_label );
+				$coauthors_label.appendTo( $bulk_right_column );
+				$bulk_right_column.find( 'div.inline-edit-col' ).addClass( 'wp-clearfix' );
+				$( '#coauthors-edit' ).appendTo( $coauthors_label );
 
 				coauthors_initialized_on_bulk_edit = true;
 				coauthors_initialize( [] );
 			}
-		}
+		};
 	}
 
-});
+} );
 
-if ( typeof( console ) === 'undefined' ) {
-	var console = {}
+if ( typeof console === 'undefined' ) {
+	var console = {};
 	console.log = console.error = function() {};
 }

--- a/js/guest-authors.js
+++ b/js/guest-authors.js
@@ -3,21 +3,27 @@ jQuery( document ).ready( function( $ ) {
 		$( '#wpbody-content input#submit' ).addClass( 'button-primary' ).removeAttr( 'disabled' );
 	} );
 
-	// Initialize the co-author suggest for reassignment.
-	$( '#leave-assigned-to' ).suggest( coAuthorsGuestAuthors.ajaxUrl, {
-		minchars: 2,
+	// Initialize the co-author autocomplete for reassignment.
+	$( '#leave-assigned-to-display' ).autocomplete( {
+		source: coAuthorsGuestAuthors.ajaxUrl,
+		minLength: 2,
 		delay: 500,
-		onSelect: function() {
-			var $this = $( this );
-			var parts = this.value.split( '∣' );
+		select: function( event, ui ) {
+			// Show the display name in the visible field.
+			$( this ).val( ui.item.label );
 
-			if ( parts.length >= 2 ) {
-				// Store the user_nicename as the value (used for form submission).
-				$this.val( parts[1].trim() );
-			}
+			// Store the user_nicename in the hidden field for form submission.
+			$( '#leave-assigned-to' ).val( ui.item.value );
 
 			// Auto-select the "Reassign to another co-author" radio option.
 			$( '#reassign-another' ).trigger( 'click' );
+
+			return false;
+		},
+		focus: function( event, ui ) {
+			// Show the display name while navigating options.
+			$( this ).val( ui.item.label );
+			return false;
 		}
 	} );
 } );

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -309,14 +309,15 @@ class CoAuthors_Guest_Authors {
 		global $coauthors_plus;
 
 		if ( ! current_user_can( $this->list_guest_authors_cap ) ) {
-			die();
+			wp_send_json( array() );
 		}
 
-		if ( ! isset( $_GET['q'] ) ) {
-			die();
+		// jQuery UI autocomplete uses 'term' parameter.
+		$search = isset( $_GET['term'] ) ? sanitize_text_field( $_GET['term'] ) : '';
+		if ( empty( $search ) ) {
+			wp_send_json( array() );
 		}
 
-		$search = sanitize_text_field( $_GET['q'] );
 		if ( ! empty( $_GET['guest_author'] ) ) {
 			$ignore = array( $this->get_guest_author_by( 'ID', (int) $_GET['guest_author'] )->user_login );
 		} else {
@@ -324,21 +325,16 @@ class CoAuthors_Guest_Authors {
 		}
 
 		$authors = $coauthors_plus->search_authors( $search, $ignore );
+		$results = array();
 
-		if ( empty( $authors ) ) {
-			echo esc_html__( 'No matching authors found.', 'co-authors-plus' );
-			die();
-		}
-
-		// Return in the same format as the main co-author suggest for consistency.
 		foreach ( $authors as $author ) {
-			printf(
-				"%s ∣ %s\n",
-				esc_html( $author->display_name ),
-				esc_html( $author->user_nicename )
+			$results[] = array(
+				'label' => $author->display_name,
+				'value' => $author->user_nicename,
 			);
 		}
-		die();
+
+		wp_send_json( $results );
 	}
 
 
@@ -397,7 +393,7 @@ class CoAuthors_Guest_Authors {
 		// Enqueue our guest author CSS on the related pages
 		if ( $this->parent_page === $pagenow && isset( $_GET['page'] ) && 'view-guest-authors' === $_GET['page'] ) {
 			wp_enqueue_style( 'guest-authors-css', plugins_url( 'css/guest-authors.css', __DIR__ ), false, COAUTHORS_PLUS_VERSION );
-			wp_enqueue_script( 'guest-authors-js', plugins_url( 'js/guest-authors.js', __DIR__ ), array( 'jquery', 'suggest' ), COAUTHORS_PLUS_VERSION );
+			wp_enqueue_script( 'guest-authors-js', plugins_url( 'js/guest-authors.js', __DIR__ ), array( 'jquery', 'jquery-ui-autocomplete' ), COAUTHORS_PLUS_VERSION );
 
 			// Pass AJAX URL for co-author search.
 			$guest_author_id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
@@ -539,9 +535,10 @@ class CoAuthors_Guest_Authors {
 				echo '<li class="hide-if-no-js"><label for="reassign-another">';
 				echo '<input type="radio" id="reassign-another" name="reassign" class="reassign-option" value="reassign-another" />&nbsp;&nbsp;' . esc_html__( 'Reassign to another co-author:', 'co-authors-plus' ) . '&nbsp;&nbsp;</label>';
 				printf(
-					'<input type="text" id="leave-assigned-to" name="leave-assigned-to" class="coauthor-suggest" placeholder="%s" autocomplete="off" style="width:200px;" />',
+					'<input type="text" id="leave-assigned-to-display" class="coauthor-suggest" placeholder="%s" autocomplete="off" style="width:200px;" />',
 					esc_attr__( 'Search for author...', 'co-authors-plus' )
 				);
+				echo '<input type="hidden" id="leave-assigned-to" name="leave-assigned-to" />';
 				echo '</li>';
 				// Leave mapped to a linked account
 				if ( get_user_by( 'login', $guest_author->linked_account ) ) {

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -173,10 +173,13 @@ class CoAuthors_Plus {
 
 			$asset = require $asset_file;
 
+			// Add wp-editor dependency for PluginDocumentSettingPanel (accessed via global wp object for WP 6.4+ compatibility).
+			$dependencies = array_merge( $asset['dependencies'], array( 'wp-editor' ) );
+
 			wp_register_script(
 				'coauthors-sidebar-js',
 				plugins_url( 'build/index.js', COAUTHORS_PLUS_FILE ),
-				$asset['dependencies'],
+				$dependencies,
 				$asset['version']
 			);
 
@@ -1388,22 +1391,22 @@ class CoAuthors_Plus {
 	public function ajax_suggest(): void {
 
 		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'coauthors-search' ) ) {
-			die();
+			wp_send_json( array() );
 		}
 
-		if ( empty( $_REQUEST['q'] ) ) {
-			die();
+		// jQuery UI autocomplete uses 'term' parameter.
+		$search = isset( $_REQUEST['term'] ) ? sanitize_text_field( strtolower( $_REQUEST['term'] ) ) : '';
+		if ( empty( $search ) ) {
+			wp_send_json( array() );
 		}
 
-		$search = sanitize_text_field( strtolower( $_REQUEST['q'] ) );
-		$ignore = array_map( 'sanitize_text_field', explode( ',', $_REQUEST['existing_authors'] ) ); // phpcs:ignore
+		$ignore = array();
+		if ( ! empty( $_REQUEST['existing_authors'] ) ) {
+			$ignore = array_map( 'sanitize_text_field', explode( ',', $_REQUEST['existing_authors'] ) );
+		}
 
 		$authors = $this->search_authors( $search, $ignore );
-
-		// Return message if no authors found
-		if ( empty( $authors ) ) {
-			echo esc_html( apply_filters( 'coauthors_no_matching_authors_message', 'Sorry, no matching authors found.' ) );
-		}
+		$results = array();
 
 		foreach ( $authors as $author ) {
 			$user_type = 'guest-user';
@@ -1411,20 +1414,18 @@ class CoAuthors_Plus {
 				$user_type = 'wp-user';
 			}
 
-			printf(
-				"%s ∣ %s ∣ %s ∣ %s ∣ %s ∣ %s \n",
-				esc_html( $author->ID ),
-				esc_html( $author->user_login ),
-				// Ensure that author names can contain a pipe character by replacing the pipe character with the
-				// divides character, which will now serve as a delimiter of the author parameters. (#370)
-				esc_html( str_replace( '∣', '|', $author->display_name ) ),
-				esc_html( $author->user_email ),
-				esc_html( rawurldecode( $author->user_nicename ) ),
-				esc_url( get_avatar_url( $author->ID,  array( 'user_type' => $user_type ) ) )
+			$results[] = array(
+				'id'       => $author->ID,
+				'login'    => $author->user_login,
+				'label'    => $author->display_name,
+				'value'    => $author->display_name,
+				'email'    => $author->user_email,
+				'nicename' => rawurldecode( $author->user_nicename ),
+				'avatar'   => get_avatar_url( $author->ID, array( 'user_type' => $user_type ) ),
 			);
 		}
 
-		die();
+		wp_send_json( $results );
 
 	}
 
@@ -1524,7 +1525,7 @@ class CoAuthors_Plus {
 		wp_enqueue_script( 'jquery' );
 		wp_enqueue_script( 'jquery-ui-sortable' );
 		wp_enqueue_style( 'co-authors-plus-css', plugins_url( 'css/co-authors-plus.css', COAUTHORS_PLUS_FILE ), false, COAUTHORS_PLUS_VERSION );
-		wp_enqueue_script( 'co-authors-plus-js', plugins_url( 'js/co-authors-plus.js', COAUTHORS_PLUS_FILE ), array( 'jquery', 'suggest' ), COAUTHORS_PLUS_VERSION, true );
+		wp_enqueue_script( 'co-authors-plus-js', plugins_url( 'js/co-authors-plus.js', COAUTHORS_PLUS_FILE ), array( 'jquery', 'jquery-ui-autocomplete' ), COAUTHORS_PLUS_VERSION, true );
 
 		$js_strings = array(
 			'edit_label'      => __( 'Edit', 'co-authors-plus' ),
@@ -2102,7 +2103,7 @@ class CoAuthors_Plus {
 		</label>
 		<div id="coauthors-edit" class="inline-edit-group wp-clearfix hide-if-no-js">
 			<p id="coauthors-bulk-edit-desc"><?php echo wp_kses( __( 'Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors.', 'co-authors-plus' ), array( 'strong' => array() ) ); ?></p>
-			<?php wp_nonce_field( 'coauthors-edit', 'coauthors-nonce' ); ?>
+			<input type="hidden" name="coauthors-nonce" value="<?php echo esc_attr( wp_create_nonce( 'coauthors-edit' ) ); ?>" />
 		</div>
 		<?php
 	}

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -81,13 +81,6 @@ const CoAuthors = () => {
 	const { setAuthorsStore } = useDispatch( 'cap/authors' );
 
 	/**
-	 * Is saving post
-	 */
-	const isSavingPost = useSelect(
-		(select) => select('core/editor').isSavingPost
-	);
-
-	/**
 	 * Threshold filter for determining when a search query is preformed.
 	 *
 	 * @param {integer} threshold length threshold. default 2.

--- a/src/index.js
+++ b/src/index.js
@@ -29,19 +29,30 @@ const PluginDocumentSettingPanelAuthors = () => (
 	</PluginDocumentSettingPanel>
 );
 
-registerPlugin( 'plugin-coauthors-document-setting', {
-	render: PluginDocumentSettingPanelAuthors,
-	icon: 'users',
-} );
+// Only register plugin if PluginDocumentSettingPanel is available.
+if ( PluginDocumentSettingPanel ) {
+	registerPlugin( 'plugin-coauthors-document-setting', {
+		render: PluginDocumentSettingPanelAuthors,
+		icon: 'users',
+	} );
+}
 
 // Save authors when the post is saved.
 // https://github.com/WordPress/gutenberg/issues/17632
-const { isSavingPost, getCurrentPost } = select("core/editor");
-const { getAuthors, saveAuthors } = select("cap/authors");
-
 let checked = true; // Start in a checked state.
 
 subscribe(() => {
+	const editorStore = select("core/editor");
+	const authorsStore = select("cap/authors");
+
+	// Bail early if stores aren't ready yet.
+	if (!editorStore || !authorsStore) {
+		return;
+	}
+
+	const { isSavingPost, getCurrentPost } = editorStore;
+	const { getAuthors, saveAuthors } = authorsStore;
+
 	if (isSavingPost()) {
 		checked = false;
 	} else if (!checked) {


### PR DESCRIPTION
## Summary

- Switch from WordPress core suggest library to jQuery UI autocomplete for co-author selection
- Provides cleaner UX with display names and avatars instead of pipe-delimited data strings
- Fix several Block Editor issues that were causing the Authors panel to not load

## Changes

- Update co-author picker to use autocomplete with custom `_renderItem` for avatar display
- Update guest author reassign to use autocomplete
- Update AJAX handlers to return JSON with `label`/`value` format
- Add CSS for autocomplete dropdown with avatar styling
- Fix Block Editor panel not loading (add `wp-editor` dependency)
- Fix React errors from store access at module load time
- Remove unused `isSavingPost` variable in CoAuthors component
- Fix duplicate `coauthors-nonce` ID warning on Posts screen

## Test plan

- [ ] Test co-author autocomplete in Classic Editor metabox - should show display names with avatars
- [ ] Test Quick Edit co-author autocomplete on Posts screen
- [ ] Test Bulk Edit co-author field on Posts screen
- [ ] Test guest author reassign autocomplete when deleting a guest author
- [ ] Test Block Editor Authors panel loads and functions correctly
- [ ] Verify no duplicate ID warnings in browser console on Posts screen

Addresses #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)