### PR TITLE
refactor: simplify guest author lookup in delete_user_action()

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1144,11 +1144,13 @@ class CoAuthors_Plus {
 			$user_data = get_user_by( 'id', $delete_id );
 
 			// Get the associated user.
-			$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $user_data->data->user_login );
+			if ( $user_data && ! empty( $user_data->data->user_login ) ) {
+				$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $user_data->data->user_login );
 
-			if ( isset( $associated_user->ID ) ) {
-				// Delete associated guest user.
-				$this->guest_authors->delete( $associated_user->ID );
+				if ( $associated_user && isset( $associated_user->ID ) ) {
+					// Delete associated guest user.
+					$this->guest_authors->delete( $associated_user->ID );
+				}
 			}
 		}
 	}

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1140,12 +1140,9 @@ class CoAuthors_Plus {
 		}
 
 		if ( $this->is_guest_authors_enabled() ) {
-			// Get the deleted user data by user id.
-			$user_data = get_user_by( 'id', $delete_id );
-
-			// Get the associated user.
-			if ( $user_data && ! empty( $user_data->data->user_login ) ) {
-				$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $user_data->data->user_login );
+			// Get the associated user from the already fetched $delete_user object.
+			if ( $delete_user ) {
+				$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $delete_user->user_login );
 
 				if ( $associated_user && isset( $associated_user->ID ) ) {
 					// Delete associated guest user.

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1144,7 +1144,7 @@ class CoAuthors_Plus {
 			if ( $delete_user ) {
 				$associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $delete_user->user_login );
 
-				if ( $associated_user && isset( $associated_user->ID ) ) {
+				if ( isset( $associated_user->ID ) ) {
 					// Delete associated guest user.
 					$this->guest_authors->delete( $associated_user->ID );
 				}


### PR DESCRIPTION
## Summary

Defensive cleanup for the guest author deletion block in `delete_user_action()`.

**Note:** The original PHP warning (`Attempt to read property "term_id" on false`) from #1198 was already fixed on `develop` in commit `9ecae097` with an `if ( $term )` guard. This PR is a related cleanup of a nearby code path.

## Problem

The guest author deletion block in `delete_user_action()` used a separate `get_user_by()` call to retrieve the user being deleted, even though the same data was already available in the `$delete_user` variable fetched earlier in the same method. Additionally, it accessed `$user_data->data->user_login` without validating that `get_user_by()` had returned a valid object.

## Solution

- Reused the existing `$delete_user` variable instead of making a duplicate `get_user_by()` call.
- Added an `if ( $delete_user )` guard before accessing `$delete_user->user_login` to make the intent explicit and prevent potential issues if `$delete_user` is ever false.
- Simplified `$associated_user` access to use `isset( $associated_user->ID )` directly, relying on PHP's `isset()` language construct which safely handles `false`/`null` without warnings.

## Changes

### php/class-coauthors-plus.php

**Before:**
```php
if ( $this->is_guest_authors_enabled() ) {
    // Get the deleted user data by user id.
    $user_data = get_user_by( 'id', $delete_id );

    // Get the associated user.
    $associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $user_data->data->user_login );

    if ( isset( $associated_user->ID ) ) {
        // Delete associated guest user.
        $this->guest_authors->delete( $associated_user->ID );
    }
}
```

**After:**
```php
if ( $this->is_guest_authors_enabled() ) {
    // Get the associated user from the already fetched $delete_user object.
    if ( $delete_user ) {
        $associated_user = $this->guest_authors->get_guest_author_by( 'linked_account', $delete_user->user_login );

        if ( isset( $associated_user->ID ) ) {
            // Delete associated guest user.
            $this->guest_authors->delete( $associated_user->ID );
        }
    }
}
```

**Why:** Eliminates a redundant database call, makes the null-guard intent explicit, and simplifies the `$associated_user` check to rely on PHP's built-in `isset()` safety.