### PR TITLE
Fix: allow guest author creation on WordPress 7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
 			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.25.7",
@@ -1936,6 +1937,7 @@
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
 			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
 			}
@@ -2043,6 +2045,7 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2084,6 +2087,7 @@
 					"url": "https://opencollective.com/csstools"
 				}
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2247,6 +2251,7 @@
 			"version": "11.10.5",
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
 			"integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.10.5",
@@ -3410,6 +3415,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -3431,6 +3437,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -3443,6 +3450,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -3896,6 +3904,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -3921,6 +3930,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -3947,6 +3957,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
 			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -4353,6 +4364,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4813,6 +4825,7 @@
 			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -5140,6 +5153,7 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
 			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -5371,6 +5385,7 @@
 			"version": "18.3.27",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -5566,6 +5581,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
 			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "6.21.0",
 				"@typescript-eslint/types": "6.21.0",
@@ -7261,6 +7277,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
 			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -7307,6 +7324,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -7349,6 +7367,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
 			"integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -7528,6 +7547,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -7584,6 +7604,7 @@
 			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
 			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -7737,6 +7758,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -7797,6 +7819,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -8346,6 +8369,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -8789,6 +8813,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -9543,6 +9568,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
 			"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -10340,7 +10366,8 @@
 			"version": "0.0.1507524",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
 			"integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
@@ -10880,6 +10907,7 @@
 			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -13667,6 +13695,7 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -14583,6 +14612,7 @@
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -14914,7 +14944,8 @@
 			"version": "0.0.1534754",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
 			"integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
 			"version": "8.18.3",
@@ -15568,6 +15599,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -15934,6 +15966,7 @@
 			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
 			"integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -16752,7 +16785,6 @@
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
 			"integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.57.0"
 			},
@@ -16771,7 +16803,6 @@
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
 			"integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -16789,7 +16820,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -16837,6 +16867,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -17894,6 +17925,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -17943,6 +17975,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -17962,6 +17995,7 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -18107,7 +18141,8 @@
 		"node_modules/redux": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+			"peer": true
 		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -18590,6 +18625,7 @@
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
 			"integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -19727,6 +19763,7 @@
 					"url": "https://github.com/sponsors/stylelint"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
 				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -20037,6 +20074,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -20468,6 +20506,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -20716,6 +20755,7 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
 			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -20928,6 +20968,7 @@
 			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -21228,6 +21269,7 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.0.tgz",
 			"integrity": "sha512-CWT8v7ShSfj7tGs4TLRtaOLmOCPWhoKEvp+eA7FVx8Xrjb3XfT0aXdxDItnRZmE8sHcH+a8ayDrJCOjXKxVFfQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.6",
@@ -21330,6 +21372,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -21407,6 +21450,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -21460,6 +21504,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
 			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/bonjour": "^3.5.9",
 				"@types/connect-history-api-fallback": "^1.3.5",
@@ -21519,6 +21564,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -22116,6 +22162,7 @@
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
 			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+			"peer": true,
 			"requires": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.25.7",
@@ -23349,6 +23396,7 @@
 					"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
 					"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@keyv/serialize": "^1.1.1"
 					}
