### PR TITLE
Sync 4.0.2 release commits back to develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Multiple byline management for WordPress, supporting both WordPress users and gu
 | **Class prefix** | `CoAuthors_` (legacy), `CoAuthors\` / `Automattic\CoAuthorsPlus\` (namespaced) |
 | **Function prefix** | `cap_` (helpers), `coauthors*` (template tags) |
 | **Source directory** | `php/` (PHP classes), `src/` (JS/blocks) |
-| **Version** | 4.0.1 |
+| **Version** | 4.0.2 |
 | **Requires PHP** | 7.4+ |
 | **Requires WP** | 6.4+ |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2026-04-29
+
+### Changed
+
+* `coauthors_links_single()` now reads `display_name`, `website`, and `user_url` directly from the passed `$author` object rather than via `get_the_author()` / `get_the_author_meta()`. This fixes the long-standing bug where every byline rendered as the first author's name and where guest-author websites never linked, but it does mean `the_author`, `the_author_meta`, and `author_meta` filters no longer apply when the function is called. Plugins that previously hooked those filters to amend bylines will need to filter at a different layer by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1255
+
+### Fixed
+
+* Stop the editor dropping the current user when a co-author term can't be resolved, and never persist a termless post on REST save by @GaryJones in https://github.com/Automattic/Co-Authors-Plus/pull/1253
+* Render each guest author's own name and website on bylines emitted via `coauthors_links()` / `coauthors_links_single()` (was duplicating the first author and dropping guest-author website links), fixing #1131 by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1255
+* Extend author SQL filters to support `author__in` and comma-separated author IDs by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1249
+* Clear conflicting `WP_Query` flags on guest author pages to prevent PHP warnings and category-query conflicts by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1250
+
+### Maintenance
+
+* Extract shared taxonomy clause helpers in `posts_where_filter()` to deduplicate the multi-author query path by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1251
+* Tear down `CoAuthors_Template_Filters` registrations between test cases to stop them leaking into other suites by @GaryJones in https://github.com/Automattic/Co-Authors-Plus/pull/1256
+* Exclude `AGENTS.md` and `CONTRIBUTING.md` from the distribution ZIP by @GaryJones in https://github.com/Automattic/Co-Authors-Plus/pull/1246
+
+### Documentation
+
+* Use an absolute GitHub link for the changelog URL in the README by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1247
+* Correct the plugin ZIP filename in the installation guide by @faisalahammad in https://github.com/Automattic/Co-Authors-Plus/pull/1248
+
 ## [4.0.1] - 2026-04-24
 
 ### Fixed
@@ -656,6 +680,7 @@ Props to the many people who helped make this release possible: [catchmyfame](ht
 **1.1.0 (Apr. 14, 2009)**
 * Initial beta release.
 
+[4.0.2]: https://github.com/automattic/co-authors-plus/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/automattic/co-authors-plus/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/automattic/co-authors-plus/compare/3.7.0...4.0.0
 [3.7.0]: https://github.com/automattic/co-authors-plus/compare/3.6.6...3.7.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Co-Authors Plus
 
-Stable tag: 4.0.1  
+Stable tag: 4.0.2  
 Requires at least: 6.4  
 Tested up to: 6.9  
 Requires PHP: 7.4  

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -11,7 +11,7 @@
  * Plugin Name:       Co-Authors Plus
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
- * Version:           4.0.1
+ * Version:           4.0.2
  * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
@@ -21,7 +21,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const COAUTHORS_PLUS_VERSION = '4.0.1';
+const COAUTHORS_PLUS_VERSION = '4.0.2';
 const COAUTHORS_PLUS_FILE = __FILE__;
 
 require_once __DIR__ . '/template-tags.php';

--- a/languages/co-authors-plus.pot
+++ b/languages/co-authors-plus.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Co-Authors Plus 4.0.1\n"
+"Project-Id-Version: Co-Authors Plus 4.0.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/co-authors-plus\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-24T20:54:32+00:00\n"
+"POT-Creation-Date: 2026-04-29T15:40:21+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: co-authors-plus\n"
@@ -229,7 +229,7 @@ msgstr ""
 #: php/blocks/block-coauthor-image/class-block-coauthor-image.php:119
 #: php/blocks/block-coauthor-name/class-block-coauthor-name.php:72
 #: template-tags.php:248
-#: template-tags.php:644
+#: template-tags.php:658
 #, php-format
 msgid "Posts by %s"
 msgstr ""
@@ -612,8 +612,9 @@ msgstr ""
 #: php/class-coauthors-plus.php:470
 #: php/class-coauthors-plus.php:600
 #: php/class-coauthors-plus.php:690
-#: php/class-coauthors-plus.php:1904
-#: php/class-coauthors-plus.php:2200
+#: php/class-coauthors-plus.php:2155
+#: php/class-coauthors-plus.php:2451
+#: build/index.js:1
 #: src/index.js:24
 msgid "Authors"
 msgstr ""
@@ -628,7 +629,7 @@ msgstr ""
 
 #: php/class-coauthors-plus.php:547
 #: php/class-coauthors-plus.php:692
-#: php/class-coauthors-plus.php:1626
+#: php/class-coauthors-plus.php:1877
 msgid "Click on an author to change them. Drag to change their order. Click on <strong>Remove</strong> to remove them."
 msgstr ""
 
@@ -646,43 +647,43 @@ msgstr ""
 msgid "No co-author exists for that term"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1113
-#: php/class-coauthors-plus.php:1141
+#: php/class-coauthors-plus.php:1351
+#: php/class-coauthors-plus.php:1379
 msgid "This filter is deprecated when saving via the REST API and will be removed in a future version. Use the set_object_terms action for the author taxonomy instead."
 msgstr ""
 
-#: php/class-coauthors-plus.php:1621
+#: php/class-coauthors-plus.php:1872
 #: php/class-coauthors-wp-list-table.php:239
 msgid "Edit"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1622
+#: php/class-coauthors-plus.php:1873
 msgid "Remove"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1623
+#: php/class-coauthors-plus.php:1874
 msgid "Are you sure you want to remove this author?"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1624
+#: php/class-coauthors-plus.php:1875
 msgid "Click to change this author, or drag to change their position"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1625
+#: php/class-coauthors-plus.php:1876
 msgid "Search for an author"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1667
+#: php/class-coauthors-plus.php:1918
 msgid "Mine"
 msgstr ""
 
 #. translators: Author display name.
-#: php/class-coauthors-plus.php:2065
+#: php/class-coauthors-plus.php:2316
 #, php-format
 msgid "Author: %s"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2203
+#: php/class-coauthors-plus.php:2454
 msgid "Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors."
 msgstr ""
 
@@ -777,162 +778,214 @@ msgid "Written by"
 msgstr ""
 
 #. translators: Author display name.
-#: template-tags.php:418
-#: template-tags.php:428
+#: template-tags.php:430
+#: template-tags.php:442
 #, php-format
 msgid "Visit %s&#8217;s website"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:95
 msgid "Avatar Settings"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:97
 msgid "Avatar size"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:107
 msgid "Make avatar a link to author archive."
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
+#: build/blocks/block-coauthor-name/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:117
 #: src/blocks/block-coauthor-image/edit.js:176
 #: src/blocks/block-coauthor-name/edit.js:86
 msgid "Link rel"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
+#: build/blocks/block-coauthors/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:128
 #: src/blocks/block-coauthor-image/edit.js:187
 #: src/blocks/block-coauthors/edit.js:265
 msgid "Co-Authors Layout"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:131
 #: src/blocks/block-coauthor-image/edit.js:190
 msgid "Vertical align"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:136
 #: src/blocks/block-coauthor-image/edit.js:195
 msgid "Default"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:140
 #: src/blocks/block-coauthor-image/edit.js:199
 msgid "Baseline"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:144
 #: src/blocks/block-coauthor-image/edit.js:203
 msgid "Bottom"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:148
 #: src/blocks/block-coauthor-image/edit.js:207
 msgid "Middle"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:152
 #: src/blocks/block-coauthor-image/edit.js:211
 msgid "Sub"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:156
 #: src/blocks/block-coauthor-image/edit.js:215
 msgid "Super"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:160
 #: src/blocks/block-coauthor-image/edit.js:219
 msgid "Text Bottom"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:164
 #: src/blocks/block-coauthor-image/edit.js:223
 msgid "Text Top"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:168
 #: src/blocks/block-coauthor-image/edit.js:227
 msgid "Top"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/index.js:1
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-avatar/edit.js:176
 #: src/blocks/block-coauthor-image/edit.js:235
 msgid "Vertical alignment defaults to bottom in the block layout and middle in the inline layout."
 msgstr ""
 
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-image/edit.js:129
 msgid "Author featured image"
 msgstr ""
 
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-image/edit.js:163
 msgid "Image Settings"
 msgstr ""
 
+#: build/blocks/block-coauthor-image/index.js:1
 #: src/blocks/block-coauthor-image/edit.js:166
 msgid "Make featured image a link to author archive."
 msgstr ""
 
+#: build/blocks/block-coauthor-name/index.js:1
 #: src/blocks/block-coauthor-name/edit.js:72
 msgid "Settings"
 msgstr ""
 
+#: build/blocks/block-coauthor-name/index.js:1
 #: src/blocks/block-coauthor-name/edit.js:75
 msgid "Make co-author name a link"
 msgstr ""
 
+#: build/blocks/block-coauthor-name/index.js:1
 #: src/blocks/block-coauthor-name/edit.js:99
 msgid "HTML element"
 msgstr ""
 
+#: build/blocks/block-coauthors/index.js:1
 #: src/blocks/block-coauthors/edit.js:194
 #: src/blocks/block-coauthors/edit.js:196
 msgid "Prefix"
 msgstr ""
 
+#: build/blocks/block-coauthors/index.js:1
 #: src/blocks/block-coauthors/edit.js:269
 msgid "Separator"
 msgstr ""
 
+#: build/blocks/block-coauthors/index.js:1
 #: src/blocks/block-coauthors/edit.js:274
 msgid "Enter character(s) used to separate authors."
 msgstr ""
 
+#: build/blocks/block-coauthors/index.js:1
 #: src/blocks/block-coauthors/edit.js:281
 msgid "Last Separator"
 msgstr ""
 
+#: build/blocks/block-coauthors/index.js:1
 #: src/blocks/block-coauthors/edit.js:286
 msgid "Enter character(s) used to separate the last author."
 msgstr ""
 
+#: build/index.js:1
 #: src/components/author-selection/index.jsx:74
 msgid "Move Up"
 msgstr ""
 
+#: build/index.js:1
 #: src/components/author-selection/index.jsx:85
 msgid "Move down"
 msgstr ""
 
+#: build/index.js:1
 #: src/components/author-selection/index.jsx:102
 msgid "Remove Author"
 msgstr ""
 
-#: src/components/co-authors/index.jsx:156
+#: build/index.js:1
+#: src/components/co-authors/index.jsx:171
 msgid "Select An Author"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/block.json
 #: src/blocks/block-coauthor-avatar/block.json
 msgctxt "block title"
 msgid "Co-Author Avatar"
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/block.json
 #: src/blocks/block-coauthor-avatar/block.json
 msgctxt "block description"
 msgid "Displays a small scale version of a co-author's avatar. Utilizes fallbacks from Gravatar so everyone has an avatar."
 msgstr ""
 
+#: build/blocks/block-coauthor-avatar/block.json
+#: build/blocks/block-coauthor-description/block.json
+#: build/blocks/block-coauthor-image/block.json
+#: build/blocks/block-coauthor-name/block.json
 #: src/blocks/block-coauthor-avatar/block.json
 #: src/blocks/block-coauthor-description/block.json
 #: src/blocks/block-coauthor-image/block.json
@@ -941,56 +994,67 @@ msgctxt "block keyword"
 msgid "coauthors"
 msgstr ""
 
+#: build/blocks/block-coauthor-description/block.json
 #: src/blocks/block-coauthor-description/block.json
 msgctxt "block title"
 msgid "Co-Author Biography"
 msgstr ""
 
+#: build/blocks/block-coauthor-description/block.json
 #: src/blocks/block-coauthor-description/block.json
 msgctxt "block description"
 msgid "Displays a co-author's biographical description."
 msgstr ""
 
+#: build/blocks/block-coauthor-description/block.json
 #: src/blocks/block-coauthor-description/block.json
 msgctxt "block keyword"
 msgid "description"
 msgstr ""
 
+#: build/blocks/block-coauthor-description/block.json
 #: src/blocks/block-coauthor-description/block.json
 msgctxt "block keyword"
 msgid "bio"
 msgstr ""
 
+#: build/blocks/block-coauthor-description/block.json
 #: src/blocks/block-coauthor-description/block.json
 msgctxt "block keyword"
 msgid "biography"
 msgstr ""
 
+#: build/blocks/block-coauthor-image/block.json
 #: src/blocks/block-coauthor-image/block.json
 msgctxt "block title"
 msgid "Co-Author Featured Image"
 msgstr ""
 
+#: build/blocks/block-coauthor-image/block.json
 #: src/blocks/block-coauthor-image/block.json
 msgctxt "block description"
 msgid "Uses your theme's image sizes to display a scalable avatar for a co-author with a guest author profile. Does not fallback to Gravatar images."
 msgstr ""
 
+#: build/blocks/block-coauthor-name/block.json
 #: src/blocks/block-coauthor-name/block.json
 msgctxt "block title"
 msgid "Co-Author Name"
 msgstr ""
 
+#: build/blocks/block-coauthor-name/block.json
 #: src/blocks/block-coauthor-name/block.json
 msgctxt "block description"
 msgid "Displays a co-author's display name and optionally links to their author archive."
 msgstr ""
 
+#: build/blocks/block-coauthors/block.json
 #: src/blocks/block-coauthors/block.json
 msgctxt "block title"
 msgid "Co-Authors"
 msgstr ""
 
+#: build/blocks/block-coauthors/block.json
 #: src/blocks/block-coauthors/block.json
 msgctxt "block description"
 msgid "Displays the co-authors of a post by using blocks to create a template. Start with co-author name and add any other co-author blocks."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "co-authors-plus",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "co-authors-plus",
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.44.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "co-authors-plus",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"description": "Allows multiple authors to be assigned to a post.",
 	"license": "GPL-2.0-or-later",
 	"private": true,


### PR DESCRIPTION
## Summary

Post-release sync after 4.0.2 (#1257). Brings the three release commits (changelog, i18n, version bumps) from `main` onto `develop` so the two branches align before the next development cycle, mirroring #1245 for the previous release.

No code changes beyond what was reviewed in #1257.