### PR TITLE
Tear down template filter globals between test cases

### DIFF
--- a/tests/Integration/TemplateTags/CoauthorsLinksSingleTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsLinksSingleTest.php
@@ -16,6 +16,28 @@ class CoauthorsLinksSingleTest extends TestCase {
 	use \Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
 
 	/**
+	 * Tear down test state.
+	 *
+	 * `CoAuthors_Template_Filters::__construct()` registers `the_author` and
+	 * `the_author_posts_link` filters globally. Tests in this class instantiate
+	 * it, so we must unhook those filters and unset the global instance to
+	 * prevent state from leaking into later tests in the suite.
+	 */
+	public function tear_down() {
+		global $coauthors_plus_template_filters;
+
+		if ( $coauthors_plus_template_filters instanceof \CoAuthors_Template_Filters ) {
+			remove_filter( 'the_author', array( $coauthors_plus_template_filters, 'filter_the_author' ) );
+			remove_filter( 'the_author_posts_link', array( $coauthors_plus_template_filters, 'filter_the_author_posts_link' ) );
+			remove_filter( 'the_author', array( $coauthors_plus_template_filters, 'filter_the_author_rss' ), 15 );
+		}
+
+		$coauthors_plus_template_filters = null;
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Test that coauthors_links() outputs each guest author's display name
 	 * exactly once when a post has multiple guest authors.
 	 *


### PR DESCRIPTION
## Summary

Follow-up to #1255.

`CoauthorsLinksSingleTest::test_coauthors_links_shows_each_guest_author_name_once` instantiates `CoAuthors_Template_Filters` to recreate the auto-applying-byline scenario from the bug report. Its constructor registers `the_author`, `the_author_posts_link`, and a second `the_author` (priority 15) filter on global hook lists, and the test never unhooks them. PHPUnit's WordPress integration test base resets a lot of global state between tests, but registered filters survive — so any later test in the run that calls `get_the_author()` on a single-author post inherits the auto-applied byline filter and gets back something like "Author A, Author B" instead of "Author A". That's the kind of leak that surfaces as flakiness depending on test ordering rather than a clean failure.

The PR adds a `tear_down()` that removes the three filters and clears the global `$coauthors_plus_template_filters` so the suite goes back to a clean slate after the class runs.

## Test plan

- [ ] `composer test:integration` — full suite green (221 tests, 842 assertions locally).
- [ ] `composer test:integration-ms` — multisite suite green.