@@ -23404,6 +23452,7 @@
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
 			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"@csstools/css-syntax-patches-for-csstree": {
@@ -23416,7 +23465,8 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
 			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@csstools/media-query-list-parser": {
 			"version": "3.0.1",
@@ -23543,6 +23593,7 @@
 			"version": "11.10.5",
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.5.tgz",
 			"integrity": "sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==",
+			"peer": true,
 			"requires": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.10.5",
@@ -24458,7 +24509,8 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@opentelemetry/api-logs": {
 			"version": "0.57.2",
@@ -24474,6 +24526,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"@opentelemetry/core": {
@@ -24481,6 +24534,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -24775,6 +24829,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -24793,6 +24848,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -24811,7 +24867,8 @@
 			"version": "1.38.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
 			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@opentelemetry/sql-common": {
 			"version": "0.40.1",
@@ -24985,6 +25042,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
 						"fast-uri": "^3.0.1",
@@ -25296,6 +25354,7 @@
 			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -25549,6 +25608,7 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
 			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -25782,6 +25842,7 @@
 			"version": "18.3.27",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+			"peer": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -25954,6 +26015,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
 			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@typescript-eslint/scope-manager": "6.21.0",
 				"@typescript-eslint/types": "6.21.0",
@@ -27109,6 +27171,7 @@
 							"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
 							"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 							"dev": true,
+							"peer": true,
 							"requires": {}
 						},
 						"eslint-import-resolver-typescript": {
@@ -27131,6 +27194,7 @@
 							"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
 							"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 							"dev": true,
+							"peer": true,
 							"requires": {
 								"@rtsao/scc": "^1.1.0",
 								"array-includes": "^3.1.9",
@@ -27169,6 +27233,7 @@
 							"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
 							"integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
 							"dev": true,
+							"peer": true,
 							"requires": {
 								"@typescript-eslint/utils": "^5.10.0"
 							}
@@ -27278,6 +27343,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
 						"fast-uri": "^3.0.1",
@@ -27319,7 +27385,8 @@
 					"version": "npm:wp-prettier@3.0.3",
 					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
 					"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"resolve": {
 					"version": "2.0.0-next.5",
@@ -27428,7 +27495,8 @@
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"acorn-import-attributes": {
 			"version": "1.9.5",
@@ -27470,6 +27538,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -27848,6 +27917,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
 						"fast-uri": "^3.0.1",
@@ -28166,6 +28236,7 @@
 			"version": "4.28.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
 			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"peer": true,
 			"requires": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -28735,6 +28806,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
 					"integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"json-schema-traverse": "^1.0.0",
@@ -29298,7 +29370,8 @@
 			"version": "0.0.1507524",
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
 			"integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"diff-sequences": {
 			"version": "29.6.3",
@@ -29712,6 +29785,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
 			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -31737,6 +31811,7 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -32438,6 +32513,7 @@
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -32686,7 +32762,8 @@
 							"version": "0.0.1534754",
 							"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
 							"integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-							"dev": true
+							"dev": true,
+							"peer": true
 						},
 						"ws": {
 							"version": "8.18.3",
@@ -33187,6 +33264,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
 						"fast-uri": "^3.0.1",
@@ -33472,6 +33550,7 @@
 			"resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
 			"integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"ajv": "^6.12.6",
 				"ajv-errors": "^1.0.1",
@@ -34058,7 +34137,6 @@
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
 			"integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"fsevents": "2.3.2",
 				"playwright-core": "1.57.0"
@@ -34069,8 +34147,7 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 					"dev": true,
-					"optional": true,
-					"peer": true
+					"optional": true
 				}
 			}
 		},
@@ -34078,8 +34155,7 @@
 			"version": "1.57.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
 			"integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"plur": {
 			"version": "4.0.0",
@@ -34101,6 +34177,7 @@
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
 			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -34809,6 +34886,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0"
 			}
@@ -34840,6 +34918,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -34855,7 +34934,8 @@
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
 			"integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"read-cache": {
 			"version": "1.0.0",
@@ -34968,7 +35048,8 @@
 		"redux": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+			"peer": true
 		},
 		"reflect.getprototypeof": {
 			"version": "1.0.10",
@@ -35319,6 +35400,7 @@
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
 			"integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@parcel/watcher": "^2.4.1",
 				"chokidar": "^4.0.0",
@@ -36189,6 +36271,7 @@
 			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
 			"integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
 				"@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -36341,6 +36424,7 @@
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 					"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"cssesc": "^3.0.0",
 						"util-deprecate": "^1.0.2"
@@ -36711,7 +36795,8 @@
 					"version": "4.0.3",
 					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				}
 			}
 		},
