### PR TITLE
Exclude AGENTS.md and CONTRIBUTING.md from the distribution ZIP

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -36,7 +36,9 @@
 /package-lock.json
 
 # Documentation (not needed in plugin distribution)
+/AGENTS.md
 /CHANGELOG.md
+/CONTRIBUTING.md
 /docs/
 
 # Test configuration


### PR DESCRIPTION
## Summary

`AGENTS.md` and `CONTRIBUTING.md` are contributor-facing documentation with no runtime role. They shouldn't be shipped inside the plugin ZIP on WordPress.org or attached to GitHub Releases, so add them to `.distignore` alongside `CHANGELOG.md` and `/docs/`, which are already excluded for the same reason.

Takes effect from the next release onwards; the already-published 4.0.1 ZIPs still contain these two files.

## Test plan

- [ ] On next release, confirm `AGENTS.md` and `CONTRIBUTING.md` are absent from the generated `co-authors-plus.zip` (either by inspecting the release asset or by running `rsync -rc --exclude-from=.distignore ./ /tmp/out/` locally and listing the output).