### PR TITLE
Gate CoAuthors_Controller REST endpoints on post visibility

### DIFF
--- a/php/api/endpoints/class-coauthors-controller.php
+++ b/php/api/endpoints/class-coauthors-controller.php
@@ -82,7 +82,7 @@ class CoAuthors_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
-					'permission_callback' => '__return_true'
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				),
 			)
 		);
@@ -118,10 +118,124 @@ class CoAuthors_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				),
 			)
 		);
+	}
+
+	/**
+	 * Check Permission For Get Items
+	 *
+	 * Co-authors should only be listed for a post when the post is publicly
+	 * viewable, or when the current user has permission to read the post.
+	 *
+	 * @since 4.0.0
+	 * @param WP_REST_Request $request
+	 * @return true|WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+
+		$post_id = (int) $request->get_param( 'post_id' );
+		$post    = get_post( $post_id );
+
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'co-authors-plus' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( is_post_publicly_viewable( $post ) ) {
+			return true;
+		}
+
+		if ( current_user_can( 'read_post', $post->ID ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to view co-authors for this post.', 'co-authors-plus' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Check Permission For Get Item
+	 *
+	 * A single co-author profile is exposed to unauthenticated users only when
+	 * the author has at least one publicly viewable post. Otherwise the
+	 * requester must be able to edit others' posts, matching the capability
+	 * check used by the plugin's older authors endpoint.
+	 *
+	 * @since 4.0.0
+	 * @param WP_REST_Request $request
+	 * @return true|WP_Error True if the request has read access, WP_Error otherwise.
+	 */
+	public function get_item_permissions_check( $request ) {
+
+		if ( $this->coauthors_plus->current_user_can_set_authors() ) {
+			return true;
+		}
+
+		$coauthor = $this->coauthors_plus->get_coauthor_by(
+			'user_nicename',
+			$request->get_param( 'user_nicename' )
+		);
+
+		if ( is_object( $coauthor ) && self::is_coauthor( $coauthor ) && $this->has_public_posts( $coauthor ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to view this co-author.', 'co-authors-plus' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Does Co-Author Have Publicly Viewable Posts
+	 *
+	 * Determines whether the co-author is attributed on at least one post that
+	 * any visitor could read. Guest authors and WP users are handled by the
+	 * same co-author term lookup so the check is consistent across both.
+	 *
+	 * @since 4.0.0
+	 * @param WP_User|stdClass $coauthor
+	 */
+	public function has_public_posts( $coauthor ): bool {
+
+		$term = $this->coauthors_plus->get_author_term( $coauthor );
+
+		if ( ! $term ) {
+			return false;
+		}
+
+		$public_post_types = get_post_types( array( 'public' => true ) );
+
+		$query = new \WP_Query(
+			array(
+				'post_type'              => array_values( $public_post_types ),
+				'post_status'            => 'publish',
+				'posts_per_page'         => 1,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'tax_query'              => array(
+					array(
+						'taxonomy' => $this->coauthors_plus->coauthor_taxonomy,
+						'field'    => 'term_id',
+						'terms'    => $term->term_id,
+					),
+				),
+			)
+		);
+
+		return ! empty( $query->posts );
 	}
 
 	/**

--- a/tests/Integration/CoAuthorsControllerTest.php
+++ b/tests/Integration/CoAuthorsControllerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use CoAuthors\API\Endpoints\CoAuthors_Controller;
+use WP_Error;
+use WP_REST_Request;
+
+/**
+ * @coversDefaultClass \CoAuthors\API\Endpoints\CoAuthors_Controller
+ */
+class CoAuthorsControllerTest extends TestCase {
+
+	/**
+	 * @var CoAuthors_Controller
+	 */
+	private $controller;
+
+	public function set_up() {
+
+		parent::set_up();
+
+		global $coauthors_plus;
+
+		$this->controller = new CoAuthors_Controller( $coauthors_plus );
+	}
+
+	private function make_request( string $path, array $params = array() ): WP_REST_Request {
+		$request = new WP_REST_Request( 'GET', $path );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $request;
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_allows_anonymous_on_published_post(): void {
+
+		$author = $this->create_author( 'public-author' );
+		$post   = $this->create_post( $author );
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_items_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors', array( 'post_id' => $post->ID ) )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_blocks_anonymous_on_draft_post(): void {
+
+		$author  = $this->create_author( 'draft-author' );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'draft',
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_items_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors', array( 'post_id' => $post_id ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_blocks_anonymous_on_private_post(): void {
+
+		$author  = $this->create_author( 'private-author' );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'private',
+			)
+		);
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_items_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors', array( 'post_id' => $post_id ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_allows_editor_on_draft_post(): void {
+
+		$author  = $this->create_author( 'draft-author-editor' );
+		$editor  = $this->create_editor( 'editor-for-draft' );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'draft',
+			)
+		);
+
+		wp_set_current_user( $editor->ID );
+
+		$result = $this->controller->get_items_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors', array( 'post_id' => $post_id ) )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @covers ::get_items_permissions_check
+	 */
+	public function test_get_items_returns_404_for_missing_post(): void {
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_items_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors', array( 'post_id' => 999999 ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_post_invalid_id', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_get_item_allows_anonymous_for_author_with_public_post(): void {
+
+		$author = $this->create_author( 'published-author' );
+		$post   = $this->create_post( $author );
+		$this->_cap->add_coauthors( $post->ID, array( $author->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_item_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors/published-author', array( 'user_nicename' => 'published-author' ) )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_get_item_blocks_anonymous_for_author_without_public_posts(): void {
+
+		$author  = $this->create_author( 'hidden-author' );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'draft',
+			)
+		);
+		$this->_cap->add_coauthors( $post_id, array( $author->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_item_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors/hidden-author', array( 'user_nicename' => 'hidden-author' ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_get_item_allows_editor_for_any_author(): void {
+
+		$author = $this->create_author( 'any-author' );
+		$editor = $this->create_editor( 'editor-for-any' );
+
+		wp_set_current_user( $editor->ID );
+
+		$result = $this->controller->get_item_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors/any-author', array( 'user_nicename' => 'any-author' ) )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @covers ::get_item_permissions_check
+	 */
+	public function test_get_item_blocks_anonymous_for_unknown_author(): void {
+
+		wp_set_current_user( 0 );
+
+		$result = $this->controller->get_item_permissions_check(
+			$this->make_request( '/coauthors/v1/coauthors/does-not-exist', array( 'user_nicename' => 'does-not-exist' ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary

The REST endpoints registered by `CoAuthors_Controller` (introduced in v3.6.0) used `__return_true` as their `permission_callback`. That left both `GET /wp-json/coauthors/v1/coauthors?post_id=X` and `GET /wp-json/coauthors/v1/coauthors/{nicename}` fully open to unauthenticated visitors, which allowed anyone to enumerate the co-authors of draft, private, scheduled, and password-protected posts, and to fetch the biographies of co-authors who have never been attributed on a publicly viewable post. This diverged from both WordPress core's handling of non-public posts and from the plugin's older authors endpoint, which gates the equivalent data behind `edit_others_posts`.

The fix reintroduces proper permission checks without breaking legitimate frontend use. The collection endpoint now defers to `is_post_publicly_viewable()` and falls back to a `read_post` capability check, so published posts remain publicly inspectable while drafts and private posts require the usual read permissions. The single-author endpoint exposes a profile to anonymous visitors only when the co-author is attributed on at least one publicly viewable post, which matches the spirit of WordPress core's own `/wp/v2/users` behaviour. Editors retain unrestricted access through the plugin's existing `current_user_can_set_authors()` check.

The concern surfaced via a HackerOne report and a follow-up triage question in Slack about whether co-authors of private posts should really be public. The answer is no: author metadata for embargoed or unpublished content is not already public, and aligning with WordPress core's visibility model is the least surprising behaviour.

Integration tests cover the permission callbacks across anonymous, editor, missing post, and draft/private/public post scenarios, and a matching pair of assertions for the single-author endpoint.

## Test plan

- [ ] CI integration suite passes (new `CoAuthorsControllerTest` and existing `EndpointsTest`).
- [ ] Anonymous `curl /wp-json/coauthors/v1/coauthors?post_id={draft_id}` returns 401/403.
- [ ] Anonymous `curl /wp-json/coauthors/v1/coauthors?post_id={published_id}` still returns the expected co-author list.
- [ ] Anonymous `curl /wp-json/coauthors/v1/coauthors/{nicename}` returns 403 for a co-author with no public posts, and the full profile once they have one.
- [ ] An editor can still hit both endpoints for any post or co-author.