### PR TITLE
Security hardening fixes for 4.0.1

### DIFF
--- a/php/blocks/block-coauthor-image/class-block-coauthor-image.php
+++ b/php/blocks/block-coauthor-image/class-block-coauthor-image.php
@@ -114,7 +114,7 @@ class Block_CoAuthor_Image {
 		if ( '' !== $link && true === $attributes['isLink'] ) {
 			$link_attributes = Templating::render_attributes(
 				array(
-					'href'  => $author['link'],
+					'href'  => $link,
 					'rel'   => $attributes['rel'],
 					'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), $display_name ),
 				)

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -783,7 +783,10 @@ class CoAuthors_Guest_Authors {
 			return $post_data;
 		}
 
-		// @todo caps check
+		if ( empty( $original_args['ID'] ) || ! current_user_can( 'edit_post', $original_args['ID'] ) ) {
+			return $post_data;
+		}
+
 		if ( ! isset( $_POST['guest-author-nonce'] ) || ! wp_verify_nonce( $_POST['guest-author-nonce'], 'guest-author-nonce' ) ) {
 			return $post_data;
 		}
@@ -839,7 +842,10 @@ class CoAuthors_Guest_Authors {
 			return;
 		}
 
-		// @todo caps check
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
 		if ( ! isset( $_POST['guest-author-nonce'] ) || ! wp_verify_nonce( $_POST['guest-author-nonce'], 'guest-author-nonce' ) ) {
 			return;
 		}

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1017,10 +1017,15 @@ class CoAuthors_Plus {
 		}
 
 		// This action happens when a post is saved while editing a post
-		if ( isset( $_REQUEST['coauthors-nonce'], $_POST['coauthors'] ) && is_array( $_POST['coauthors'] ) ) { // phpcs:ignore
+		if (
+			isset( $_REQUEST['coauthors-nonce'], $_POST['coauthors'] )
+			&& is_array( $_POST['coauthors'] )
+			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['coauthors-nonce'] ) ), 'coauthors-edit' )
+			&& $this->current_user_can_set_authors()
+		) {
 
 			// rawurlencode() is for encoding co-author name with special characters to compare names when getting co-author.
-			$author = rawurlencode( sanitize_text_field( $_POST['coauthors'][0] ) ); // phpcs:ignore
+			$author = rawurlencode( sanitize_text_field( wp_unslash( $_POST['coauthors'][0] ) ) );
 
 			if ( $author ) {
 				$author_data = $this->get_coauthor_by( 'user_nicename', $author );

--- a/tests/Integration/Blocks/BlockCoAuthorImageTest.php
+++ b/tests/Integration/Blocks/BlockCoAuthorImageTest.php
@@ -82,7 +82,7 @@ class BlockCoAuthorImageTest extends TestCase {
 	 */
 	public function test_javascript_link_is_stripped_from_href(): void {
 		$block  = $this->make_block_for_link( 'javascript:alert(1)' );
-		$output = Block_CoAuthor_Image::render_block( array( 'isLink' => true ), '', $block );
+		$output = $block->render();
 
 		$this->assertStringNotContainsString( 'javascript:', $output );
 		$this->assertStringNotContainsString( 'href="javascript', $output );
@@ -95,7 +95,7 @@ class BlockCoAuthorImageTest extends TestCase {
 	public function test_valid_http_link_survives_escaping(): void {
 		$link   = 'https://example.com/author/example-author/';
 		$block  = $this->make_block_for_link( $link );
-		$output = Block_CoAuthor_Image::render_block( array( 'isLink' => true ), '', $block );
+		$output = $block->render();
 
 		$this->assertStringContainsString( 'href="' . esc_url( $link ) . '"', $output );
 	}
@@ -106,7 +106,7 @@ class BlockCoAuthorImageTest extends TestCase {
 	 */
 	public function test_no_anchor_is_rendered_when_is_link_is_false(): void {
 		$block  = $this->make_block_for_link( 'https://example.com/author/example-author/', false );
-		$output = Block_CoAuthor_Image::render_block( array( 'isLink' => false ), '', $block );
+		$output = $block->render();
 
 		$this->assertStringNotContainsString( '<a ', $output );
 		$this->assertStringNotContainsString( 'href=', $output );

--- a/tests/Integration/Blocks/BlockCoAuthorImageTest.php
+++ b/tests/Integration/Blocks/BlockCoAuthorImageTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\Blocks;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+use CoAuthors\Blocks\Block_CoAuthor_Image;
+use WP_Block;
+use WP_Block_Type_Registry;
+
+/**
+ * Regression tests for the href escaping in Block_CoAuthor_Image::render_block.
+ *
+ * The block previously used the raw $author['link'] value for the anchor's
+ * href attribute, relying solely on render_attributes' esc_attr handling.
+ * Because render_attributes does not strip unsafe URL schemes, a filter
+ * rewriting the REST "link" field could surface a javascript: URL. The
+ * block now uses the esc_url'd copy of the link.
+ *
+ * @covers \CoAuthors\Blocks\Block_CoAuthor_Image::render_block
+ */
+class BlockCoAuthorImageTest extends TestCase {
+
+	const BLOCK_NAME = 'co-authors-plus/image';
+
+	/** @var int */
+	private $attachment_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->attachment_id = $this->factory()->attachment->create_upload_object(
+			dirname( __DIR__ ) . '/fixtures/dummy-attachment.png'
+		);
+
+		// The render callback requires a registered block type so that
+		// WP_Block's constructor can map available_context onto $block->context.
+		// If the plugin's build dir is not present (dev checkouts without a JS
+		// build), register a minimal block type here so the test still runs.
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( ! $registry->is_registered( self::BLOCK_NAME ) ) {
+			register_block_type(
+				self::BLOCK_NAME,
+				array(
+					'uses_context'    => array( 'co-authors-plus/author', 'co-authors-plus/layout' ),
+					'render_callback' => array( Block_CoAuthor_Image::class, 'render_block' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Build a WP_Block instance whose context carries an author payload with
+	 * the given REST "link" value.
+	 */
+	private function make_block_for_link( string $link, bool $is_link = true ): WP_Block {
+		$available_context = array(
+			'co-authors-plus/author' => array(
+				'id'             => 1,
+				'display_name'   => 'Example Author',
+				'link'           => $link,
+				'featured_media' => $this->attachment_id,
+			),
+			'co-authors-plus/layout' => 'default',
+		);
+
+		return new WP_Block(
+			array(
+				'blockName'    => self::BLOCK_NAME,
+				'attrs'        => array( 'isLink' => $is_link ),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			),
+			$available_context
+		);
+	}
+
+	/**
+	 * A javascript: URL in the REST "link" field must not reach the rendered
+	 * href attribute. esc_url returns an empty string for unsafe schemes, so
+	 * the rendered anchor should carry no javascript: scheme at all.
+	 */
+	public function test_javascript_link_is_stripped_from_href(): void {
+		$block  = $this->make_block_for_link( 'javascript:alert(1)' );
+		$output = Block_CoAuthor_Image::render_block( array( 'isLink' => true ), '', $block );
+
+		$this->assertStringNotContainsString( 'javascript:', $output );
+		$this->assertStringNotContainsString( 'href="javascript', $output );
+	}
+
+	/**
+	 * A legitimate http(s) link should survive escaping and appear in the
+	 * rendered anchor's href.
+	 */
+	public function test_valid_http_link_survives_escaping(): void {
+		$link   = 'https://example.com/author/example-author/';
+		$block  = $this->make_block_for_link( $link );
+		$output = Block_CoAuthor_Image::render_block( array( 'isLink' => true ), '', $block );
+
+		$this->assertStringContainsString( 'href="' . esc_url( $link ) . '"', $output );
+	}
+
+	/**
+	 * When isLink is false, no wrapping anchor should be rendered and the
+	 * href bug cannot surface at all.
+	 */
+	public function test_no_anchor_is_rendered_when_is_link_is_false(): void {
+		$block  = $this->make_block_for_link( 'https://example.com/author/example-author/', false );
+		$output = Block_CoAuthor_Image::render_block( array( 'isLink' => false ), '', $block );
+
+		$this->assertStringNotContainsString( '<a ', $output );
+		$this->assertStringNotContainsString( 'href=', $output );
+	}
+}

--- a/tests/Integration/CoauthorsSetPostAuthorFieldSecurityTest.php
+++ b/tests/Integration/CoauthorsSetPostAuthorFieldSecurityTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression tests for the nonce and capability checks on
+ * CoAuthors_Plus::coauthors_set_post_author_field().
+ *
+ * The filter previously accepted any request that merely carried a
+ * coauthors-nonce key, with no nonce verification or capability check,
+ * allowing an Author-level user to rewrite wp_posts.post_author when
+ * saving their own post. These tests pin the corrected behaviour:
+ * the filter must only override post_author when the current user can
+ * set authors and a valid coauthors-edit nonce is present.
+ *
+ * @covers \CoAuthors_Plus::coauthors_set_post_author_field
+ */
+class CoauthorsSetPostAuthorFieldSecurityTest extends TestCase {
+
+	/** @var \WP_User */
+	private $admin;
+
+	/** @var \WP_User */
+	private $editor;
+
+	/** @var \WP_User */
+	private $author;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin  = $this->factory()->user->create_and_get(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'security_admin',
+			)
+		);
+		$this->editor = $this->factory()->user->create_and_get(
+			array(
+				'role'       => 'editor',
+				'user_login' => 'security_editor',
+			)
+		);
+		$this->author = $this->factory()->user->create_and_get(
+			array(
+				'role'       => 'author',
+				'user_login' => 'security_author',
+			)
+		);
+	}
+
+	public function tear_down() {
+		unset( $_REQUEST['coauthors-nonce'], $_POST['coauthors-nonce'], $_POST['coauthors'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Build the $data / $post_array pair the filter is called with.
+	 *
+	 * @param int $post_author Author ID to seed into the simulated post data.
+	 */
+	private function make_post_data( int $post_author ): array {
+		return array(
+			'ID'          => 0,
+			'post_type'   => 'post',
+			'post_author' => $post_author,
+		);
+	}
+
+	/**
+	 * An Author-level user cannot rewrite post_author by crafting a payload,
+	 * even with a valid nonce generated in their own session.
+	 */
+	public function test_author_cannot_rewrite_post_author_via_crafted_payload(): void {
+		global $coauthors_plus;
+
+		wp_set_current_user( $this->author->ID );
+
+		$_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );
+		$_POST['coauthors']          = array( $this->admin->user_nicename );
+
+		$data     = $this->make_post_data( $this->author->ID );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $data );
+
+		$this->assertSame(
+			$this->author->ID,
+			$new_data['post_author'],
+			'Author must not be able to reassign post_author to another user.'
+		);
+	}
+
+	/**
+	 * A request with no coauthors-nonce key is a no-op.
+	 */
+	public function test_missing_nonce_does_not_rewrite_post_author(): void {
+		global $coauthors_plus;
+
+		wp_set_current_user( $this->editor->ID );
+
+		unset( $_REQUEST['coauthors-nonce'], $_POST['coauthors-nonce'] );
+		$_POST['coauthors'] = array( $this->admin->user_nicename );
+
+		$data     = $this->make_post_data( $this->editor->ID );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $data );
+
+		$this->assertSame(
+			$this->editor->ID,
+			$new_data['post_author'],
+			'Missing nonce must skip the post_author override.'
+		);
+	}
+
+	/**
+	 * A request with a garbage coauthors-nonce value is a no-op.
+	 */
+	public function test_invalid_nonce_does_not_rewrite_post_author(): void {
+		global $coauthors_plus;
+
+		wp_set_current_user( $this->editor->ID );
+
+		$_REQUEST['coauthors-nonce'] = 'not-a-real-nonce';
+		$_POST['coauthors']          = array( $this->admin->user_nicename );
+
+		$data     = $this->make_post_data( $this->editor->ID );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $data );
+
+		$this->assertSame(
+			$this->editor->ID,
+			$new_data['post_author'],
+			'Invalid nonce must skip the post_author override.'
+		);
+	}
+
+	/**
+	 * An Editor with a valid nonce can reassign post_author to another WP user.
+	 * Pins the positive path so future refactors don't silently break the
+	 * feature for users who are authorised to use it.
+	 */
+	public function test_editor_with_valid_nonce_reassigns_post_author_to_wp_user(): void {
+		global $coauthors_plus;
+
+		wp_set_current_user( $this->editor->ID );
+
+		$_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );
+		$_POST['coauthors']          = array( $this->admin->user_nicename );
+
+		$data     = $this->make_post_data( $this->editor->ID );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $data );
+
+		$this->assertSame(
+			$this->admin->ID,
+			$new_data['post_author'],
+			'Editor with a valid nonce should reassign post_author to the selected WP user.'
+		);
+	}
+
+	/**
+	 * An Editor with a valid nonce selecting a guest author linked to a WP
+	 * user results in post_author being set to the linked user's ID.
+	 */
+	public function test_editor_with_valid_nonce_maps_linked_guest_author_to_wp_user(): void {
+		global $coauthors_plus;
+
+		// Create a guest author linked to the admin's user account.
+		$coauthors_plus->guest_authors->create_guest_author_from_user_id( $this->admin->ID );
+
+		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by(
+			'linked_account',
+			$this->admin->user_login
+		);
+
+		$this->assertIsObject( $guest_author, 'Fixture: linked guest author must be creatable.' );
+
+		wp_set_current_user( $this->editor->ID );
+
+		$_REQUEST['coauthors-nonce'] = wp_create_nonce( 'coauthors-edit' );
+		$_POST['coauthors']          = array( $guest_author->user_nicename );
+
+		$data     = $this->make_post_data( $this->editor->ID );
+		$new_data = $coauthors_plus->coauthors_set_post_author_field( $data, $data );
+
+		$this->assertSame(
+			$this->admin->ID,
+			$new_data['post_author'],
+			'Selecting a linked guest author should map post_author to the linked WP user ID.'
+		);
+	}
+}

--- a/tests/Integration/GuestAuthorSaveCapsTest.php
+++ b/tests/Integration/GuestAuthorSaveCapsTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression tests for the capability checks added to
+ * CoAuthors_Guest_Authors::manage_guest_author_filter_post_data() and
+ * CoAuthors_Guest_Authors::manage_guest_author_save_meta_fields().
+ *
+ * The two save hooks used to rely solely on the guest-author-nonce.
+ * A current_user_can( 'edit_post', ... ) check now guards both hooks
+ * as defence in depth, in case the nonce is ever exposed to a user
+ * who lacks rights to edit the guest author.
+ *
+ * @covers \CoAuthors_Guest_Authors::manage_guest_author_filter_post_data
+ * @covers \CoAuthors_Guest_Authors::manage_guest_author_save_meta_fields
+ */
+class GuestAuthorSaveCapsTest extends TestCase {
+
+	/** @var \WP_User */
+	private $admin;
+
+	/** @var \WP_User */
+	private $subscriber;
+
+	/** @var int */
+	private $guest_author_post_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin      = $this->factory()->user->create_and_get(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'ga_caps_admin',
+			)
+		);
+		$this->subscriber = $this->factory()->user->create_and_get(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'ga_caps_subscriber',
+			)
+		);
+
+		// Create the guest author as admin so the fixture is valid.
+		wp_set_current_user( $this->admin->ID );
+		$this->guest_author_post_id = $this->_cap->guest_authors->create(
+			array(
+				'display_name' => 'Caps Test Guest',
+				'user_login'   => 'caps_test_guest',
+			)
+		);
+	}
+
+	public function tear_down() {
+		unset(
+			$_POST['guest-author-nonce'],
+			$_POST['cap-display_name'],
+			$_POST['cap-first_name'],
+			$_POST['cap-last_name']
+		);
+		parent::tear_down();
+	}
+
+	/**
+	 * @return array $post_data shaped like what wp_insert_post_data receives
+	 *               for a guest-author save.
+	 */
+	private function make_post_data(): array {
+		return array(
+			'post_title' => 'Caps Test Guest (renamed)',
+			'post_name'  => 'cap-caps_test_guest',
+			'post_type'  => 'guest-author',
+		);
+	}
+
+	/**
+	 * A subscriber without edit_post rights on the guest-author post should
+	 * not be able to persist changes through the filter, even with a valid
+	 * guest-author-nonce.
+	 */
+	public function test_filter_returns_unchanged_data_when_user_lacks_edit_post_cap(): void {
+		wp_set_current_user( $this->subscriber->ID );
+
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-display_name']   = 'Should Not Stick';
+
+		$post_data = $this->make_post_data();
+
+		$filtered = $this->_cap->guest_authors->manage_guest_author_filter_post_data(
+			$post_data,
+			array( 'ID' => $this->guest_author_post_id )
+		);
+
+		$this->assertSame(
+			$post_data,
+			$filtered,
+			'Filter must return unchanged post data for users without edit_post capability.'
+		);
+	}
+
+	/**
+	 * The filter should bail when no post ID is available, since a
+	 * capability check without a post context cannot be meaningful.
+	 */
+	public function test_filter_returns_unchanged_data_when_post_id_missing(): void {
+		wp_set_current_user( $this->admin->ID );
+
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-display_name']   = 'Does Not Matter';
+
+		$post_data = $this->make_post_data();
+
+		$filtered = $this->_cap->guest_authors->manage_guest_author_filter_post_data(
+			$post_data,
+			array( 'ID' => 0 )
+		);
+
+		$this->assertSame(
+			$post_data,
+			$filtered,
+			'Filter must bail when no post ID is present, regardless of caps.'
+		);
+	}
+
+	/**
+	 * With a valid nonce and the right cap, the filter applies its
+	 * normal rewriting behaviour (e.g. setting post_title from
+	 * cap-display_name). This pins the positive path.
+	 */
+	public function test_filter_applies_changes_when_user_has_edit_post_cap(): void {
+		wp_set_current_user( $this->admin->ID );
+
+		$new_display_name            = 'Caps Test Guest Renamed';
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-display_name']   = $new_display_name;
+
+		$post_data = $this->make_post_data();
+
+		$filtered = $this->_cap->guest_authors->manage_guest_author_filter_post_data(
+			$post_data,
+			array( 'ID' => $this->guest_author_post_id )
+		);
+
+		$this->assertSame(
+			$new_display_name,
+			$filtered['post_title'],
+			'Filter should rewrite post_title from cap-display_name for users with edit_post capability.'
+		);
+	}
+
+	/**
+	 * A subscriber cannot persist meta fields through the save_post action.
+	 */
+	public function test_save_meta_fields_skips_writes_when_user_lacks_edit_post_cap(): void {
+		$existing_first_name = get_post_meta( $this->guest_author_post_id, 'cap-first_name', true );
+
+		wp_set_current_user( $this->subscriber->ID );
+
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-first_name']     = 'Attacker';
+
+		$post = get_post( $this->guest_author_post_id );
+		$this->_cap->guest_authors->manage_guest_author_save_meta_fields( $this->guest_author_post_id, $post );
+
+		$this->assertSame(
+			$existing_first_name,
+			get_post_meta( $this->guest_author_post_id, 'cap-first_name', true ),
+			'Subscriber must not be able to persist guest-author meta.'
+		);
+	}
+
+	/**
+	 * An admin with valid nonce and cap persists the meta fields.
+	 */
+	public function test_save_meta_fields_persists_when_user_has_edit_post_cap(): void {
+		wp_set_current_user( $this->admin->ID );
+
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-first_name']     = 'Legit';
+
+		$post = get_post( $this->guest_author_post_id );
+		$this->_cap->guest_authors->manage_guest_author_save_meta_fields( $this->guest_author_post_id, $post );
+
+		$this->assertSame(
+			'Legit',
+			get_post_meta( $this->guest_author_post_id, 'cap-first_name', true ),
+			'Admin with valid nonce should be able to persist guest-author meta.'
+		);
+	}
+
+	/**
+	 * Missing nonce is still a no-op for authorised users (guards the
+	 * pre-existing nonce check from silently regressing).
+	 */
+	public function test_save_meta_fields_requires_nonce_even_for_admin(): void {
+		$existing_first_name = get_post_meta( $this->guest_author_post_id, 'cap-first_name', true );
+
+		wp_set_current_user( $this->admin->ID );
+
+		unset( $_POST['guest-author-nonce'] );
+		$_POST['cap-first_name'] = 'Should Not Stick';
+
+		$post = get_post( $this->guest_author_post_id );
+		$this->_cap->guest_authors->manage_guest_author_save_meta_fields( $this->guest_author_post_id, $post );
+
+		$this->assertSame(
+			$existing_first_name,
+			get_post_meta( $this->guest_author_post_id, 'cap-first_name', true ),
+			'Missing nonce must prevent writes even for authorised users.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The first commit fixes `CoAuthors_Plus::coauthors_set_post_author_field`. The hook previously decided whether to override `post_author` based on `isset( $_REQUEST['coauthors-nonce'] )` alone, with no nonce verification and no capability check. An Author-level user could POST `coauthors-nonce=anything&coauthors[]=target-nicename` when saving their own post and have `wp_posts.post_author` rewritten to another user's ID. The fix verifies the `coauthors-edit` nonce with `wp_verify_nonce` and gates the branch on `current_user_can_set_authors`, matching the checks already used in `coauthors_update_post`. `wp_verify_nonce` is preferred over `check_admin_referer` because the hook fires on every post save, and dying on an invalid or expired nonce would break unrelated flows.

The second commit replaces the `// @todo caps check` comments in `manage_guest_author_filter_post_data` and `manage_guest_author_save_meta_fields` with an explicit `current_user_can( 'edit_post', ... )` check. Both functions previously relied only on the `guest-author-nonce`. Adding the capability check gives defence in depth if the nonce is ever exposed.

The third commit is a one-line change in `Block_CoAuthor_Image::render_block` to use the already-computed `$link` variable (which passes through `esc_url`) instead of the raw `$author['link']` when building the anchor's `href`. `render_attributes` applies `esc_attr` but does not strip `javascript:` schemes, and `$author['link']` comes from a filterable REST response.

## Test plan

- [ ] Classic editor: adding and reordering co-authors on a post still saves correctly for users with `edit_others_posts`.
- [ ] Block editor: coauthor assignment via the sidebar still persists.
- [ ] Author-level user saving their own post cannot rewrite `post_author` via a crafted `coauthors[]` payload.
- [ ] Guest author create/edit saves correctly for users with the right caps.
- [ ] Guest author save silently returns when the current user lacks `edit_post` for that guest author.
- [ ] Co-Author Image block, when configured to link, renders a working author-archive URL with `rel` and `title` intact.