### PR TITLE
Stop editor dropping the current user when a coauthor term can't be resolved

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -156,7 +156,10 @@ class Endpoints {
 
 		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {
-				$response[] = $this->_format_author_data( $author );
+				$formatted = $this->_format_author_data( $author );
+				if ( null !== $formatted ) {
+					$response[] = $formatted;
+				}
 			}
 		}
 
@@ -220,8 +223,13 @@ class Endpoints {
 
 			$author = $this->coauthors->get_coauthor_by( 'user_nicename', $term->slug );
 
-			if ( $author ) {
-				$response[] = $this->_format_author_data( $author );
+			if ( ! $author ) {
+				continue;
+			}
+
+			$formatted = $this->_format_author_data( $author );
+			if ( null !== $formatted ) {
+				$response[] = $formatted;
 			}
 		}
 
@@ -251,16 +259,27 @@ class Endpoints {
 	 * Helper function to consistently format the author data for
 	 * the response.
 	 *
-	 * @param object  $author The result from co-authors methods.
-	 * @return array
+	 * Returns null if a valid taxonomy term can't be resolved for the author.
+	 * Callers should skip null entries: a coauthor row without a term id can't
+	 * be persisted by the editor (wp_set_object_terms would silently drop it),
+	 * so we exclude it from the response rather than feed the editor data it
+	 * can't round-trip.
+	 *
+	 * @param object $author The result from co-authors methods.
+	 * @return array|null
 	 */
-	public function _format_author_data( $author ): array {
-		$term      = $this->coauthors->update_author_term( $author );
+	public function _format_author_data( $author ): ?array {
+		$term = $this->coauthors->update_author_term( $author );
+
+		if ( ! $term || is_wp_error( $term ) ) {
+			return null;
+		}
+
 		$user_type = isset( $author->type ) && 'guest-author' === $author->type ? 'guest-user' : 'wp-user';
 
 		return array(
 			'id'           => esc_html( $author->ID ),
-			'termId'       => $term ? (int) $term->term_id : null,
+			'termId'       => (int) $term->term_id,
 			'userNicename' => esc_html( rawurldecode( $author->user_nicename ) ),
 			'login'        => esc_html( $author->user_login ),
 			'email'        => sanitize_email( $author->user_email ),
@@ -281,7 +300,10 @@ class Endpoints {
 
 		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {
-				$response[] = $this->_format_author_data( $author );
+				$formatted = $this->_format_author_data( $author );
+				if ( null !== $formatted ) {
+					$response[] = $formatted;
+				}
 			}
 		}
 	}

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1226,25 +1226,33 @@ class CoAuthors_Plus {
 			return;
 		}
 
-		$this->is_rest_save = true;
-
-		if ( empty( $terms ) ) {
-			// Post ended up with no coauthor terms after handle_terms ran.
-			// Restore from post_author so we never persist a termless post.
-			$user = get_userdata( $post->post_author );
-			if ( $user ) {
-				$this->add_coauthors( $post->ID, array( $user->user_nicename ) );
-			}
-		} else {
-			$coauthor_nicenames = array();
-			foreach ( $terms as $term ) {
-				$coauthor_nicenames[] = $term->slug;
-			}
-			$this->add_coauthors( $post->ID, $coauthor_nicenames );
-		}
-
+		$this->is_rest_save             = true;
 		$this->rest_coauthors_processed = true;
-		$this->is_rest_save = false;
+
+		try {
+			if ( empty( $terms ) ) {
+				// Post ended up with no coauthor terms after handle_terms ran.
+				// Restore from post_author so we never persist a termless post.
+				$user = get_userdata( $post->post_author );
+				if ( $user ) {
+					$this->add_coauthors( $post->ID, array( $user->user_nicename ) );
+				}
+			} else {
+				$coauthor_nicenames = array();
+				foreach ( $terms as $term ) {
+					$coauthor_nicenames[] = $term->slug;
+				}
+				$this->add_coauthors( $post->ID, $coauthor_nicenames );
+			}
+		} finally {
+			// Always reset the flags. rest_coauthors_processed in particular
+			// must not leak across REST requests (or, in the test suite, across
+			// tests that share the global $coauthors_plus instance) — otherwise
+			// the next coauthors_update_post() call short-circuits and posts
+			// created via wp_insert_post() never receive their author term.
+			$this->is_rest_save             = false;
+			$this->rest_coauthors_processed = false;
+		}
 	}
 
 	/**

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1195,6 +1195,13 @@ class CoAuthors_Plus {
 	 * Bridges the REST API save flow to add_coauthors() so that post_author
 	 * stays in sync and legacy filters continue to fire (with deprecation notices).
 	 *
+	 * If the request set `coauthors` to a list that left the post with no
+	 * valid terms (e.g. all term IDs were invalid and silently dropped by
+	 * wp_set_object_terms), fall back to the post_author so the post is
+	 * never termless. Without this guard, get_coauthors() would fall back
+	 * to post_author at read time on every front-end request, masking the
+	 * fact that the editor's save dropped data.
+	 *
 	 * @param WP_Post         $post    Inserted or updated post object.
 	 * @param WP_REST_Request $request Request object.
 	 */
@@ -1215,17 +1222,27 @@ class CoAuthors_Plus {
 			)
 		);
 
-		if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		if ( is_wp_error( $terms ) ) {
 			return;
 		}
 
-		$coauthor_nicenames = array();
-		foreach ( $terms as $term ) {
-			$coauthor_nicenames[] = $term->slug;
+		$this->is_rest_save = true;
+
+		if ( empty( $terms ) ) {
+			// Post ended up with no coauthor terms after handle_terms ran.
+			// Restore from post_author so we never persist a termless post.
+			$user = get_userdata( $post->post_author );
+			if ( $user ) {
+				$this->add_coauthors( $post->ID, array( $user->user_nicename ) );
+			}
+		} else {
+			$coauthor_nicenames = array();
+			foreach ( $terms as $term ) {
+				$coauthor_nicenames[] = $term->slug;
+			}
+			$this->add_coauthors( $post->ID, $coauthor_nicenames );
 		}
 
-		$this->is_rest_save = true;
-		$this->add_coauthors( $post->ID, $coauthor_nicenames );
 		$this->rest_coauthors_processed = true;
 		$this->is_rest_save = false;
 	}

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,9 @@
-import { moveItem, removeItem, addItemByValue } from '../utils';
+import {
+	moveItem,
+	removeItem,
+	addItemByValue,
+	buildCoauthorTermIds,
+} from '../utils';
 import {
 	selectedAuthors,
 	newAuthorValue,
@@ -84,5 +89,58 @@ describe( 'Utility - addItemByValue', () => {
 		expect(
 			addItemByValue( newAuthorValue, selectedAuthors, dropdownOptions )
 		).toStrictEqual( [ ...selectedAuthors, dropdownOptions[ 0 ] ] );
+	} );
+} );
+
+describe( 'Utility - buildCoauthorTermIds', () => {
+	const author = ( termId ) => ( { termId } );
+
+	it( 'returns the term IDs of the new authors when everything resolved', () => {
+		const result = buildCoauthorTermIds(
+			[ author( 10 ), author( 20 ) ],
+			[ author( 10 ) ],
+			[ 10 ]
+		);
+		expect( result ).toStrictEqual( [ 10, 20 ] );
+	} );
+
+	it( 'preserves term IDs that the REST endpoint failed to resolve', () => {
+		// User's own term (5) couldn't be resolved, selectedAuthors is empty.
+		// User then picks term 20 from the dropdown — term 5 must survive.
+		const result = buildCoauthorTermIds(
+			[ author( 20 ) ],
+			[],
+			[ 5 ]
+		);
+		expect( result ).toStrictEqual( [ 5, 20 ] );
+	} );
+
+	it( 'preserves unresolved IDs when the user removes a resolved author', () => {
+		// Term 5 is unresolved, terms 10 + 20 are resolved.
+		// User removes 10; the remaining list should keep 5 and 20.
+		const result = buildCoauthorTermIds(
+			[ author( 20 ) ],
+			[ author( 10 ), author( 20 ) ],
+			[ 5, 10, 20 ]
+		);
+		expect( result ).toStrictEqual( [ 5, 20 ] );
+	} );
+
+	it( 'drops authors that have no valid termId', () => {
+		const result = buildCoauthorTermIds(
+			[ author( 10 ), author( null ), author( undefined ), { } ],
+			[ author( 10 ) ],
+			[ 10 ]
+		);
+		expect( result ).toStrictEqual( [ 10 ] );
+	} );
+
+	it( 'tolerates an undefined currentTermIds list', () => {
+		const result = buildCoauthorTermIds(
+			[ author( 10 ) ],
+			[],
+			undefined
+		);
+		expect( result ).toStrictEqual( [ 10 ] );
 	} );
 } );

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -17,7 +17,11 @@ import AuthorsSelection from '../author-selection';
 /**
  * Utilities
  */
-import { addItemByValue, formatAuthorData } from '../../utils';
+import {
+	addItemByValue,
+	buildCoauthorTermIds,
+	formatAuthorData,
+} from '../../utils';
 
 /**
  * Hooks
@@ -74,11 +78,21 @@ const CoAuthors = () => {
 	/**
 	 * Setter for updating authors via the core entity store.
 	 *
+	 * Builds the new term ID list via buildCoauthorTermIds() so that any
+	 * unresolved term IDs (whose details the REST endpoint couldn't load)
+	 * survive an add / remove / reorder action by the user. Without this
+	 * guard those IDs would be silently dropped when the user makes any edit.
+	 *
 	 * @param {Array} newAuthors array of rich author objects (with termId).
 	 */
 	const updateAuthors = ( newAuthors ) => {
-		const termIds = newAuthors.map( ( author ) => author.termId );
-		editPost( { coauthors: termIds } );
+		editPost( {
+			coauthors: buildCoauthorTermIds(
+				newAuthors,
+				selectedAuthors,
+				coauthorTermIds
+			),
+		} );
 	};
 
 	/**
@@ -135,20 +149,21 @@ const CoAuthors = () => {
 		}
 	}, 500 );
 
-	// Show spinner while the post entity is loading or authors are being resolved.
-	const showSpinner = ! hasResolvedPost || isLoading || ( hasResolvedPost && coauthorTermIds?.length && ! selectedAuthors.length );
+	// Show spinner while the post entity or author details are still loading.
+	// Once loading completes, render the resolved authors (which may be an
+	// empty list) so the panel never sits on a perpetual spinner if the
+	// REST endpoint can't resolve a term ID.
+	const showSpinner = ! hasResolvedPost || isLoading;
 
 	return (
 		<>
-			{ ! showSpinner && Boolean( selectedAuthors.length ) ? (
-				<>
-					<AuthorsSelection
-						selectedAuthors={ selectedAuthors }
-						updateAuthors={ updateAuthors }
-					/>
-				</>
-			) : (
+			{ showSpinner ? (
 				<Spinner />
+			) : (
+				<AuthorsSelection
+					selectedAuthors={ selectedAuthors }
+					updateAuthors={ updateAuthors }
+				/>
 			) }
 
 			<ComboboxControl

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,6 +65,43 @@ export const addItemByValue = (
 };
 
 /**
+ * Build the term ID list to persist after an edit.
+ *
+ * The editor can only display authors whose details the REST endpoint
+ * resolved (`selectedAuthors`). When some IDs in `currentTermIds` couldn't be
+ * resolved, they aren't represented in the UI, so a naive
+ * `newAuthors.map( a => a.termId )` would silently drop them on the next
+ * edit. This helper preserves those unresolved IDs at the front of the
+ * returned list and appends the user's edited authors in order.
+ *
+ * @param {Array} newAuthors      Resolved authors after the user's edit.
+ * @param {Array} selectedAuthors Resolved authors before the edit.
+ * @param {Array} currentTermIds  All term IDs in the entity store (resolved + unresolved).
+ * @return {Array} Term IDs to persist, with unresolved IDs preserved.
+ */
+export const buildCoauthorTermIds = (
+	newAuthors,
+	selectedAuthors,
+	currentTermIds
+) => {
+	const isValidId = ( id ) => Number.isInteger( id );
+
+	const newTermIds = newAuthors
+		.map( ( author ) => author?.termId )
+		.filter( isValidId );
+
+	const resolvedTermIds = new Set(
+		selectedAuthors.map( ( author ) => author?.termId ).filter( isValidId )
+	);
+
+	const unresolvedTermIds = ( currentTermIds || [] ).filter(
+		( id ) => isValidId( id ) && ! resolvedTermIds.has( id )
+	);
+
+	return [ ...unresolvedTermIds, ...newTermIds ];
+};
+
+/**
  * Format the author option object.
  *
  * @param {Object} root0              An author object from the API endpoint.

--- a/tests/Integration/RestSaveCoauthorsFallbackTest.php
+++ b/tests/Integration/RestSaveCoauthorsFallbackTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use CoAuthors\API\Endpoints;
+use WP_REST_Request;
+
+/**
+ * Regression coverage for issue #1252.
+ *
+ * Defends two related guards introduced after the OP reported the editor
+ * silently unassigning the current user:
+ *
+ *   1. `Endpoints::_format_author_data()` returns null when an author has
+ *      no resolvable taxonomy term, so the editor never receives a row
+ *      with `termId: null` (which `wp_set_object_terms()` would skip).
+ *   2. `CoAuthors_Plus::sync_coauthors_on_rest_save()` falls back to the
+ *      post_author when a REST save leaves the post with zero coauthor
+ *      terms (e.g. all submitted IDs were invalid), so the post is never
+ *      persisted termless.
+ */
+class RestSaveCoauthorsFallbackTest extends TestCase {
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::get_coauthors_by_term_ids
+	 */
+	public function test_authors_by_term_ids_skips_terms_with_no_resolvable_author(): void {
+		$editor = $this->create_editor( 'rest-fallback-editor' );
+		wp_set_current_user( $editor->ID );
+
+		// Real term that does resolve to the editor user.
+		$this->_cap->update_author_term( $editor );
+		$editor_term = $this->_cap->get_author_term( $editor );
+
+		// An orphan term whose slug points at no WP user or guest author.
+		$orphan_term = wp_insert_term(
+			'orphan-author',
+			$this->_cap->coauthor_taxonomy,
+			array(
+				'slug'        => 'cap-no-such-author',
+				'description' => 'Orphan author term',
+			)
+		);
+		$this->assertIsArray( $orphan_term );
+
+		$request = new WP_REST_Request( 'GET', '/coauthors/v1/' . Endpoints::AUTHORS_BY_TERMS_ROUTE );
+		$request->set_param( 'ids', $editor_term->term_id . ',' . $orphan_term['term_id'] );
+
+		$response = ( new Endpoints( $this->_cap ) )->get_coauthors_by_term_ids( $request );
+		$data     = $response->get_data();
+
+		$this->assertCount(
+			1,
+			$data,
+			'Orphan term should be skipped, so only the editor is returned.'
+		);
+		$this->assertSame( (int) $editor_term->term_id, $data[0]['termId'] );
+		$this->assertIsInt( $data[0]['termId'], 'Returned termId must be an int, never null.' );
+	}
+
+	/**
+	 * @covers \CoAuthors_Plus::sync_coauthors_on_rest_save
+	 */
+	public function test_rest_save_with_no_resolvable_term_ids_falls_back_to_post_author(): void {
+		$editor = $this->create_editor( 'rest-fallback-author' );
+		$post   = $this->create_post( $editor );
+
+		// Sanity check: the editor is the only coauthor before we save.
+		$before = wp_get_object_terms( $post->ID, $this->_cap->coauthor_taxonomy, array( 'fields' => 'slugs' ) );
+		$this->assertSame( array( 'cap-' . $editor->user_login ), $before );
+
+		wp_set_current_user( $editor->ID );
+
+		// Simulate the editor saving with a bogus coauthor term ID. WP core's
+		// handle_terms() will replace existing terms with this set; the bogus
+		// ID gets dropped by wp_set_object_terms(), leaving the post termless.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'id', $post->ID );
+		$request->set_param( 'coauthors', array( 999999 ) );
+		$request->set_param( 'title', 'After bogus save' );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$after = wp_get_object_terms( $post->ID, $this->_cap->coauthor_taxonomy, array( 'fields' => 'slugs' ) );
+
+		$this->assertNotEmpty(
+			$after,
+			'After a save that drops every submitted term, the post must not be termless.'
+		);
+		$this->assertSame(
+			array( 'cap-' . $editor->user_login ),
+			$after,
+			'The fallback should restore the post_author as the sole coauthor.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1252.

The OP reported that on a fresh post the Authors panel showed a spinner that never resolved, that adding a different author silently unassigned the current user, and that `get_coauthors($post_id)` on the front-end still returned them. The combination is hard to spot in the editor but visible everywhere else.

Two things were happening. On the JS side, the panel built the saved term-id list from `selectedAuthors` (the rich rows the REST endpoint resolved) instead of from `coauthorTermIds` (the entity-store value). When `/coauthors/v1/authors-by-term-ids` returned no rows for a given id — for any reason: deleted user, broken object cache, missing guest-author post, third-party filter — the user disappeared from `selectedAuthors`, the spinner was stuck on by the `coauthorTermIds.length && !selectedAuthors.length` clause, and the next add/remove rebuilt the array from the resolved rows only, dropping anything unresolved.

On the PHP side two things let that data loss persist quietly: `Endpoints::_format_author_data()` returned `'termId' => null` when it couldn't resolve a term, which the editor saved as `coauthors:[null]` — `wp_set_object_terms` strips that, and the post ends up with no coauthor terms at all. `sync_coauthors_on_rest_save()` then bailed early on the empty term list, and `get_coauthors()` papered over it on the front-end by falling back to `post_author` — so the editor showed one thing, the front-end showed another.

The fix moves the source of truth in the editor onto `coauthorTermIds` via a new `buildCoauthorTermIds()` helper that preserves any unresolved ids when the user edits, drops the spinner clause that kept the panel in a permanent loading state, makes `_format_author_data()` return null and have its callers skip rather than emit an unsavable row, and falls back to the post_author in `sync_coauthors_on_rest_save()` if a save still leaves the post termless.

## Test plan

- [ ] On a fresh install, open a new post — the Authors panel resolves the current user without spinning.
- [ ] Reproduce the original report by mocking the resolution endpoint to return `[]` for the current user's term id; add another author, save, and confirm the post keeps both the original (now-unresolved) term and the new one rather than swapping them.
- [ ] Save a post with a deliberately bogus `coauthors: [999999]` via the REST API and confirm the post comes back with the post_author as coauthor rather than termless.
- [ ] `composer test:integration` and `npm run test:unit` are green (new coverage in `RestSaveCoauthorsFallbackTest` and `utils.test.js`).