### PR TITLE
fix: guard get_current_screen() calls to prevent fatal in early-init contexts

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -165,6 +165,12 @@ class CoAuthors_Plus {
 	 * @return bool
 	 */
 	public function is_block_editor( $post = null ): bool {
+		// get_current_screen() is only available after the screen is set up.
+		// Guard against contexts where it has not been loaded yet (e.g. REST saves).
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
 		$screen = get_current_screen();
 
 		// Pre-5.0 compatibility
@@ -442,8 +448,13 @@ class CoAuthors_Plus {
 
 		if ( ! $post_type ) {
 			$post_type = get_post_type();
-			if ( ! $post_type && is_admin() ) {
-				$post_type = get_current_screen()->post_type;
+			// get_current_screen() is only available once the admin screen is initialised.
+			// Bail out of the screen look-up when the function does not exist yet — e.g.
+			// when save_post fires during plugins_loaded from a third-party plugin, or
+			// during a REST / WP-CLI request where the admin screen is never set up.
+			if ( ! $post_type && is_admin() && function_exists( 'get_current_screen' ) ) {
+				$screen    = get_current_screen();
+				$post_type = $screen ? $screen->post_type : '';
 			}
 		}
 

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -166,12 +166,18 @@ class CoAuthors_Plus {
 	 */
 	public function is_block_editor( $post = null ): bool {
 		// get_current_screen() is only available after the screen is set up.
-		// Guard against contexts where it has not been loaded yet (e.g. REST saves).
+		// Guard against contexts where it has not been loaded yet (e.g. REST saves,
+		// or save_post firing during plugins_loaded). The function may exist but
+		// still return null if called before the screen is initialised.
 		if ( ! function_exists( 'get_current_screen' ) ) {
 			return false;
 		}
 
 		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return false;
+		}
 
 		// Pre-5.0 compatibility
 		if ( method_exists( $screen, 'is_block_editor' ) ) {

--- a/tests/Integration/CoAuthorsPlusTest.php
+++ b/tests/Integration/CoAuthorsPlusTest.php
@@ -225,6 +225,57 @@ class CoAuthorsPlusTest extends TestCase {
 	}
 
 	/**
+	 * Ensures is_post_type_enabled() does not fatal when the admin screen is not
+	 * yet initialised — reproduces the error reported in GitHub issue #1094, where
+	 * a third-party plugin triggered save_post during plugins_loaded before the
+	 * admin screen was set up.
+	 *
+	 * @covers CoAuthors_Plus::is_post_type_enabled()
+	 * @ticket 1094
+	 */
+	public function test_is_post_type_enabled_without_screen_does_not_fatal(): void {
+
+		global $coauthors_plus, $post;
+
+		// Clear the global post so get_post_type() returns nothing.
+		$post_backup = $post;
+		$post        = '';
+
+		// Null out the current screen to simulate a context where the screen has
+		// not been initialised (e.g. save_post fired during plugins_loaded).
+		$screen_backup             = $GLOBALS['current_screen'] ?? null;
+		$GLOBALS['current_screen'] = null;
+
+		// Must not throw or fatal; must return false (post type undetermined).
+		$this->assertFalse( $coauthors_plus->is_post_type_enabled() );
+
+		// Restore globals.
+		$GLOBALS['current_screen'] = $screen_backup;
+		$post                      = $post_backup;
+	}
+
+	/**
+	 * Ensures is_block_editor() returns false gracefully when the admin screen has
+	 * not yet been initialised.
+	 *
+	 * @covers CoAuthors_Plus::is_block_editor()
+	 * @ticket 1094
+	 */
+	public function test_is_block_editor_without_screen_returns_false(): void {
+
+		global $coauthors_plus;
+
+		$screen_backup             = $GLOBALS['current_screen'] ?? null;
+		$GLOBALS['current_screen'] = null;
+
+		// Must not throw or fatal; must return false.
+		$this->assertFalse( $coauthors_plus->is_block_editor() );
+
+		// Restore.
+		$GLOBALS['current_screen'] = $screen_backup;
+	}
+
+	/**
 	 * Checks if the current user can set co-authors or not using current screen.
 	 *
 	 * @covers CoAuthors_Plus::current_user_can_set_authors()


### PR DESCRIPTION
## Summary

`get_current_screen()` is only available after the admin screen is set up, but two methods in `CoAuthors_Plus` called it unconditionally. When `save_post` fires during `plugins_loaded` — as can happen with plugins like Revisionary Pro — this produces a fatal error.

Fixes #1094

## Changes

### `php/class-coauthors-plus.php` — `is_block_editor()`

**Before:**
```php
public function is_block_editor( $post = null ): bool {
    $screen = get_current_screen();
```

**After:**
```php
public function is_block_editor( $post = null ): bool {
    // get_current_screen() is only available after the screen is set up.
    // Guard against contexts where it has not been loaded yet (e.g. REST saves).
    if ( ! function_exists( 'get_current_screen' ) ) {
        return false;
    }

    $screen = get_current_screen();
```

**Why:** Returns `false` (not in block editor) when called before the screen exists, which is always correct in non-admin contexts.

---

### `php/class-coauthors-plus.php` — `is_post_type_enabled()`

**Before:**
```php
if ( ! $post_type && is_admin() ) {
    $post_type = get_current_screen()->post_type;
}
```

**After:**
```php
// get_current_screen() is only available once the admin screen is initialised.
// Bail out of the screen look-up when the function does not exist yet — e.g.
// when save_post fires during plugins_loaded from a third-party plugin, or
// during a REST / WP-CLI request where the admin screen is never set up.
if ( ! $post_type && is_admin() && function_exists( 'get_current_screen' ) ) {
    $screen    = get_current_screen();
    $post_type = $screen ? $screen->post_type : '';
}
```

**Why:** The `function_exists()` guard skips the screen look-up when unavailable. The null check on `$screen` handles AJAX requests where `is_admin()` returns `true` but `get_current_screen()` returns `null`.

## Testing

**Test 1: Fatal no longer occurs on early `save_post`**
1. Add this mu-plugin to simulate the scenario:
```php
// mu-plugins/test-cap-1094.php
add_action( 'plugins_loaded', function() {
    wp_insert_post( [
        'post_title'  => 'Test post',
        'post_status' => 'publish',
        'post_type'   => 'post',
        'post_author' => 1,
    ] );
} );
```
2. Load any admin page.

**Before fix:** Fatal — `Call to undefined function get_current_screen()`  
**After fix:** No fatal. Post created; co-authors assigned from `post_author`.

**Test 2: Normal editing flow unchanged**
1. Create a new post in the block editor — Authors panel appears.
2. Edit an existing post in the classic editor — Co-Authors meta box appears.
3. Add/remove co-authors, save, confirm front-end display.

Result: Works as expected.