### PR TITLE
fix: reduce readme tags to WordPress.org limit of 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tested up to: 6.9
 Requires PHP: 7.4  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html  
-Tags: authors, users, multiple authors, co-authors, multi-author, publishing  
+Tags: authors, users, multiple authors, co-authors, multi-author  
 Contributors: batmoo, danielbachhuber, automattic, GaryJ  
 
 Assign multiple bylines to posts, pages, and custom post types with a search-as-you-type input box.


### PR DESCRIPTION
## Summary

Remove 'publishing' tag to comply with WordPress.org plugin directory requirement of maximum 5 tags.

## Test plan

- [ ] Verify WordPress.org plugin page no longer shows tag warning after next deploy

Fixes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)