### PR TITLE
Show user count before creating guest authors

### DIFF
--- a/features/create-guest-author.feature
+++ b/features/create-guest-author.feature
@@ -7,6 +7,7 @@ Feature: Guest authors can be created
 		When I run `wp co-authors-plus create-guest-authors`
 		Then STDOUT should be:
       """
+      Attempting to create guest author profiles for 1 users.
       All done! Here are your results:
       - 1 guest author profiles were created
       - 0 users already had guest author profiles
@@ -17,6 +18,7 @@ Feature: Guest authors can be created
 		Then I run the previous command again
 		Then STDOUT should be:
       """
+      Attempting to create guest author profiles for 1 users.
       All done! Here are your results:
       - 0 guest author profiles were created
       - 1 users already had guest author profiles

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -30,9 +30,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$this->args = wp_parse_args( $assoc_args, $defaults );
 
 		$users    = get_users();
+		$count    = count( $users );
 		$created  = 0;
 		$skipped  = 0;
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Processing guest authors...', count( $users ) );
+
+		WP_CLI::log( "Attempting to create guest author profiles for {$count} users." );
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Processing guest authors...', $count );
 		foreach ( $users as $user ) {
 
 			$result = $coauthors_plus->guest_authors->create_guest_author_from_user_id( $user->ID );


### PR DESCRIPTION
## Summary

Displays the total number of users upfront before the progress bar starts when running `wp co-authors-plus create-guest-authors`. This gives users immediate visibility into the scope of the operation.

```
Attempting to create guest author profiles for 42 users.
Processing guest authors... 100% [============================] 0:05 / 0:05
```

This is consistent with other CLI commands like `create-terms-for-posts` which already show a count.

Cherry-picked from #377 (props @aaronjorbin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)