### PR TITLE
Docs: Update changelog URL in README to absolute GitHub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Co-Authors Plus
+# Co-Authors Plus
 
 Stable tag: 4.0.0  
 Requires at least: 6.4  
@@ -73,4 +73,4 @@ Yes! You can disable guest authors entirely through a filter. Having the followi
 
 ## Change Log
 
-[View the change log](./CHANGELOG.md).
+[View the change log](https://github.com/Automattic/co-authors-plus/blob/develop/CHANGELOG.md).


### PR DESCRIPTION
This PR updates the "View the change log" link in the README from a relative path (`./CHANGELOG.md`) to an absolute GitHub URL (`https://github.com/Automattic/co-authors-plus/blob/develop/CHANGELOG.md`). 

Currently on WordPress.org, the changelog link points to `https://wordpress.org/plugins/co-authors-plus/#developers` which is invalid and doesn't show the changelog file. This change ensures that users clicking the link in the plugin repository are correctly directed to the changelog on GitHub.