@@ -36907,7 +36992,8 @@
 			"version": "0.21.3",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
 			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -37058,6 +37144,7 @@
 			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
 			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
 				"@unrs/resolver-binding-android-arm64": "1.11.1",
@@ -37279,6 +37366,7 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.0.tgz",
 			"integrity": "sha512-CWT8v7ShSfj7tGs4TLRtaOLmOCPWhoKEvp+eA7FVx8Xrjb3XfT0aXdxDItnRZmE8sHcH+a8ayDrJCOjXKxVFfQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.6",
@@ -37345,6 +37433,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
 			"integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@discoveryjs/json-ext": "^0.5.0",
 				"@webpack-cli/configtest": "^2.1.1",
@@ -37387,6 +37476,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
 						"fast-uri": "^3.0.1",
@@ -37428,6 +37518,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
 			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@types/bonjour": "^3.5.9",
 				"@types/connect-history-api-fallback": "^1.3.5",
@@ -37466,6 +37557,7 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 					"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.3",
 						"fast-uri": "^3.0.1",

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1432,11 +1432,10 @@ class CoAuthors_Guest_Authors {
 			return $maybe_empty;
 		}
 
-		if ( empty( $postarr['post_title'] ) ) {
-			return true;
-		}
-
-		return $maybe_empty;
+		// Guest author posts store their data in post meta, not post_content/post_excerpt.
+		// Allow empty content so auto-drafts and new posts can be created.
+		// Display name validation is handled separately in manage_guest_author_filter_post_data().
+		return false;
 	}
 
 	/**

--- a/tests/Integration/GuestAuthorsTest.php
+++ b/tests/Integration/GuestAuthorsTest.php
@@ -1011,4 +1011,139 @@ class GuestAuthorsTest extends TestCase {
 
 		$this->assertEquals( $count_before, $count_after, 'Orphaned guest author post should be cleaned up on term creation failure.' );
 	}
+
+	/**
+	 * Checks that the empty content filter does not interfere with non-guest-author post types.
+	 *
+	 * @covers CoAuthors_Guest_Authors::filter_wp_insert_post_empty_content()
+	 */
+	public function test_filter_wp_insert_post_empty_content_passes_through_for_other_post_types(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_obj = $coauthors_plus->guest_authors;
+
+		$result = $guest_author_obj->filter_wp_insert_post_empty_content(
+			true,
+			array( 'post_type' => 'post' )
+		);
+
+		$this->assertTrue( $result, 'Filter should pass through $maybe_empty for non-guest-author post types.' );
+
+		$result = $guest_author_obj->filter_wp_insert_post_empty_content(
+			false,
+			array( 'post_type' => 'post' )
+		);
+
+		$this->assertFalse( $result, 'Filter should pass through $maybe_empty for non-guest-author post types.' );
+	}
+
+	/**
+	 * Checks that the empty content filter allows guest author posts with empty content.
+	 *
+	 * Guest author posts store data in post meta rather than post_content, so
+	 * the filter must not block insertion even when title/content are empty.
+	 *
+	 * @covers CoAuthors_Guest_Authors::filter_wp_insert_post_empty_content()
+	 */
+	public function test_filter_wp_insert_post_empty_content_allows_guest_author_posts(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_obj = $coauthors_plus->guest_authors;
+
+		// Even when core considers the post "empty", the filter should allow it.
+		$result = $guest_author_obj->filter_wp_insert_post_empty_content(
+			true,
+			array(
+				'post_type'  => $guest_author_obj->post_type,
+				'post_title' => '',
+			)
+		);
+
+		$this->assertFalse( $result, 'Filter should return false for guest author posts to allow empty content.' );
+	}
+
+	/**
+	 * Checks that guest author posts with a display name also pass the empty content filter.
+	 *
+	 * @covers CoAuthors_Guest_Authors::filter_wp_insert_post_empty_content()
+	 */
+	public function test_filter_wp_insert_post_empty_content_allows_guest_author_posts_with_title(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_obj = $coauthors_plus->guest_authors;
+
+		$result = $guest_author_obj->filter_wp_insert_post_empty_content(
+			true,
+			array(
+				'post_type'  => $guest_author_obj->post_type,
+				'post_title' => 'Test Author',
+			)
+		);
+
+		$this->assertFalse( $result, 'Filter should return false for guest author posts regardless of title.' );
+	}
+
+	/**
+	 * Checks that wp_insert_post() succeeds for the guest author post type
+	 * when title and content are empty, simulating an auto-draft scenario.
+	 *
+	 * This is the scenario that caused failures: the block editor creates an
+	 * auto-draft with empty title/content, and the empty content filter must
+	 * not block it.
+	 *
+	 * @covers CoAuthors_Guest_Authors::filter_wp_insert_post_empty_content()
+	 */
+	public function test_wp_insert_post_succeeds_for_guest_author_auto_draft(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_obj = $coauthors_plus->guest_authors;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => $guest_author_obj->post_type,
+				'post_title'   => '',
+				'post_content' => '',
+				'post_status'  => 'auto-draft',
+			),
+			true
+		);
+
+		$this->assertNotWPError( $post_id, 'wp_insert_post should succeed for guest author auto-drafts with empty content.' );
+		$this->assertGreaterThan( 0, $post_id );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Checks that creating a guest author via the create() method works end-to-end.
+	 *
+	 * This exercises the full flow including the empty content filter.
+	 *
+	 * @covers CoAuthors_Guest_Authors::create()
+	 * @covers CoAuthors_Guest_Authors::filter_wp_insert_post_empty_content()
+	 */
+	public function test_create_guest_author_succeeds_with_display_name(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_obj = $coauthors_plus->guest_authors;
+
+		$guest_author_id = $guest_author_obj->create(
+			array(
+				'user_login'   => 'test-empty-content-author',
+				'display_name' => 'Test Empty Content Author',
+			)
+		);
+
+		$this->assertIsInt( $guest_author_id, 'create() should return a post ID.' );
+		$this->assertGreaterThan( 0, $guest_author_id );
+
+		$guest_author = $guest_author_obj->get_guest_author_by( 'ID', $guest_author_id );
+		$this->assertInstanceOf( \stdClass::class, $guest_author );
+		$this->assertEquals( 'Test Empty Content Author', $guest_author->display_name );
+	}
 }


