### PR TITLE
fix(search): raise search_authors() result cap and gate back-fill by capability

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2078,6 +2078,7 @@ class CoAuthors_Plus {
 		// instead of the user details. If the term is missing, we probably need to
 		// back-fill with user details. Let's do this first... easier than running
 		// an upgrade script that could break on a lot of users
+		$cap         = apply_filters( 'coauthors_edit_author_cap', 'edit_posts' );
 		$args        = array(
 			'count_total'    => false,
 			'search'         => sprintf( '*%s*', $search ),
@@ -2087,22 +2088,31 @@ class CoAuthors_Plus {
 				'user_email',
 				'user_login',
 			),
-			'capability'     => array( apply_filters( 'coauthors_edit_author_cap', 'edit_posts' ) ),
+			'capability'     => array( $cap ),
 			'fields'         => 'all_with_meta',
 		);
+		$args        = apply_filters( 'coauthors_search_authors_get_users_args', $args );
 		$found_users = get_users( $args );
 
 		foreach ( $found_users as $found_user ) {
+			// get_users()'s 'capability' arg bounds the query but isn't the
+			// correctness guarantee; skip back-filling a term for anyone who
+			// doesn't actually hold the capability.
+			if ( ! $found_user->has_cap( $cap ) ) {
+				continue;
+			}
 			$term = $this->get_author_term( $found_user );
 			if ( empty( $term ) || empty( $term->description ) ) {
 				$this->update_author_term( $found_user );
 			}
 		}
 
+		// Raised from 10 to 50 (#1057) so large sites' autocomplete stops silently
+		// truncating matches. Adjust further via the filter below.
 		$args = array(
 			'search' => $search,
 			'get'    => 'all',
-			'number' => 10,
+			'number' => 50,
 		);
 		$args = apply_filters( 'coauthors_search_authors_get_terms_args', $args );
 		add_filter( 'terms_clauses', array( $this, 'filter_terms_clauses' ) );

--- a/tests/Integration/Bylines/SearchAuthorsTest.php
+++ b/tests/Integration/Bylines/SearchAuthorsTest.php
@@ -171,4 +171,101 @@ class SearchAuthorsTest extends TestCase {
 		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
 		$this->assertArrayHasKey( $author2->user_login, $authors );
 	}
+
+	/**
+	 * Checks search_authors() returns all matches when more than 10 share a prefix.
+	 *
+	 * @covers ::search_authors
+	 */
+	public function test_search_authors_returns_all_results_beyond_default_limit(): void {
+
+		global $coauthors_plus;
+
+		$prefix  = 'maxtest';
+		$editors = array();
+
+		for ( $i = 1; $i <= 7; $i++ ) {
+			$editors[] = $this->create_editor( "{$prefix}_editor_{$i}" );
+		}
+
+		$guest_logins = array();
+		for ( $i = 1; $i <= 6; $i++ ) {
+			$guest_logins[] = "{$prefix}_guest_{$i}";
+			$this->create_guest_author( "{$prefix}_guest_{$i}" );
+		}
+
+		$authors = $coauthors_plus->search_authors( $prefix );
+
+		$this->assertGreaterThanOrEqual( 13, count( $authors ) );
+
+		foreach ( $editors as $editor ) {
+			$this->assertArrayHasKey( $editor->user_login, $authors );
+		}
+		foreach ( $guest_logins as $guest_login ) {
+			$this->assertArrayHasKey( $guest_login, $authors );
+		}
+	}
+
+	/**
+	 * Checks search_authors() excludes a subscriber sharing a prefix with an editor.
+	 *
+	 * @covers ::search_authors
+	 */
+	public function test_search_authors_excludes_low_cap_users_from_keyword_search(): void {
+
+		global $coauthors_plus;
+
+		$prefix     = 'capcheck';
+		$editor     = $this->create_editor( "{$prefix}_editor" );
+		$subscriber = $this->create_subscriber( "{$prefix}_subscriber" );
+
+		$authors = $coauthors_plus->search_authors( $prefix );
+
+		$this->assertArrayHasKey( $editor->user_login, $authors );
+		$this->assertArrayNotHasKey( $subscriber->user_login, $authors );
+	}
+
+	/**
+	 * Checks search_authors() does not create an author term for a subscriber.
+	 *
+	 * @covers ::search_authors
+	 */
+	public function test_search_authors_does_not_backfill_terms_for_low_cap_users(): void {
+
+		global $coauthors_plus;
+
+		$prefix     = 'termgrowth';
+		$subscriber = $this->create_subscriber( "{$prefix}_subscriber" );
+
+		$this->assertEmpty( $coauthors_plus->get_author_term( $subscriber ) );
+
+		$coauthors_plus->search_authors( $prefix );
+
+		$this->assertEmpty( $coauthors_plus->get_author_term( $subscriber ) );
+	}
+
+	/**
+	 * Checks search_authors() still includes a user granted the capability
+	 * directly rather than through a role, now that role__in is gone.
+	 *
+	 * Regression test for the case GaryJones reproduced on wp-env WP 7.1:
+	 * capability combined with role__in incorrectly dropped a subscriber
+	 * granted edit_posts directly as a per-user capability.
+	 *
+	 * @covers ::search_authors
+	 */
+	public function test_search_authors_includes_user_with_directly_granted_capability(): void {
+
+		global $coauthors_plus;
+
+		$prefix     = 'directcap';
+		$editor     = $this->create_editor( "{$prefix}_editor" );
+		$subscriber = $this->create_subscriber( "{$prefix}_subscriber" );
+		$subscriber->add_cap( 'edit_posts' );
+
+		$authors = $coauthors_plus->search_authors( $prefix );
+
+		$this->assertArrayHasKey( $editor->user_login, $authors );
+		$this->assertArrayHasKey( $subscriber->user_login, $authors );
+	}
 }


