### PR TITLE
Fix: Mark post dirty when co-authors change in the block editor

### DIFF
--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -10,8 +10,8 @@ import apiFetch from '@wordpress/api-fetch';
 import { ComboboxControl, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { useDispatch, useSelect, register } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+import { dispatch as wpDispatch, useDispatch, useSelect, register } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 
 /**
@@ -51,6 +51,7 @@ const CoAuthors = () => {
 	 */
 	const [ selectedAuthors, setSelectedAuthors ] = useState( [] ); // Currently selected options.
 	const [ dropdownOptions, setDropdownOptions ] = useState( [] ); // Options that are available in the dropdown.
+	const isHydrated = useRef( false ); // Tracks whether initial author data has loaded.
 
 	/**
 	 * Retrieve post id.
@@ -89,12 +90,22 @@ const CoAuthors = () => {
 
 	/**
 	 * Setter for updating authors and selected authors simultaneously.
+	 * When the change is user-initiated (after initial hydration),
+	 * also marks the post as dirty so the editor enables the save button.
 	 *
 	 * @param {Array} newAuthors array of new authors.
 	 */
 	const updateAuthors = ( newAuthors ) => {
 		setAuthorsStore( newAuthors );
 		setSelectedAuthors( newAuthors );
+
+		// Mark the post dirty in the core editor store so the
+		// Update/Publish button enables when authors are the only change.
+		if ( isHydrated.current ) {
+			wpDispatch( 'core/editor' ).editPost( {
+				coauthors_modified: Date.now(),
+			} );
+		}
 	};
 
 	/**
@@ -162,6 +173,11 @@ const CoAuthors = () => {
 
 		updateAuthors( authors );
 
+		// Mark hydration complete after the first load so that
+		// subsequent calls to updateAuthors mark the post dirty.
+		if ( ! isHydrated.current ) {
+			isHydrated.current = true;
+		}
 	}, [ authors ] );
 
 	return (


### PR DESCRIPTION
## Summary

When changing authors in the Co-Authors Plus sidebar panel is the **only edit** on a published post, the Update button remains disabled. The editor never detects a change because co-author state is managed in an isolated Redux store (`cap/authors`) that does not notify `core/editor`'s entity record system.

This fix dispatches a synthetic edit to `core/editor` via `editPost()` when authors are changed by the user, marking the post as dirty and enabling the save button.

Fixes #1223

## The Problem

1. User opens a published post in the block editor
2. Changes authors in the Co-Authors Plus sidebar (add, remove, swap, or reorder)
3. The Update button stays disabled — the change cannot be saved
4. Navigating away silently loses the author change

### Root cause

- Co-author changes go to `cap/authors` (custom Redux store) and local `useState`, but **never** to `core/editor` or `core`'s entity record system
- `isEditedPostDirty()` checks `hasEditsForEntityRecord("postType", ...)` — since CAP only writes to its own store, core never sees any change
- The existing `subscribe()` piggyback in `src/index.js` only fires when `isSavingPost()` becomes true, which requires the post to already be dirty from another edit

### Why a synthetic edit is necessary

Core sidebar fields mark the post dirty by passing real data through `editPost()`:
- Author (without CAP): `editPost({ author: userId })`
- Categories: `editPost({ categories: [1, 5, 12] })`
- Tags: `editPost({ tags: [3, 7] })`

CAP cannot do this because its data model doesn't map to core post fields — co-authors are stored in a custom `author` taxonomy via a separate REST endpoint (`/coauthors/v1/authors/`), and guest authors don't have WordPress user IDs. A synthetic edit signal is the minimal way to bridge this gap without restructuring the save architecture.

## The Fix

**One file changed:** `src/components/co-authors/index.jsx`

1. Import `dispatch` from `@wordpress/data` and `useRef` from `@wordpress/element`
2. Add `isHydrated` ref to track whether initial author data has loaded from the API
3. In `updateAuthors`, after updating the CAP store and local state, dispatch `editPost({ coauthors_modified: Date.now() })` to mark the post dirty — but only after hydration is complete
4. Set `isHydrated.current = true` after the first `useEffect` load, so the initial data fetch doesn't falsely mark the post dirty

The `coauthors_modified` key is a non-persistent signal — it marks the entity as edited but is ignored during the REST save since it doesn't correspond to a registered post field.

## Testing

Tested manually on a WordPress 6.9.4 multisite with Gutenberg 22.8.2:

- ✅ Open published post → change author → Update button enables → save persists
- ✅ Open published post → no changes → Update button stays disabled (no false dirty)
- ✅ Add co-author → Update enables
- ✅ Remove co-author → Update enables
- ✅ Reorder co-authors → Update enables
- ✅ Existing save behavior unchanged — `subscribe()` piggyback fires as before

## AI Disclosure

```
AI assistance: Yes
Tool(s): Claude Code
Used for: Codebase analysis to trace the root cause across CAP and
Gutenberg source, drafting the fix, and building. Investigation,
approach, and final review done by the contributor.
```