### PR TITLE
Fix ComboboxControl deprecation warnings

### DIFF
--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -184,6 +184,8 @@ const CoAuthors = () => {
 				options={ dropdownOptions }
 				onChange={ onChange }
 				onFilterValueChange={ onFilterValueChange }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 			/>
 		</>
 	);


### PR DESCRIPTION
## Summary

- Adds `__next40pxDefaultSize` prop to opt into the new 40px default height
- Adds `__nextHasNoMarginBottom` prop to opt into no bottom margin

These props suppress deprecation warnings in the browser console for the ComboboxControl in the Block Editor Authors panel, preparing the component for upcoming WordPress default changes.

Fixes #1192 (items 2 and 3 - item 1 was already fixed in develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)