### PR TITLE
Make guest-author CPT private

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -125,9 +125,10 @@ class CoAuthors_Guest_Authors {
 				'use_featured_image'    => $this->labels['use_featured_image'] ?? '',
 				'remove_featured_image' => $this->labels['remove_featured_image'] ?? '',
 			),
-			'public'              => true,
+			'public'              => false,
 			'publicly_queryable'  => false,
 			'exclude_from_search' => true,
+			'show_ui'             => true,
 			'show_in_menu'        => false,
 			'show_in_rest'        => true,
 			'supports'            => array(

--- a/tests/Integration/GuestAuthorsTest.php
+++ b/tests/Integration/GuestAuthorsTest.php
@@ -1146,4 +1146,27 @@ class GuestAuthorsTest extends TestCase {
 		$this->assertInstanceOf( \stdClass::class, $guest_author );
 		$this->assertEquals( 'Test Empty Content Author', $guest_author->display_name );
 	}
+
+	/**
+	 * Checks that the guest-author post type is registered as private but
+	 * still exposes an admin UI.
+	 *
+	 * Public guest-author CPTs surface in other plugins (e.g. Yoast SEO) that
+	 * scan for public post types, even though guest-authors are not meant to
+	 * be queried on the front end. The admin UI must stay available so guest
+	 * author profiles can still be edited.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/105
+	 */
+	public function test_guest_author_post_type_is_private_but_has_admin_ui(): void {
+
+		global $coauthors_plus;
+
+		$post_type_object = get_post_type_object( $coauthors_plus->guest_authors->post_type );
+
+		$this->assertInstanceOf( \WP_Post_Type::class, $post_type_object );
+		$this->assertFalse( $post_type_object->public, 'Guest author CPT must not be registered as public.' );
+		$this->assertFalse( $post_type_object->publicly_queryable, 'Guest author CPT must not be publicly queryable.' );
+		$this->assertTrue( $post_type_object->show_ui, 'Guest author CPT must still expose an admin UI.' );
+	}
 }


### PR DESCRIPTION
## Summary

The `guest-author` custom post type has long been registered with `public => true`, even though `publicly_queryable` is already `false`. The combination means guest authors are not meant to be queried on the front end — but the `public` flag is what other plugins consult when deciding which post types are "user-facing", and so plugins such as Yoast SEO surface Guest Authors in their configuration screens where they serve no purpose (see issue #105).

This change flips `public => false` and explicitly sets `show_ui => true`. The second change is necessary because `show_ui` defaults to whatever `public` is; without it, the admin editor for guest author profiles would disappear along with the public visibility. The resulting post type is fully private from a frontend and plugin-discovery perspective, but administrators can still create and edit guest author profiles as before.

A regression test has been added to lock in the three load-bearing properties (`public`, `publicly_queryable`, `show_ui`) so a future refactor cannot silently restore the original behaviour.

## Breaking change

Any custom code that queries guest-authors directly through the front end — for example `?post_type=guest-author` URLs or calls to `get_post_type_archive_link( 'guest-author' )` — will stop resolving. In practice this has never been a supported path (the CPT had `publicly_queryable => false` and `rewrite => false` already), but flipping `public` makes the intent explicit and may expose code that depended on the accidental visibility.

Accordingly this should ship in the 4.0 release rather than a minor.

Closes #105

## Test plan

- [ ] Activate the plugin on a site that also runs Yoast SEO and confirm Guest Authors no longer appear in Yoast's post type configuration panel.
- [ ] Visit `/wp-admin/edit.php?post_type=guest-author` and confirm the Guest Authors admin screen still loads and lists existing profiles.
- [ ] Create, edit and delete a guest author via the admin UI and confirm all three operations still work.
- [ ] Confirm `/?post_type=guest-author` on the front end returns a 404 (previous behaviour was also a 404 via `publicly_queryable => false`, but worth re-verifying).
- [ ] Confirm the new integration test `test_guest_author_post_type_is_private_but_has_admin_ui` passes in CI.