### PR TITLE
Remove long-dead deprecated.php

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,6 @@ co-authors-plus/
 ├── co-authors-plus.php                # Main plugin file (includes, globals, bootstrap)
 ├── template-tags.php                  # Template tag functions (coauthors(), get_coauthors(), etc.)
 ├── upgrade.php                        # Database upgrade functions
-├── deprecated.php                     # Deprecated functions
 ├── php/
 │   ├── class-coauthors-plus.php       # Main plugin class (taxonomy, meta boxes, AJAX)
 │   ├── class-coauthors-guest-authors.php  # Guest author CPT management

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -25,7 +25,6 @@ const COAUTHORS_PLUS_VERSION = '3.7.0';
 const COAUTHORS_PLUS_FILE = __FILE__;
 
 require_once __DIR__ . '/template-tags.php';
-require_once __DIR__ . '/deprecated.php';
 
 require_once __DIR__ . '/php/class-coauthors-template-filters.php';
 require_once __DIR__ . '/php/class-coauthors-endpoint.php';

--- a/deprecated.php
+++ b/deprecated.php
@@ -1,7 +1,0 @@
-<?php
-
-/**
- * Constants
- */
-define( 'COAUTHORS_PLUS_PATH', dirname( COAUTHORS_PLUS_FILE ) );
-define( 'COAUTHORS_PLUS_URL', plugin_dir_url( COAUTHORS_PLUS_FILE ) );


### PR DESCRIPTION
## Summary

The plugin has carried a `deprecated.php` file since December 2013,
when commit `f78c6e4` ("Create a 'deprecated' file, and move our unused
constants there") moved two `define()` calls out of the main plugin
bootstrap. Those two constants — `COAUTHORS_PLUS_PATH` and
`COAUTHORS_PLUS_URL` — have been the entire contents of the file ever
since, and a repo-wide grep confirms nothing in the current codebase
references either of them. They predate the 3.0 line entirely and have
been dead weight for over twelve years.

This PR deletes the file, removes the `require_once` that pulls it in
from `co-authors-plus.php`, and drops the corresponding line from the
directory tree in `AGENTS.md`. No behaviour within the plugin changes.

## Breaking change

Any third-party code outside this repository that happens to reference
`COAUTHORS_PLUS_PATH` or `COAUTHORS_PLUS_URL` will hit an undefined
constant warning after upgrading. In practice these constants were
never publicised, and WordPress core already provides the canonical
primitives (`plugin_dir_path()`, `plugin_dir_url()`) that any sensible
consumer should be using instead — so the real-world risk is very low.
Nevertheless, flagging this as a 4.0-appropriate change so it can be
noted in the release changelog.

## Test plan

- [ ] Activate the plugin and confirm it loads without fatals.
- [ ] Confirm the CI suite passes against the branch.