### PR TITLE
Restore guest-author avatars on admin screens

### DIFF
--- a/php/api/endpoints/class-coauthors-controller.php
+++ b/php/api/endpoints/class-coauthors-controller.php
@@ -437,6 +437,8 @@ class CoAuthors_Controller extends WP_REST_Controller {
 
 		$fields = $this->get_fields_for_response( $request );
 
+		$user_type = ( $author instanceof \WP_User || ( isset( $author->type ) && 'guest-author' !== $author->type ) ) ? 'wp-user' : 'guest-user';
+
 		if ( $author instanceof \WP_User ) {
 			$author              = $author->data;
 			$author->description = get_user_meta( $author->ID, 'description', true );
@@ -449,7 +451,17 @@ class CoAuthors_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'avatar_urls', $fields ) ) {
-			$data['avatar_urls'] = rest_get_avatar_urls( $author->ID );
+			$avatar_urls = array();
+			foreach ( rest_get_avatar_sizes() as $size ) {
+				$avatar_urls[ $size ] = get_avatar_url(
+					$author->ID,
+					array(
+						'size'      => $size,
+						'user_type' => $user_type,
+					)
+				);
+			}
+			$data['avatar_urls'] = $avatar_urls;
 		}
 
 		if ( rest_is_field_included( 'description', $fields ) ) {

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -255,7 +255,8 @@ class Endpoints {
 	 * @return array
 	 */
 	public function _format_author_data( $author ): array {
-		$term = $this->coauthors->update_author_term( $author );
+		$term      = $this->coauthors->update_author_term( $author );
+		$user_type = isset( $author->type ) && 'guest-author' === $author->type ? 'guest-user' : 'wp-user';
 
 		return array(
 			'id'           => esc_html( $author->ID ),
@@ -264,7 +265,7 @@ class Endpoints {
 			'login'        => esc_html( $author->user_login ),
 			'email'        => sanitize_email( $author->user_email ),
 			'displayName'  => esc_html( str_replace( '∣', '|', $author->display_name ) ),
-			'avatar'       => esc_url( get_avatar_url( $author->ID ) ),
+			'avatar'       => esc_url( get_avatar_url( $author->ID, array( 'user_type' => $user_type ) ) ),
 			'userType'     => esc_html( $author->type ),
 		);
 	}

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -572,7 +572,7 @@ class CoAuthors_Plus {
 					$avatar_url = get_avatar_url( $coauthor->ID, array( 'user_type' => $user_type ) );
 					?>
 					<li>
-						<?php echo get_avatar( $coauthor->ID ); ?>
+						<?php echo get_avatar( $coauthor->ID, 96, '', '', array( 'user_type' => $user_type ) ); ?>
 						<span id="<?php echo esc_attr( 'coauthor-readonly-' . $count ); ?>" class="coauthor-tag">
 							<input type="text" name="coauthorsinput[]" readonly="readonly" value="<?php echo esc_attr( $coauthor->display_name ); ?>" />
 							<input type="text" name="coauthors[]" value="<?php echo esc_attr( $coauthor->user_login ); ?>" />
@@ -675,13 +675,14 @@ class CoAuthors_Plus {
 					$args['post_type'] = $post->post_type;
 				}
 				$author_filter_url = add_query_arg( array_map( 'rawurlencode', $args ), admin_url( 'edit.php' ) );
+				$user_type         = $author instanceof WP_User ? 'wp-user' : 'guest-user';
 				?>
 				<a href="<?php echo esc_url( $author_filter_url ); ?>"
 				data-user_nicename="<?php echo esc_attr( $author->user_nicename ); ?>"
 				data-user_email="<?php echo esc_attr( $author->user_email ); ?>"
 				data-display_name="<?php echo esc_attr( $author->display_name ); ?>"
 				data-user_login="<?php echo esc_attr( $author->user_login ); ?>"
-				data-avatar="<?php echo esc_attr( get_avatar_url( $author->ID ) ); ?>"
+				data-avatar="<?php echo esc_attr( get_avatar_url( $author->ID, array( 'user_type' => $user_type ) ) ); ?>"
 				><?php echo esc_html( $author->display_name ); ?></a><?php echo ( $count < count( $authors ) ) ? ',' : ''; ?>
 				<?php
 				$count++;
@@ -2156,25 +2157,24 @@ class CoAuthors_Plus {
 			return $args;
 		}
 
-		// Do not filter when we have a WordPress user sent from CAP meta box
+		// Do not filter when the caller has flagged the lookup as a WP user.
 		if ( isset( $args['user_type'] ) && 'wp-user' === $args['user_type'] ) {
 			return $args;
 		}
 
-		// Do not filter when on the user screen
+		// Do not filter when on the Users admin screens (core handles those).
 		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		if ( ! is_null( $current_screen ) && isset( $current_screen->parent_base ) && 'users' === $current_screen->parent_base ) {
 			return $args;
 		}
 
-		// Do not filter on the post list screen, profile screen, and post takeover pop-up.
-		if ( isset( $current_screen->base ) && ( 'post' === $current_screen->base || 'profile' === $current_screen->base || 'edit' === $current_screen->base ) ) {
-			return $args;
-		}
-
-		// Do not filter the avatar if this is doing a heartbeat request on WP refresh lock.
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Only checking action name, not processing data.
-		if ( wp_doing_ajax() && isset( $_POST['action'] ) && 'heartbeat' === sanitize_key( $_POST['action'] ) ) {
+		// A numeric ID is ambiguous: a WP user ID can collide with a guest-author
+		// post ID. Unless the caller has explicitly flagged the lookup as a
+		// guest author, defer to WordPress when a matching user exists so core
+		// contexts like post locks, the profile screen and heartbeat refreshes
+		// keep rendering the correct user's avatar.
+		$explicit_guest = isset( $args['user_type'] ) && 'guest-user' === $args['user_type'];
+		if ( ! $explicit_guest && get_user_by( 'id', $id ) ) {
 			return $args;
 		}
 

--- a/tests/Integration/FilterPreGetAvatarDataTest.php
+++ b/tests/Integration/FilterPreGetAvatarDataTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * @covers \CoAuthors_Plus::filter_pre_get_avatar_data_url()
+ */
+class FilterPreGetAvatarDataTest extends TestCase {
+
+	private function attach_image( int $post_id ): string {
+		$attachment_id = $this->factory()->attachment->create_upload_object(
+			__DIR__ . '/fixtures/dummy-attachment.png',
+			$post_id
+		);
+		set_post_thumbnail( $post_id, $attachment_id );
+		return wp_get_attachment_url( $attachment_id );
+	}
+
+	/**
+	 * Insert a WP user at a specific ID so it collides with a guest-author post ID.
+	 *
+	 * The factory's `ID` argument is ignored by `wp_insert_user()` on insert, so
+	 * we go directly through `$wpdb` to reserve the id we need.
+	 */
+	private function create_user_at_id( int $id, string $login, string $email ): void {
+		global $wpdb;
+		$wpdb->insert(
+			$wpdb->users,
+			array(
+				'ID'            => $id,
+				'user_login'    => $login,
+				'user_pass'     => 'password',
+				'user_nicename' => $login,
+				'user_email'    => $email,
+				'user_registered' => current_time( 'mysql' ),
+				'display_name'  => $login,
+			)
+		);
+		clean_user_cache( $id );
+	}
+
+	public function tear_down(): void {
+		$GLOBALS['current_screen'] = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * The featured image should be returned for a guest author across every
+	 * admin screen when the caller flags the lookup as a guest user.
+	 *
+	 * @dataProvider data_admin_screens
+	 */
+	public function test_guest_author_featured_image_returned_on_admin_screens( ?string $screen ): void {
+		$guest_author_id  = $this->create_guest_author( 'featured_guest' );
+		$expected_fragment = $this->attach_image( $guest_author_id );
+
+		if ( null !== $screen ) {
+			set_current_screen( $screen );
+		}
+
+		$url = get_avatar_url(
+			$guest_author_id,
+			array( 'user_type' => 'guest-user' )
+		);
+
+		$this->assertStringContainsString(
+			pathinfo( $expected_fragment, PATHINFO_FILENAME ),
+			$url,
+			"Expected featured image for guest author on screen '$screen'."
+		);
+	}
+
+	public function data_admin_screens(): array {
+		return array(
+			'no screen (frontend)'  => array( null ),
+			'post edit (post.php)'  => array( 'post' ),
+			'post list (edit.php)'  => array( 'edit-post' ),
+			'profile (profile.php)' => array( 'profile' ),
+		);
+	}
+
+	/**
+	 * When a WP user ID collides with a guest-author post ID and the caller
+	 * did not flag the lookup as a guest author, core's Gravatar URL must win
+	 * (the original bug fixed by PR #996 — a user's avatar should not be
+	 * replaced with a colliding guest author's featured image).
+	 */
+	public function test_colliding_wp_user_wins_when_user_type_not_specified(): void {
+		$guest_author_id = $this->create_guest_author( 'collision_ga' );
+		$this->attach_image( $guest_author_id );
+
+		$this->create_user_at_id( $guest_author_id, 'collision_user', 'collision_user@example.com' );
+
+		$url = get_avatar_url( $guest_author_id );
+
+		$this->assertStringContainsString(
+			'gravatar.com',
+			$url,
+			'Expected WP user Gravatar to win when caller did not flag as guest-user.'
+		);
+	}
+
+	/**
+	 * Guest-user flag overrides a collision — callers that know they are
+	 * rendering a guest author (CAP meta box, post list column, REST endpoint)
+	 * get the featured image even if a WP user has the same ID.
+	 */
+	public function test_guest_user_flag_wins_over_colliding_wp_user(): void {
+		$guest_author_id   = $this->create_guest_author( 'flag_ga' );
+		$expected_fragment = $this->attach_image( $guest_author_id );
+
+		$this->create_user_at_id( $guest_author_id, 'flag_collision', 'flag_collision@example.com' );
+
+		$url = get_avatar_url(
+			$guest_author_id,
+			array( 'user_type' => 'guest-user' )
+		);
+
+		$this->assertStringContainsString(
+			pathinfo( $expected_fragment, PATHINFO_FILENAME ),
+			$url
+		);
+	}
+
+	/**
+	 * The wp-user flag always bypasses the filter.
+	 */
+	public function test_wp_user_flag_bypasses_filter(): void {
+		$guest_author_id = $this->create_guest_author( 'bypass_ga' );
+		$this->attach_image( $guest_author_id );
+
+		$url = get_avatar_url(
+			$guest_author_id,
+			array( 'user_type' => 'wp-user' )
+		);
+
+		$this->assertStringContainsString( 'gravatar.com', $url );
+	}
+}

--- a/tests/Integration/FilterPreGetAvatarDataTest.php
+++ b/tests/Integration/FilterPreGetAvatarDataTest.php
@@ -25,6 +25,7 @@ class FilterPreGetAvatarDataTest extends TestCase {
 	private function create_user_at_id( int $id, string $login, string $email ): void {
 		global $wpdb;
 		$wpdb->insert(
+			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Test-only helper: we need to reserve a specific user id to reproduce the GA/user collision fixed by PR #996, which wp_insert_user() cannot do.
 			$wpdb->users,
 			array(
 				'ID'            => $id,


### PR DESCRIPTION
## Summary

[#1239](https://github.com/Automattic/co-authors-plus/issues/1239) reports that upgrading from 3.7.0 to 4.0.0 unsets guest-author avatars. The data is intact — `_thumbnail_id` meta is untouched — but on three admin screens (`post.php`, `edit.php`, `profile.php`) guest authors now fall back to a default Gravatar instead of their featured image. The frontend and the Guest Authors list page still render correctly, which is why the regression wasn't caught pre-release.

The root cause is a workaround introduced in [#996](https://github.com/Automattic/co-authors-plus/pull/996) for a narrow collision bug: because a numeric id passed to `get_avatar()` can resolve to either a WP user or a guest-author post, a user's avatar could inadvertently be replaced by a colliding guest-author's featured image. #996 solved this by short-circuiting the `pre_get_avatar_data` filter entirely on the post edit, post list, profile and heartbeat contexts. That workaround is much broader than the problem it solved, and as [flagged on the PR at the time](https://github.com/Automattic/co-authors-plus/pull/996#pullrequestreview-2891083974), turned the filter exception into a rule.

This PR replaces the screen-based short-circuits with a collision-aware check. When the caller has not explicitly flagged the lookup as a guest user, we defer to WordPress if — and only if — a matching WP user actually exists at that id. That preserves the #996 fix for the scenarios it was designed for (post locks, profile refreshes, heartbeat) without penalising the common unmapped-GA case on every admin screen. The internal CAP call sites that are unambiguously rendering a guest author (the co-author meta box, the posts list column, the REST endpoint formatter) now pass `user_type => 'guest-user'` so the filter engages even when a colliding WP user id happens to exist.

A new integration test covers the four screens from the regression report, both directions of the #996 collision, and the `wp-user`/`guest-user` flag semantics, using `$wpdb->insert()` to force a colliding user id since `wp_insert_user()` ignores an explicit `ID` on insert.

Verified on clean wp-env installs: the regression reproduces on unpatched 4.0.0 (Gravatar fallback on the three admin screens) and resolves with this fix (featured image across all screens), while the #996 collision protection remains intact (colliding WP user wins when no `user_type` is specified; `user_type=guest-user` correctly overrides).

## Test plan

- [ ] Fresh install of WordPress with CAP 3.7.0, create a guest author with an avatar/featured image, upgrade to this branch, and confirm the featured image still renders on:
  - [ ] The frontend
  - [ ] The Guest Authors list page
  - [ ] The post edit screen (both classic and block editor)
  - [ ] The post list screen
  - [ ] The Edit Guest Author profile screen
- [ ] Confirm no regression of #996: create a WP user and a guest author that share a numeric id, and verify `get_avatar(id)` without a `user_type` flag renders the WP user's Gravatar.
- [ ] Confirm the REST search/author endpoints return the guest-author featured image as the `avatar` URL.

Fixes #1239.