### PR TITLE
Fix: Correct plugin ZIP filename in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Co-Authors Plus
+# Co-Authors Plus
 
 Stable tag: 4.0.0  
 Requires at least: 6.4  
@@ -32,7 +32,7 @@ Co-Authors Plus is an almost complete rewrite of the [Co-Authors](https://wordpr
 ## Installation
 
 1. IMPORTANT: If you are using the original Co-Authors plugin, disable it before installing Co-Authors Plus.
-2. Extract the coauthors-plus.zip file and upload its contents to the `/wp-content/plugins/` directory. Alternately, you can install directly from the Plugin directory within your WordPress Install.
+2. Extract the co-authors-plus.zip file and upload its contents to the `/wp-content/plugins/` directory. Alternately, you can install directly from the Plugin directory within your WordPress Install.
 3. Activate the plugin through the "Plugins" menu in WordPress.
 4. Place [co-authors template tags](https://github.com/Automattic/Co-Authors-Plus/wiki/Template-tags) in your template.
 5. Add co-authors to your posts and pages.


### PR DESCRIPTION
## Summary

The manual installation instructions in `README.md` referenced the wrong ZIP filename. Step 2 told users to extract **`coauthors-plus.zip`**, but the file actually distributed via WordPress.org (and produced by the release workflow) is **`co-authors-plus.zip`** — hyphenated, matching the official plugin slug and repository name.

## Problem

```
Extract the coauthors-plus.zip file and upload its contents to the /wp-content/plugins/ directory.
```

A user following these instructions to install the plugin manually would look for `coauthors-plus.zip` after downloading from WordPress.org, only to find the file is named `co-authors-plus.zip`. This creates unnecessary friction and confusion, especially for non-technical users who are less likely to realise the names differ only in formatting.

## Fix

```diff
-2. Extract the coauthors-plus.zip file and upload its contents to the `/wp-content/plugins/` directory.
+2. Extract the co-authors-plus.zip file and upload its contents to the `/wp-content/plugins/` directory.
```

A single-character correction — adding the two missing hyphens — so the documented filename exactly matches the file users actually download.
