### PR TITLE
Remove dynamic term backfill on REST API

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -249,58 +249,9 @@ class CoAuthors_Plus {
 		register_taxonomy( $this->coauthor_taxonomy, $this->supported_post_types(), $args );
 
 		// Bridge REST API saves to add_coauthors() for post_author sync and legacy filter compatibility.
-		// Backfill empty coauthor terms from post_author in REST responses (handles legacy posts).
 		foreach ( $this->supported_post_types() as $post_type ) {
 			add_action( "rest_after_insert_{$post_type}", array( $this, 'sync_coauthors_on_rest_save' ), 10, 2 );
-			add_filter( "rest_prepare_{$post_type}", array( $this, 'backfill_coauthor_terms_in_rest' ), 10, 2 );
 		}
-	}
-
-	/**
-	 * Backfill coauthor taxonomy terms for posts that predate Co-Authors Plus.
-	 *
-	 * When a post has no author taxonomy terms (e.g. created before the plugin
-	 * was activated), assign the term derived from post_author so the editor
-	 * receives valid coauthor data in the REST response.
-	 *
-	 * @param WP_REST_Response $response The response object.
-	 * @param WP_Post          $post     The post object.
-	 * @return WP_REST_Response
-	 */
-	public function backfill_coauthor_terms_in_rest( $response, $post ) {
-		$data = $response->get_data();
-
-		if ( ! empty( $data['coauthors'] ) ) {
-			return $response;
-		}
-
-		// Only backfill when the current user can edit the post to avoid
-		// database writes on unauthenticated GET requests.
-		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
-			return $response;
-		}
-
-		// Post has no coauthor terms — seed from post_author.
-		$user = get_userdata( $post->post_author );
-		if ( ! $user ) {
-			return $response;
-		}
-
-		$this->add_coauthors( $post->ID, array( $user->user_nicename ) );
-
-		// Refresh the coauthors field in the response.
-		$terms = wp_get_object_terms(
-			$post->ID,
-			$this->coauthor_taxonomy,
-			array( 'fields' => 'ids' )
-		);
-
-		if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
-			$data['coauthors'] = array_map( 'intval', $terms );
-			$response->set_data( $data );
-		}
-
-		return $response;
 	}
 
 	/**

--- a/tests/Integration/RestPostReadDoesNotMutateCoauthorsTest.php
+++ b/tests/Integration/RestPostReadDoesNotMutateCoauthorsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use WP_REST_Request;
+
+/**
+ * Regression coverage for issue #1241.
+ *
+ * A REST read of a post must never mutate the post's coauthor taxonomy
+ * assignments. 4.0.0 shipped a dynamic backfill filter hooked into
+ * rest_prepare_{post_type} that called add_coauthors() — with replace
+ * semantics — whenever it believed the response lacked coauthor data.
+ * The response-based guard was fooled by narrowing filters such as
+ * `_fields=id`, causing authenticated reads to silently replace guest
+ * author assignments with the post_author on every affected request.
+ */
+class RestPostReadDoesNotMutateCoauthorsTest extends TestCase {
+
+	public function test_rest_post_read_with_fields_filter_preserves_guest_author(): void {
+		$editor          = $this->create_editor( 'rest-read-editor' );
+		$post            = $this->create_post( $editor );
+		$guest_author_id = $this->create_guest_author( 'rest_read_ga' );
+		$guest_author    = $this->_cap->guest_authors->get_guest_author_by( 'ID', $guest_author_id );
+
+		$this->_cap->add_coauthors( $post->ID, array( $guest_author->user_login ) );
+
+		$terms_before = wp_list_pluck(
+			wp_get_object_terms( $post->ID, $this->_cap->coauthor_taxonomy ),
+			'slug'
+		);
+		$this->assertContains(
+			'cap-' . $guest_author->user_login,
+			$terms_before,
+			'Guest author term should be assigned before the REST read.'
+		);
+
+		wp_set_current_user( $editor->ID );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( '_fields', 'id' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$terms_after = wp_list_pluck(
+			wp_get_object_terms( $post->ID, $this->_cap->coauthor_taxonomy ),
+			'slug'
+		);
+
+		sort( $terms_before );
+		sort( $terms_after );
+
+		$this->assertSame(
+			$terms_before,
+			$terms_after,
+			'A REST read with _fields=id must not mutate the coauthor taxonomy assignments.'
+		);
+	}
+}


### PR DESCRIPTION
## Description

Closes https://github.com/Automattic/co-authors-plus/issues/1241

This PR solves the problem by removing the backfill. IMO a dynamic backfill when reading posts is risky (there isn't a good way to restore any data which has been affected by it, nor does it log when it changes data), and there's already a CLI command that backfills terms, so I don't think it's necessary.

## Deploy Notes

Are there any new dependencies added that should be taken into account when deploying to WordPress.org?

Nope.

## Steps to Test

1. Verify author saving and guest author saving works nicely in general.
2. Follow[ the steps to reproduce the issue here](https://github.com/Automattic/co-authors-plus/issues/1241#issuecomment-4314800938) before and after applying this PR. The issue should be resolved and authors should stay correctly assigned with this PR.