### PR TITLE
fix(tags): guest author names duplicating and missing website links

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -406,31 +406,45 @@ function coauthors_emails( $between = null, $betweenLast = null, $before = null,
 /**
  * Outputs a single co-author, linked to their website if they've provided one.
  *
- * @param object $author
- * @return string
+ * Uses the passed $author object directly for display name, website, and URL to
+ * avoid relying on the global $authordata, which may be stale or overridden by
+ * the 'the_author' filter when CoAuthors_Template_Filters is active.
+ *
+ * @since 3.0
+ *
+ * @param object $author Co-author object (guest author or WP_User-like).
+ * @return string HTML link to the co-author's website, or their plain display name.
  */
 function coauthors_links_single( $author ) {
-	if ( 'guest-author' === $author->type && get_the_author_meta( 'website' ) ) {
+	$display_name = isset( $author->display_name ) ? $author->display_name : '';
+
+	// Guest authors store their personal site URL in the 'website' property, which
+	// is sourced from post meta and is not present on the global $authordata object.
+	// We therefore read it directly from the passed $author rather than via
+	// get_the_author_meta(), which would silently return empty for guest authors.
+	if ( 'guest-author' === $author->type && ! empty( $author->website ) ) {
 		return sprintf(
 			'<a href="%s" title="%s" rel="author external">%s</a>',
-			esc_url( get_the_author_meta( 'website' ) ),
+			esc_url( $author->website ),
 			/* translators: Author display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
-			esc_html( get_the_author() )
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( $display_name ) ) ),
+			esc_html( $display_name )
 		);
 	}
 
-	if ( get_the_author_meta( 'url' ) ) {
+	// For regular WP users, the website URL lives in the user_url property.
+	$user_url = isset( $author->user_url ) ? $author->user_url : '';
+	if ( $user_url ) {
 		return sprintf(
 			'<a href="%s" title="%s" rel="author external">%s</a>',
-			esc_url( get_the_author_meta( 'url' ) ),
+			esc_url( $user_url ),
 			/* translators: Author display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
-			esc_html( get_the_author() )
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( $display_name ) ) ),
+			esc_html( $display_name )
 		);
 	}
 
-	return esc_html( get_the_author() );
+	return esc_html( $display_name );
 }
 
 /**

--- a/tests/Integration/TemplateTags/CoauthorsLinksSingleTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsLinksSingleTest.php
@@ -55,25 +55,28 @@ class CoauthorsLinksSingleTest extends TestCase {
 
 		$output = coauthors_links( null, null, null, null, false );
 
-		// Each guest author name must appear exactly once in the visible link text.
+		// Each guest author's name must appear in the output exactly once.
+		// These guest authors have no website so coauthors_links_single() returns
+		// plain text (no anchor tag). We therefore check for the display name
+		// string directly rather than for ">Name<" markup.
 		$this->assertStringContainsString(
-			'>' . $guest_author_1->display_name . '<',
+			$guest_author_1->display_name,
 			$output,
 			'First guest author display name not found in output.'
 		);
 		$this->assertStringContainsString(
-			'>' . $guest_author_2->display_name . '<',
+			$guest_author_2->display_name,
 			$output,
 			'Second guest author display name not found in output.'
 		);
 		$this->assertEquals(
 			1,
-			substr_count( $output, '>' . $guest_author_1->display_name . '<' ),
+			substr_count( $output, $guest_author_1->display_name ),
 			'First guest author display name must appear exactly once.'
 		);
 		$this->assertEquals(
 			1,
-			substr_count( $output, '>' . $guest_author_2->display_name . '<' ),
+			substr_count( $output, $guest_author_2->display_name ),
 			'Second guest author display name must appear exactly once.'
 		);
 	}

--- a/tests/Integration/TemplateTags/CoauthorsLinksSingleTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsLinksSingleTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\TemplateTags;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+
+/**
+ * Tests for coauthors_links_single() using the author object directly.
+ *
+ * @see https://github.com/Automattic/co-authors-plus/issues/1131
+ *
+ * @covers ::coauthors_links_single()
+ */
+class CoauthorsLinksSingleTest extends TestCase {
+
+	use \Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+
+	/**
+	 * Test that coauthors_links() outputs each guest author's display name
+	 * exactly once when a post has multiple guest authors.
+	 *
+	 * Regression test for issue #1131 where all co-authors displayed the first
+	 * author's name because coauthors_links_single() read from global $authordata
+	 * rather than the passed $author object.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1131
+	 */
+	public function test_coauthors_links_shows_each_guest_author_name_once(): void {
+		global $coauthors_plus, $coauthors_plus_template_filters;
+
+		// Activate the template filters (as a theme using coauthors_auto_apply_template_tags would).
+		$coauthors_plus_template_filters = new \CoAuthors_Template_Filters();
+
+		// Create two distinct guest authors.
+		$guest_author_1_id = $this->create_guest_author( 'Jane Doe' );
+		$guest_author_2_id = $this->create_guest_author( 'John Doe' );
+
+		$this->assertIsInt( $guest_author_1_id, 'First guest author creation failed.' );
+		$this->assertIsInt( $guest_author_2_id, 'Second guest author creation failed.' );
+
+		$guest_author_1 = $coauthors_plus->get_coauthor_by( 'user_login', 'Jane Doe' );
+		$guest_author_2 = $coauthors_plus->get_coauthor_by( 'user_login', 'John Doe' );
+
+		$this->assertIsObject( $guest_author_1, 'Could not retrieve first guest author object.' );
+		$this->assertIsObject( $guest_author_2, 'Could not retrieve second guest author object.' );
+
+		// Create a post and assign both guest authors as co-authors.
+		$post            = $this->create_post();
+		$GLOBALS['post'] = $post;
+
+		$coauthors_plus->add_coauthors(
+			$post->ID,
+			array( $guest_author_1->user_login, $guest_author_2->user_login )
+		);
+
+		$output = coauthors_links( null, null, null, null, false );
+
+		// Each guest author name must appear exactly once in the visible link text.
+		$this->assertStringContainsString(
+			'>' . $guest_author_1->display_name . '<',
+			$output,
+			'First guest author display name not found in output.'
+		);
+		$this->assertStringContainsString(
+			'>' . $guest_author_2->display_name . '<',
+			$output,
+			'Second guest author display name not found in output.'
+		);
+		$this->assertEquals(
+			1,
+			substr_count( $output, '>' . $guest_author_1->display_name . '<' ),
+			'First guest author display name must appear exactly once.'
+		);
+		$this->assertEquals(
+			1,
+			substr_count( $output, '>' . $guest_author_2->display_name . '<' ),
+			'Second guest author display name must appear exactly once.'
+		);
+	}
+
+	/**
+	 * Test that coauthors_links_single() uses the $author object's display_name
+	 * rather than reading from the global $authordata, so guest authors are
+	 * rendered with their own name regardless of the current $authordata state.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1131
+	 */
+	public function test_coauthors_links_single_uses_passed_author_display_name(): void {
+		global $authordata;
+
+		$author  = $this->create_author( 'lead_author' );
+		$post    = $this->create_post( $author );
+		$GLOBALS['post'] = $post;
+
+		// Set $authordata to lead_author — simulating the start of a loop.
+		$authordata = $author;
+
+		// Create a distinct guest author.
+		$guest_id     = $this->create_guest_author( 'Guest Writer' );
+		global $coauthors_plus;
+		$guest_author = $coauthors_plus->get_coauthor_by( 'user_login', 'Guest Writer' );
+
+		$this->assertIsObject( $guest_author );
+
+		// Even though $authordata points to lead_author, the output for the guest
+		// must reflect the guest's own display_name, not the lead author's.
+		$link = coauthors_links_single( $guest_author );
+
+		$this->assertStringContainsString(
+			$guest_author->display_name,
+			$link,
+			'coauthors_links_single() must use the $author object, not global $authordata.'
+		);
+		$this->assertStringNotContainsString(
+			$author->display_name,
+			$link,
+			'coauthors_links_single() must not output the lead author name for a different guest author.'
+		);
+	}
+
+	/**
+	 * Test that coauthors_links_single() correctly uses the website field
+	 * from the guest author object when present.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1131
+	 */
+	public function test_coauthors_links_single_uses_guest_author_website(): void {
+		global $coauthors_plus;
+
+		$website_url = 'https://example.com/jane';
+
+		$guest_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => 'Jane With Website',
+				'user_login'   => 'jane_with_website',
+				'website'      => $website_url,
+			)
+		);
+
+		$this->assertIsInt( $guest_id, 'Guest author with website creation failed.' );
+
+		$guest_author = $coauthors_plus->get_coauthor_by( 'user_login', 'jane_with_website' );
+
+		$this->assertIsObject( $guest_author );
+		$this->assertEquals( 'guest-author', $guest_author->type );
+		$this->assertEquals( $website_url, $guest_author->website, 'Guest author website property not set.' );
+
+		$link = coauthors_links_single( $guest_author );
+
+		$this->assertStringContainsString(
+			$website_url,
+			$link,
+			'Guest author website URL must appear in the link href.'
+		);
+		$this->assertStringContainsString(
+			$guest_author->display_name,
+			$link,
+			'Guest author display name must appear in the link text.'
+		);
+	}
+}

--- a/tests/Integration/TemplateTagsTest.php
+++ b/tests/Integration/TemplateTagsTest.php
@@ -356,48 +356,59 @@ class TemplateTagsTest extends TestCase {
 	/**
 	 * Checks single co-author if he/she is a guest author.
 	 *
+	 * The function must use the $author object's own display_name and user_url
+	 * rather than the global $authordata, so it remains correct regardless of
+	 * which author object the loop currently has in the global state.
+	 *
 	 * @covers ::coauthors_links_single()
 	 */
 	public function test_coauthors_links_single_when_guest_author(): void {
 
-		global $post, $authordata;
+		global $post;
 
 		// Backing up global post.
 		$post_backup = $post;
+		$post        = $this->post;
 
-		$post = $this->post;
-
-		// Backing up global author data.
-		$authordata_backup = $authordata;
-		$authordata        = $this->author1;
-
-		// Shows that it's necessary to set $authordata to $this->author1
-		$this->assertEquals( $authordata, $this->author1, 'Global $authordata not matching expected $this->author1.' );
-
+		// Without a URL set, the function should return the display name as plain text.
 		$this->author1->type = 'guest-author';
+		$author_link         = coauthors_links_single( $this->author1 );
 
-		$this->assertEquals( get_the_author_link(), coauthors_links_single( $this->author1 ), 'Co-Author link generation differs from Core author link one (without user_url)' );
+		$this->assertEquals(
+			esc_html( $this->author1->display_name ),
+			$author_link,
+			'Co-author link should be plain display name when no URL is set.'
+		);
 
+		// Update the user_url and re-fetch to simulate the $author object having a URL.
 		wp_update_user(
 			array(
 				'ID'       => $this->author1->ID,
-				'user_url' => 'example.org',
+				'user_url' => 'https://example.org',
 			)
 		);
-		$authordata = get_userdata( $this->author1->ID ); // Because wp_update_user flushes cache, but does not update global var
+		$author_with_url       = get_userdata( $this->author1->ID );
+		$author_with_url->type = 'guest-author';
 
-		$this->assertEquals( get_the_author_link(), coauthors_links_single( $this->author1 ), 'Co-Author link generation differs from Core author link one (with user_url)' );
+		$author_link = coauthors_links_single( $author_with_url );
 
-		$author_link = coauthors_links_single( $this->author1 );
-		$this->assertStringContainsString( get_the_author_meta( 'url' ), $author_link, 'Author url not found in link.' );
-		$this->assertStringContainsString( get_the_author(), $author_link, 'Author name not found in link.' );
+		$this->assertStringContainsString(
+			$author_with_url->user_url,
+			$author_link,
+			'Author URL must appear in the link href.'
+		);
+		$this->assertStringContainsString(
+			$author_with_url->display_name,
+			$author_link,
+			'Author display name must appear in the link text.'
+		);
 
-		// Here we are checking author name should not be more than one time.
-		// Asserting ">get_the_author()<" because "get_the_author()" can be multiple times like in href, title, etc.
-		$this->assertEquals( 1, substr_count( $author_link, '>' . get_the_author() . '<' ) );
-
-		// Restore global author data from backup.
-		$authordata = $authordata_backup;
+		// The display name should appear exactly once as the visible link text.
+		$this->assertEquals(
+			1,
+			substr_count( $author_link, '>' . $author_with_url->display_name . '<' ),
+			'Author display name must appear exactly once as visible link text.'
+		);
 
 		// Restore global post from backup.
 		$post = $post_backup;
@@ -406,83 +417,76 @@ class TemplateTagsTest extends TestCase {
 	/**
 	 * Checks single co-author when user's url is set and not a guest author.
 	 *
+	 * The function must use the $author object's own user_url property directly.
+	 *
 	 * @covers ::coauthors_links_single()
 	 */
 	public function test_coauthors_links_single_author_url_is_set(): void {
 
-		global $post, $authordata;
+		global $post;
 
 		// Backing up global post.
 		$post_backup = $post;
-
-		$post = $this->post;
-
-		// Backing up global author data.
-		$authordata_backup = $authordata;
+		$post        = $this->post;
 
 		$user_id = $this->factory()->user->create(
 			array(
-				'user_url' => 'example.org',
+				'user_url' => 'https://example.org',
 			)
 		);
-		$user    = get_user_by( 'id', $user_id );
+		$user = get_user_by( 'id', $user_id );
 
-		$authordata  = $user;
 		$author_link = coauthors_links_single( $user );
 
-		$this->assertStringContainsString( get_the_author_meta( 'url' ), $author_link, 'Author link not found.' );
-		$this->assertStringContainsString( get_the_author(), $author_link, 'Author name not found.' );
+		$this->assertStringContainsString( $user->user_url, $author_link, 'Author URL not found in link.' );
+		$this->assertStringContainsString( $user->display_name, $author_link, 'Author display name not found in link.' );
 
-		// Here we are checking author name should not be more than one time.
-		// Asserting ">get_the_author()<" because "get_the_author()" can be multiple times like in href, title, etc.
-		$this->assertEquals( 1, substr_count( $author_link, '>' . get_the_author() . '<' ) );
-
-		// Restore global author data from backup.
-		$authordata = $authordata_backup;
+		// The display name should appear exactly once as the visible link text.
+		$this->assertEquals(
+			1,
+			substr_count( $author_link, '>' . $user->display_name . '<' ),
+			'Author display name must appear exactly once as visible link text.'
+		);
 
 		// Restore global post from backup.
 		$post = $post_backup;
 	}
 
 	/**
-	 * Checks single co-author when user's website/url not exist.
+	 * Checks single co-author when user's website/url do not exist.
+	 *
+	 * The function must return just the display name from the $author object,
+	 * not from the global $authordata.
 	 *
 	 * @covers ::coauthors_links_single()
 	 */
 	public function test_coauthors_links_single_when_url_not_exist(): void {
-		global $wp_version;
-		if ( PHP_VERSION_ID >= 80100 && version_compare( $wp_version, '6.3.0', '<' ) ) {
-			/*
-			 * Ignoring PHP 8.1 "null to non-nullable" deprecation that is fixed in WP 6.3.
-			 *
-			 * @see https://core.trac.wordpress.org/ticket/58157
-			*/
-			$this->markTestSkipped( 'PHP 8.1 gives a deprecation notice that is fixed in WP 6.3' );
-		}
 
-		global $post, $authordata;
+		global $post;
 
 		// Backing up global post.
 		$post_backup = $post;
+		$post        = $this->post;
 
-		$post = $this->post;
-
-		// Backing up global author data.
-		$authordata_backup = $authordata;
-
+		// Guest author without a website: should return the display name as plain (escaped) text.
 		$this->editor1->type = 'guest-author';
 
 		$author_link = coauthors_links_single( $this->editor1 );
 
-		$this->assertEquals( get_the_author(), $author_link );
+		$this->assertEquals(
+			esc_html( $this->editor1->display_name ),
+			$author_link,
+			'Guest author without URL should return plain escaped display name.'
+		);
 
-		$authordata  = $this->author1;
+		// Regular WP user without a URL: same expectation.
 		$author_link = coauthors_links_single( $this->author1 );
 
-		$this->assertEquals( get_the_author(), $author_link );
-
-		// Restore global author data from backup.
-		$authordata = $authordata_backup;
+		$this->assertEquals(
+			esc_html( $this->author1->display_name ),
+			$author_link,
+			'WP user without URL should return plain escaped display name.'
+		);
 
 		// Restore global post from backup.
 		$post = $post_backup;


### PR DESCRIPTION
## Summary

Decouples `coauthors_links_single()` from the global `$authordata` and standard WP core functions by reading properties directly from the passed `$author` object. This fixes an issue where names would repeat for guest authors and website links would fail to render.

Fixes #1131

## Changes

### `template-tags.php`

**Before:**
```php
function coauthors_links_single( $author ) {
	if ( 'guest-author' === $author->type && get_the_author_meta( 'website' ) ) {
		return sprintf(
			'<a href="%s" title="%s" rel="author external">%s</a>',
			esc_url( get_the_author_meta( 'website' ) ),
			/* translators: Author display name. */
			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
			esc_html( get_the_author() )
		);
	}

	if ( get_the_author_meta( 'url' ) ) {
		return sprintf(
			'<a href="%s" title="%s" rel="author external">%s</a>',
			esc_url( get_the_author_meta( 'url' ) ),
			/* translators: Author display name. */
			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( get_the_author() ) ) ),
			esc_html( get_the_author() )
		);
	}

	return esc_html( get_the_author() );
}
```

**After:**
```php
function coauthors_links_single( $author ) {
	$display_name = isset( $author->display_name ) ? $author->display_name : '';

	if ( 'guest-author' === $author->type && ! empty( $author->website ) ) {
		return sprintf(
			'<a href="%s" title="%s" rel="author external">%s</a>',
			esc_url( $author->website ),
			/* translators: Author display name. */
			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( $display_name ) ) ),
			esc_html( $display_name )
		);
	}

	$user_url = isset( $author->user_url ) ? $author->user_url : '';
	if ( $user_url ) {
		return sprintf(
			'<a href="%s" title="%s" rel="author external">%s</a>',
			esc_url( $user_url ),
			/* translators: Author display name. */
			esc_attr( sprintf( __( 'Visit %s&#8217;s website', 'co-authors-plus' ), esc_html( $display_name ) ) ),
			esc_html( $display_name )
		);
	}

	return esc_html( $display_name );
}
```

**Why:** Using the `$author` object directly avoids triggering the `the_author` filter (which returns all co-authors joined when auto-apply is enabled) and allows retrieving guest author website metadata that isn't stored in the WP user tables.

## Testing

**Test 1: Multiple Guest Authors with Website**
1. Create 3 guest authors, one with a website URL.
2. Enable `coauthors_auto_apply_template_tags` filter.
3. Display authors using `coauthors_links()`.

Result: Each unique name is listed correctly, and the website link is rendered.

## Build
[co-authors-plus-fix-1131.zip](https://github.com/user-attachments/files/27190082/co-authors-plus-fix-1131.zip) available for manual testing.
Install via WP Admin → Plugins → Upload Plugin.