### PR DESCRIPTION
## Description

Fixes guest author creation on WordPress 7.0 by allowing empty post content for the guest author post type.

Two changes in WordPress core combine to break guest author creation:

1. **[#45516](https://core.trac.wordpress.org/ticket/45516)** (WP 7.0): `get_default_post_to_edit()` now passes an empty `post_title` for CPTs without `title` support, instead of `"Auto Draft"`.
2. **[#37441](https://core.trac.wordpress.org/ticket/37441)** (WP 6.9): `get_default_post_to_edit()` now passes `$wp_error = true` to `wp_insert_post()` and calls `wp_die()` on failure.

The old `filter_wp_insert_post_empty_content()` returned `true` (blocking insertion) when `post_title` was empty. Previously this never triggered because auto-drafts always had `"Auto Draft"` as the title. On WP 7.0, the empty title trips the check and the error is now fatal.

The fix unconditionally returns `false` for the guest author post type, since guest authors store data in post meta and don't need post content. Display name validation is handled separately in `manage_guest_author_filter_post_data()` and the `create()` method's required-field validation.

Fixes #1205

## Deploy Notes

No new dependencies added.

## Steps to Test

1. Check out PR.
2. Run against WordPress trunk (7.0).
3. Navigate to the guest authors admin page.
4. Click "Add New" to create a new guest author.
5. Verify the auto-draft is created successfully and the edit form loads.
6. Fill in the Display Name and other required fields, then save.
7. Verify the guest author is created correctly.
8. Also verify on WP 6.4/6.8 that existing behavior is unchanged.