### PR DESCRIPTION
## Summary

`search_authors()` uses a two-phase approach: first `get_users()` back-fills author taxonomy terms for matching WP users, then `get_terms()` searches those term descriptions. Two separate bugs meant search results were silently incomplete on many sites.

Fixes #1057

## Changes

### `php/class-coauthors-plus.php`

**Change 1 — Raise the 10-result cap to 50 in `get_terms()`**

**Before:**
```php
$args = array(
    'search' => $search,
    'get'    => 'all',
    'number' => 10,
);
```

**After:**
```php
$args = array(
    'search' => $search,
    'get'    => 'all',
    'number' => 50,
);
```

**Why:** A hard cap of 10 silently truncated autocomplete results whenever more than 10 authors matched. 50 keeps the query bounded while fixing the common case of 11+ matches. Sites can still adjust the cap via `coauthors_search_authors_get_terms_args`.

---

**Change 2 — Keep the `capability` constraint on the back-fill `get_users()` query, gate term creation by `has_cap()`**

**Before (this PR's earlier revision):**
```php
$cap = apply_filters( 'coauthors_edit_author_cap', 'edit_posts' );
$args = array(
    'count_total'    => false,
    'search'         => sprintf( '*%s*', $search ),
    'search_columns' => array( 'ID', 'display_name', 'user_email', 'user_login' ),
    'capability'     => array( $cap ),
    'role__in'       => $this->get_roles_with_cap( $cap ),
    'fields'         => 'all_with_meta',
);
$args = apply_filters( 'coauthors_search_authors_get_users_args', $args );
$found_users = get_users( $args );
```

**After:**
```php
$cap = apply_filters( 'coauthors_edit_author_cap', 'edit_posts' );
$args = array(
    'count_total'    => false,
    'search'         => sprintf( '*%s*', $search ),
    'search_columns' => array( 'ID', 'display_name', 'user_email', 'user_login' ),
    'capability'     => array( $cap ),
    'fields'         => 'all_with_meta',
);
$args = apply_filters( 'coauthors_search_authors_get_users_args', $args );
$found_users = get_users( $args );

foreach ( $found_users as $found_user ) {
    if ( ! $found_user->has_cap( $cap ) ) {
        continue;
    }
    // ...back-fill as before
}
```

**Why:** `role__in` (derived from the capability via a new `get_roles_with_cap()` helper) was added in an earlier revision to make the back-fill query more reliable on multisite/wp-env. Tracing `WP_User_Query::prepare_query()` and reproducing on wp-env (WP 7.1) showed this doesn't hold up: `capability` already expands internally to match every role that grants it, so `role__in` selects the same users on the happy path. The two arguments combine with AND, so `role__in` can never rescue a case where `capability` returns empty, only narrow it — and it does narrow it: a user granted the capability directly (not through a role) passes `capability` but fails `role__in`, and was incorrectly dropped from back-fill.

`role__in` and `get_roles_with_cap()` are removed. What stays: `capability` on the back-fill query, a `has_cap( $cap )` check in the back-fill loop before any term is created or updated (so a low-capability user can't get a term back-filled even if one somehow surfaced from `get_users()`), and the `coauthors_search_authors_get_users_args` filter so sites can further customize or short-circuit the back-fill query.

## Deploy Notes

No new dependencies. This is a pure PHP behavior change to `CoAuthors_Plus::search_authors()`:
- The `get_terms()` result limit for author-search autocomplete rises from 10 to 50. Both `coauthors_search_authors_get_terms_args` (existing) and `coauthors_search_authors_get_users_args` (new) remain available for sites that need different limits or a different back-fill query.
- The back-fill `get_users()` call runs a `has_cap()` check per user before creating or updating a term — this doesn't change term-creation behavior versus current `develop`, it's a safeguard against a side effect a low-capability user's term back-fill would otherwise leave behind.
- Sites with very large low-privilege user bases that find the back-fill query slow can use `coauthors_search_authors_get_users_args` to further constrain or short-circuit it.

## Testing

Four integration tests cover the new behavior:

1. `test_search_authors_returns_all_results_beyond_default_limit` — 13 matching authors (7 WP + 6 guest) are all returned.
2. `test_search_authors_excludes_low_cap_users_from_keyword_search` — a subscriber sharing a search prefix with an editor is excluded.
3. `test_search_authors_does_not_backfill_terms_for_low_cap_users` — subscribers do not get author terms created during search.
4. `test_search_authors_includes_user_with_directly_granted_capability` — a user granted the capability directly (not through a role) still appears in results, guarding against the regression `role__in` introduced.

Manual tests:

1. Create 7+ editors and 6+ guest authors with `maxtest` in their display name, then search `maxtest` in the Authors panel. All 13+ should appear.
2. Create a subscriber and an editor with `capcheck` in their display name, search `capcheck`. Only the editor should appear.
3. Create a subscriber with `termgrowth` in their display name, search `termgrowth`, and confirm no author term is created for the subscriber.

## Build

[co-authors-plus-fix-1057-v2.zip](https://github.com/user-attachments/files/placeholder.zip) available for manual testing.

Install via _WP Admin → Plugins → Upload Plugin_.
