### PR TITLE
Honour Archive Title block showPrefix toggle on author archives

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -113,7 +113,7 @@ class CoAuthors_Plus {
 		add_action( 'set_object_terms', array( $this, 'clear_cache_on_terms_set' ), 10, 6 );
 
 		// Filter to correct author on author archive page
-		add_filter( 'get_the_archive_title', array( $this, 'filter_author_archive_title' ) );
+		add_filter( 'get_the_archive_title', array( $this, 'filter_author_archive_title' ), 10, 3 );
 
 		// Filter to display author image if exists instead of avatar
 		add_filter( 'pre_get_avatar_data', array( $this, 'filter_pre_get_avatar_data_url' ), 10, 2 );
@@ -2291,29 +2291,44 @@ class CoAuthors_Plus {
 	}
 
 	/**
-	 * Filter of the header of author archive pages to correctly display author.
+	 * Filter the author archive title so the displayed name reflects the co-author
+	 * (including guest authors), while preserving whatever prefix core resolved.
 	 *
-	 * @param $title string Archive Page Title
+	 * The third filter argument carries the prefix that core actually used after
+	 * `get_the_archive_title_prefix` filters ran, so the core/query-title block's
+	 * `showPrefix` toggle is honoured.
 	 *
-	 * @return string Archive Page Title
+	 * @param string $title          Archive title.
+	 * @param string $original_title Archive title without prefix. Unused.
+	 * @param string $prefix         Archive title prefix as resolved by core.
+	 * @return string Archive title.
 	 */
-	public function filter_author_archive_title( $title ): string {
+	public function filter_author_archive_title( $title, $original_title = '', $prefix = '' ): string {
 
-		// Bail if not an author archive template
+		// Bail if not an author archive template.
 		if ( ! is_author() ) {
 			return $title;
 		}
 
 		$author_name_var = get_query_var( 'author_name' );
-		if ( ! is_string( $author_name_var ) ) {
+		if ( ! is_string( $author_name_var ) || '' === $author_name_var ) {
 			return $title;
 		}
 
 		$author_slug = sanitize_user( $author_name_var );
 		$author      = $this->get_coauthor_by( 'user_nicename', $author_slug );
 
-		/* translators: Author display name. */
-		return sprintf( __( 'Author: %s', 'co-authors-plus' ), $author->display_name );
+		if ( ! is_object( $author ) || empty( $author->display_name ) ) {
+			return $title;
+		}
+
+		if ( '' === $prefix ) {
+			return $author->display_name;
+		}
+
+		// Match core's `%1$s %2$s` archive-title format. The translatable part
+		// is the prefix, which core has already resolved before reaching here.
+		return sprintf( '%1$s %2$s', $prefix, $author->display_name );
 	}
 
 	/**

--- a/tests/Integration/FilterAuthorArchiveTitleTest.php
+++ b/tests/Integration/FilterAuthorArchiveTitleTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * @covers \CoAuthors_Plus::filter_author_archive_title()
+ */
+class FilterAuthorArchiveTitleTest extends TestCase {
+
+	public function tear_down(): void {
+		remove_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Default behaviour: the prefix core resolved (e.g. "Author:") is preserved
+	 * and the co-author's display name is rendered.
+	 */
+	public function test_user_author_archive_keeps_prefix_by_default(): void {
+		$author = $this->factory()->user->create_and_get(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'jane-doe',
+				'display_name' => 'Jane Doe',
+			)
+		);
+		$this->create_post( $author );
+
+		$this->go_to( home_url( '/?author_name=' . $author->user_nicename ) );
+
+		$this->assertSame( 'Author: Jane Doe', get_the_archive_title() );
+	}
+
+	/**
+	 * When the core/query-title block has `showPrefix` set to false it hooks
+	 * `get_the_archive_title_prefix` to return an empty string. The author
+	 * archive title must then render without the "Author:" prefix.
+	 *
+	 * @see https://wordpress.org/support/topic/author-being-added-on-single-author-template/
+	 */
+	public function test_user_author_archive_drops_prefix_when_show_prefix_is_disabled(): void {
+		$author = $this->factory()->user->create_and_get(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'jane-doe',
+				'display_name' => 'Jane Doe',
+			)
+		);
+		$this->create_post( $author );
+
+		$this->go_to( home_url( '/?author_name=' . $author->user_nicename ) );
+
+		add_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
+
+		$this->assertSame( 'Jane Doe', get_the_archive_title() );
+	}
+
+	/**
+	 * Guest authors (no underlying WP_User) must follow the same prefix rule
+	 * as regular user archives — present by default, absent when the block
+	 * disables it.
+	 */
+	public function test_guest_author_archive_respects_show_prefix_toggle(): void {
+		global $coauthors_plus;
+
+		$coauthors_plus->guest_authors->create(
+			array(
+				'user_login'   => 'guest-archive',
+				'display_name' => 'Guest Archive',
+			)
+		);
+
+		$this->go_to( home_url( '/?author_name=guest-archive' ) );
+
+		$this->assertSame( 'Author: Guest Archive', get_the_archive_title() );
+
+		add_filter( 'get_the_archive_title_prefix', '__return_empty_string' );
+
+		$this->assertSame( 'Guest Archive', get_the_archive_title() );
+	}
+
+	/**
+	 * Outside an author archive, the filter must be a no-op.
+	 */
+	public function test_non_author_archive_is_untouched(): void {
+		global $coauthors_plus;
+
+		$result = $coauthors_plus->filter_author_archive_title( 'Untouched', 'Untouched', '' );
+
+		$this->assertSame( 'Untouched', $result );
+	}
+}


### PR DESCRIPTION
## Summary

A user reported that on a Single Author template the "Author:" prefix still appears in front of the name even after untoggling **Show archive type in title** on the Archive Title (`core/query-title`) block ([forum thread](https://wordpress.org/support/topic/author-being-added-on-single-author-template/)).

The cause is in `CoAuthors_Plus::filter_author_archive_title()`. When the block has `showPrefix` set to false it hooks `get_the_archive_title_prefix` to return an empty string, and core then assembles the title without a prefix. CAP's hook on `get_the_archive_title` discarded that resolved title and returned a hard-coded `__( 'Author: %s', 'co-authors-plus' )` regardless, putting the prefix back.

The filter now reads the third argument that core passes (the prefix it actually used after `get_the_archive_title_prefix` filters ran) and reuses it. When the prefix is empty the co-author's display name is returned on its own; when present, it is joined with the same `%1$s %2$s` format core uses, so the existing translated prefix and any RTL-aware formatting continue to apply. The lookup also now bails safely if the co-author cannot be resolved or has no display name, instead of fataling on a property of `null`.

A new integration test covers four cases: registered-user archive with the prefix on, registered-user archive with the prefix toggled off, guest-author archive across both prefix states, and a no-op return when the filter runs outside an author archive.

## Test plan

- [ ] On a block theme, edit the Single Author template, add an Archive Title block with **Show archive type in title** disabled, and confirm the archive renders just the co-author's display name with no `Author:` prefix
- [ ] Re-enable the toggle and confirm `Author: <name>` reappears
- [ ] Repeat both checks for a guest author archive (`?author_name=<guest-slug>`)
- [ ] `composer test:integration -- --filter FilterAuthorArchiveTitleTest`