### PR TITLE
Fix fatal error when author_name is an array

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -345,7 +345,7 @@ class CoAuthors_Guest_Authors {
 	 */
 	public function action_parse_request( $query ) {
 
-		if ( ! isset( $query->query_vars['author_name'] ) ) {
+		if ( ! isset( $query->query_vars['author_name'] ) || ! is_string( $query->query_vars['author_name'] ) ) {
 			return $query;
 		}
 

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -816,8 +816,9 @@ class CoAuthors_Plus {
 				return $where;
 			}
 
-			if ( $query->get( 'author_name' ) ) {
-				$author_name = sanitize_title( $query->get( 'author_name' ) );
+			$author_name_var = $query->get( 'author_name' );
+			if ( $author_name_var && is_string( $author_name_var ) ) {
+				$author_name = sanitize_title( $author_name_var );
 			} else {
 				$author_data = get_userdata( $query->get( $this->coauthor_taxonomy ) );
 				if ( is_object( $author_data ) ) {
@@ -1335,10 +1336,11 @@ class CoAuthors_Plus {
 			return;
 		}
 
-		$author_name = sanitize_title( get_query_var( 'author_name' ) );
-		if ( ! $author_name ) {
+		$author_name_var = get_query_var( 'author_name' );
+		if ( ! $author_name_var || ! is_string( $author_name_var ) ) {
 			return;
 		}
+		$author_name = sanitize_title( $author_name_var );
 
 		$author = $this->get_coauthor_by( 'user_nicename', $author_name );
 		if ( is_object( $author ) ) {
@@ -1963,7 +1965,12 @@ class CoAuthors_Plus {
 			return $title;
 		}
 
-		$author_slug = sanitize_user( get_query_var( 'author_name' ) );
+		$author_name_var = get_query_var( 'author_name' );
+		if ( ! is_string( $author_name_var ) ) {
+			return $title;
+		}
+
+		$author_slug = sanitize_user( $author_name_var );
 		$author      = $this->get_coauthor_by( 'user_nicename', $author_slug );
 
 		/* translators: Author display name. */


### PR DESCRIPTION
## Summary

Prevents fatal errors when malformed query strings pass `author_name` as an array (e.g., `?author_name[x]=bob`).

Functions like `sanitize_title()` and `sanitize_user()` expect strings and will fatal when passed arrays. This adds `is_string()` checks before processing `author_name` in four locations:

- `CoAuthors_Guest_Authors::action_parse_request()`
- `CoAuthors_Plus::posts_where_filter()` 
- `CoAuthors_Plus::action_set_author_on_query()`
- `CoAuthors_Plus::filter_author_archive_title()`

This is also a bug in WordPress core: https://core.trac.wordpress.org/ticket/64507

Fixes #1194

🤖 Generated with [Claude Code](https://claude.com/claude-code)