### PR TITLE
Restore local wp-env by bumping dev PHP to 8.2

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
   "plugins": [
     "."
   ],
-  "phpVersion": "7.4",
+  "phpVersion": "8.2",
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,


### PR DESCRIPTION
## Summary

`wp-env start` can no longer complete locally. The root cause is upstream rot: the `wordpress:php7.4` Docker image is built on Debian Bullseye, whose archive GPG signing keys have expired. Any layer that runs `apt-get update` during the wp-env image build — including the steps wp-env generates to add the current user to the container — now fails with "At least one invalid signature was encountered", and the build aborts before the container can start.

Bumping the dev environment's `phpVersion` to 8.2 switches the base image to the Bookworm-based `wordpress:php8.2`, which has valid signing keys and builds cleanly. 8.2 is also the only PHP release still receiving upstream security support, making it a sensible floor for local development tooling regardless of what the plugin itself declares.

The scope is intentionally narrow: this is a local developer-experience fix. The tests environment remains on PHP 8.4, and the plugin's declared `Requires PHP: 7.4` minimum is untouched. Whether the forthcoming 4.0.0 release should raise that declared floor is a separate decision, parked for now.

## Test plan

- [ ] `wp-env destroy` then `wp-env start --update` completes without the Bullseye GPG error
- [ ] Dev site reachable at http://localhost:8888
- [ ] Tests site reachable at http://localhost:8889 and still on PHP 8.4