### PR TITLE
fix: prevent fatal error when guest author slug conflicts with existing user

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1304,6 +1304,19 @@ class CoAuthors_Guest_Authors {
 
 		// Make sure the author term exists and that we're assigning it to this post type
 		$author_term = $coauthors_plus->update_author_term( $this->get_guest_author_by( 'ID', $post_id ) );
+
+		if ( is_wp_error( $author_term ) ) {
+			// Clean up the post we just created since term creation failed.
+			wp_delete_post( $post_id, true );
+			return $author_term;
+		}
+
+		if ( ! $author_term ) {
+			// Clean up the post we just created since term creation failed.
+			wp_delete_post( $post_id, true );
+			return new WP_Error( 'term-creation-failed', __( 'Failed to create author term. The author slug may conflict with an existing user.', 'co-authors-plus' ) );
+		}
+
 		wp_set_post_terms( $post_id, array( $author_term->slug ), $coauthors_plus->coauthor_taxonomy );
 
 		// Explicitly clear all caches, to remove negative caches that may have existed prior to this

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1784,6 +1784,10 @@ class CoAuthors_Plus {
 			);
 
 			$new_term = wp_insert_term( $coauthor->user_login, $this->coauthor_taxonomy, $args );
+
+			if ( is_wp_error( $new_term ) ) {
+				return $new_term;
+			}
 		}
 		wp_cache_delete( 'author-term-' . $coauthor->user_nicename, 'co-authors-plus' );
 		return $this->get_author_term( $coauthor );

--- a/tests/Integration/GuestAuthorsTest.php
+++ b/tests/Integration/GuestAuthorsTest.php
@@ -915,4 +915,100 @@ class GuestAuthorsTest extends TestCase {
 		$this->assertFalse( get_term_by( 'id', $guest_author_term->term_id, $coauthors_plus->coauthor_taxonomy ) );
 		$this->assertNull( get_post( $guest_author_id ) );
 	}
+
+	/**
+	 * Checks that update_author_term returns WP_Error when wp_insert_term fails.
+	 *
+	 * @covers CoAuthors_Plus::update_author_term()
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/1135
+	 */
+	public function test_update_author_term_returns_error_on_insert_failure(): void {
+
+		global $coauthors_plus;
+
+		// Force wp_insert_term to fail by using a filter.
+		add_filter(
+			'pre_insert_term',
+			function () {
+				return new \WP_Error( 'term_exists', 'A term with this slug already exists.' );
+			}
+		);
+
+		// Create a mock coauthor object with all required properties.
+		$coauthor                = new \stdClass();
+		$coauthor->ID            = 0;
+		$coauthor->user_nicename = 'test-author-' . wp_rand();
+		$coauthor->user_login    = 'test-author-' . wp_rand();
+		$coauthor->display_name  = 'Test Author';
+		$coauthor->first_name    = 'Test';
+		$coauthor->last_name     = 'Author';
+		$coauthor->user_email    = 'test@example.com';
+
+		$result = $coauthors_plus->update_author_term( $coauthor );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		// Clean up filter.
+		remove_all_filters( 'pre_insert_term' );
+	}
+
+	/**
+	 * Checks that creating a guest author returns WP_Error when term creation fails
+	 * and cleans up the orphaned post.
+	 *
+	 * @covers CoAuthors_Guest_Authors::create()
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/1135
+	 */
+	public function test_create_guest_author_returns_error_and_cleans_up_on_term_failure(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_obj = $coauthors_plus->guest_authors;
+
+		// Count posts before attempting to create the guest author.
+		$posts_before = get_posts(
+			array(
+				'post_type'   => $guest_author_obj->post_type,
+				'post_status' => 'any',
+				'numberposts' => -1,
+			)
+		);
+		$count_before = count( $posts_before );
+
+		// Force wp_insert_term to fail by using a filter.
+		add_filter(
+			'pre_insert_term',
+			function () {
+				return new \WP_Error( 'term_exists', 'A term with this slug already exists.' );
+			}
+		);
+
+		// Try to create a guest author - term creation will fail.
+		$result = $guest_author_obj->create(
+			array(
+				'user_login'   => 'test-cleanup-author-' . wp_rand(),
+				'display_name' => 'Test Cleanup Author',
+			)
+		);
+
+		// Clean up filter.
+		remove_all_filters( 'pre_insert_term' );
+
+		// Should return a WP_Error.
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		// Verify no orphaned post was left behind.
+		$posts_after = get_posts(
+			array(
+				'post_type'   => $guest_author_obj->post_type,
+				'post_status' => 'any',
+				'numberposts' => -1,
+			)
+		);
+		$count_after = count( $posts_after );
+
+		$this->assertEquals( $count_before, $count_after, 'Orphaned guest author post should be cleaned up on term creation failure.' );
+	}
 }


### PR DESCRIPTION
## Summary

When creating a guest author with a display name that matches an existing WordPress user's slug, a fatal error occurred because `update_author_term()` failed silently and `create()` tried to access properties on `false`.

## Changes

- Handle `WP_Error` from `wp_insert_term()` in `update_author_term()` method
- Check for term creation failure in guest author `create()` method  
- Clean up orphaned guest author post if term creation fails
- Return meaningful `WP_Error` instead of causing fatal error

## Test plan

1. Create a WordPress user with display name "Joe Greene"
2. Try to create a guest author with display name "Joe Greene"
3. Should now show an error message instead of 500 Internal Server Error

Fixes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)