### PR TITLE
Enhancement: Add export-coauthors and import-coauthors WP-CLI commands

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1210,35 +1210,19 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		WP_CLI::log( sprintf( 'Found %d guest author(s).', $total ) );
 
 		// make_progress_bar is only available when WP-CLI is fully bootstrapped
-		// (not during PHPUnit integration tests). Provide a no-op fallback so
-		// both contexts work without branching the test helpers.
-		if ( function_exists( '\WP_CLI\Utils\make_progress_bar' ) ) {
-			$progress = \WP_CLI\Utils\make_progress_bar( 'Exporting guest authors...', $total );
-		} else {
-			// No-op fallback: tick()/finish() calls become safe no-ops in test context.
-			$progress = new class() {
-				/**
-				 * Advance the progress bar (no-op in test context).
-				 *
-				 * @param int $increment Unused.
-				 * @return void
-				 */
-				public function tick( int $increment = 1 ): void {}
-				/**
-				 * Finish the progress bar (no-op in test context).
-				 *
-				 * @return void
-				 */
-				public function finish(): void {}
-			};
-		}//end if
+		// (not during PHPUnit integration tests). Use null + guards instead.
+		$progress = function_exists( '\WP_CLI\Utils\make_progress_bar' )
+			? \WP_CLI\Utils\make_progress_bar( 'Exporting guest authors...', $total )
+			: null;
 
 		foreach ( $guest_author_ids as $ga_id ) {
 			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $ga_id );
 
 			if ( ! $guest_author ) {
 				WP_CLI::warning( sprintf( 'Could not load guest author with ID %d; skipping.', $ga_id ) );
-				$progress->tick();
+				if ( $progress ) {
+					$progress->tick();
+				}
 				continue;
 			}//end if
 
@@ -1288,7 +1272,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 						$wpdb->prepare(
 							// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder,WordPress.DB.PreparedSQL.NotPrepared
 							'SELECT ID, post_name, post_type FROM ' . $wpdb->posts . ' WHERE ID IN (' . $id_placeholders . ')',
-							...$post_ids
+							$post_ids
 						),
 						OBJECT_K
 					);
@@ -1308,10 +1292,14 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'post_refs' => $post_refs,
 			);
 
-			$progress->tick();
+			if ( $progress ) {
+				$progress->tick();
+			}
 		}//end foreach
 
-		$progress->finish();
+		if ( $progress ) {
+			$progress->finish();
+		}
 
 		// Write JSON to file.
 		$json = wp_json_encode( $export, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -106,7 +106,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				wp_set_post_terms( $single_post->ID, array( $author_term->slug ), $coauthors_plus->coauthor_taxonomy );
 				WP_CLI::log( "{$count}/{$total_posts}) Added - Post #{$single_post->ID} '{$single_post->post_title}' now has an author term for: " . $author->user_nicename );
 				$affected++;
-			}
+			}//end foreach
 
 			if ( $count && 0 === $count % 500 ) {
 				$this->stop_the_insanity();
@@ -115,14 +115,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 			$args['paged']++;
 			$posts = new WP_Query( $args );
-		}
+		}//end while
 		WP_CLI::log( 'Updating author terms with new counts' );
 		foreach ( $authors as $author ) {
 			$coauthors_plus->update_author_term( $author );
 		}
 
 		WP_CLI::success( "Done! Of {$total_posts} posts, {$affected} now have author terms." );
-
 	}
 
 	/**
@@ -144,11 +143,11 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @throws Exception If above-post-id is greater than or equal to below-post-id.
 	 */
 	public function create_author_terms_for_posts( $args, $assoc_args ) {
-		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post' ];
-		$post_statuses     = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
+		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : array( 'post' );
+		$post_statuses     = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : array( 'publish' );
 		$batched           = ! isset( $assoc_args['unbatched'] );
 		$records_per_batch = $assoc_args['records-per-batch'] ?? 250;
-		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : [];
+		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : array();
 		$above_post_id     = $assoc_args['above-post-id'] ?? null;
 		$below_post_id     = $assoc_args['below-post-id'] ?? null;
 
@@ -165,8 +164,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		WP_CLI::log( sprintf( 'Found %d posts with missing author terms.', $count_of_posts_with_missing_author_terms ) );
 
-		$authors      = [];
-		$author_terms = [];
+		$authors      = array();
+		$author_terms = array();
 		$count        = 0;
 		$affected     = 0;
 		$page         = 1;
@@ -213,11 +212,11 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 				$insert_author_term_relationship = $wpdb->insert(
 					$wpdb->term_relationships,
-					[
+					array(
 						'object_id'        => $record->post_id,
 						'term_taxonomy_id' => $author_term->term_taxonomy_id,
 						'term_order'       => 0,
-					]
+					)
 				);
 
 				if ( false === $insert_author_term_relationship ) {
@@ -232,11 +231,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				}
 
 				if ( $count && 0 === $count % 500 ) {
-					sleep( 1 ); // Sleep for a second every 500 posts to avoid overloading the database.
+					sleep( 1 ); 
+					// Sleep for a second every 500 posts to avoid overloading the database.
 				}
-			}
+			}//end foreach
 
-			$posts_with_missing_author_terms = [];
+			$posts_with_missing_author_terms = array();
 
 			if ( $batched && $count < $count_of_posts_with_missing_author_terms ) {
 				++$page;
@@ -286,15 +286,15 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function delete_postmeta_skipping_author_term_backfill( $args, $assoc_args ) {
-		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : [];
+		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : array();
 
 		if ( empty( $specific_post_ids ) ) {
 			$query = new WP_Query(
-				[
+				array(
 					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'meta_key' => self::SKIP_POST_FOR_BACKFILL_META_KEY,
 					'fields'   => 'ids',
-				]
+				)
 			);
 
 			$specific_post_ids = $query->get_posts();
@@ -380,12 +380,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' has been assigned "' . $original_author . '" as the author' );
 				$posts_associated++;
 				clean_post_cache( $single_post->ID );
-			}
+			}//end foreach
 
 			$this->args['paged']++;
 			$this->stop_the_insanity();
 			$posts = new WP_Query( $this->args );
-		}
+		}//end while
 
 		WP_CLI::log( 'All done! Here are your results:' );
 		if ( $posts_already_associated ) {
@@ -398,7 +398,6 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		if ( $posts_associated ) {
 			WP_CLI::log( "- {$posts_associated} posts now have the proper co-author" );
 		}
-
 	}
 
 	/**
@@ -455,7 +454,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			if ( $affected && 0 === $affected % 100 ) {
 				sleep( 2 );
 			}
-		}
+		}//end foreach
 
 		$success_message = sprintf(
 			/* translators: Count of posts. */
@@ -468,7 +467,6 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			number_format_i18n( $affected )
 		);
 		WP_CLI::success( $success_message );
-
 	}
 
 	/**
@@ -558,13 +556,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				$results->success++;
 			}
 			clean_term_cache( $old_term->term_id, $coauthors_plus->coauthor_taxonomy );
-		}
+		}//end foreach
 
 		WP_CLI::log( 'Reassignment complete. Here are your results:' );
 		WP_CLI::log( "- $results->success authors were successfully reassigned terms" );
 		WP_CLI::log( "- $results->new_term_exists authors had their old term merged to their new term" );
 		WP_CLI::log( "- $results->old_term_missing authors were missing old terms" );
-
 	}
 
 	/**
@@ -721,8 +718,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					clean_post_cache( $post->ID );
 				} else {
 					WP_CLI::log( $posts_total . ': Post #' . $post->ID . ' will be assigned "' . $to_userlogin . '" as a co-author' );
-				}
-			}
+				}//end if
+			}//end foreach
 
 			// In dry mode, we must manually advance the page
 			if ( $dry ) {
@@ -732,7 +729,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			$this->stop_the_insanity();
 
 			$posts = new WP_Query( $query_args );
-		}
+		}//end while
 
 		WP_CLI::success( 'All done!' );
 	}
@@ -781,8 +778,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 			$this->args['paged']++;
 			$posts = new WP_Query( $this->args );
-		}
-
+		}//end while
 	}
 
 	/**
@@ -821,7 +817,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'slug' => 'cap-' . $author_term->slug,
 			);
 			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
-		}
+		}//end foreach
 		WP_CLI::success( 'All done! Grab a cold one (Affogatto)' );
 	}
 
@@ -894,8 +890,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 				$args['paged']++;
 				$posts = new WP_Query( $args );
-			}
-		}
+			}//end while
+		}//end if
 
 		WP_CLI::success( 'All done' );
 	}
@@ -1067,7 +1063,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			$this->create_guest_author( $guest_author_data );
-		}
+		}//end foreach
 
 		WP_CLI::log( 'All done!' );
 	}
@@ -1129,12 +1125,415 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Export all guest authors and their post associations to a JSON file.
+	 *
+	 * Produces a portable JSON file that can be fed into the `import-coauthors`
+	 * command on a different site (e.g. after a multisite-to-single-site migration).
+	 * Post relationships are stored by slug + post type so they survive the ID
+	 * changes that occur during a WordPress export/import cycle.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--file=<file>]
+	 * : Path to write the JSON output. Defaults to co-authors-export.json in the
+	 *   current working directory.
+	 *
+	 * [--post-types=<csv>]
+	 * : Comma-separated list of post types to include when recording post
+	 *   associations. Defaults to all post types supported by the plugin.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *   wp co-authors-plus export-coauthors --file=/tmp/authors.json
+	 *   wp co-authors-plus export-coauthors --post-types=post,page
+	 *
+	 * @subcommand export-coauthors
+	 * @synopsis [--file=<file>] [--post-types=<csv>]
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function export_coauthors( $args, $assoc_args ): void {
+		global $coauthors_plus;
+
+		$output_file = $assoc_args['file'] ?? 'co-authors-export.json';
+
+		$post_types = isset( $assoc_args['post-types'] )
+			? array_map( 'sanitize_key', explode( ',', $assoc_args['post-types'] ) )
+			: $coauthors_plus->supported_post_types();
+
+		WP_CLI::log( 'Fetching all guest authors...' );
+
+		// Retrieve every guest-author CPT post.
+		$guest_author_query = new WP_Query(
+			array(
+				'post_type'      => $coauthors_plus->guest_authors->post_type,
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+				'fields'         => 'ids',
+			)
+		);
+
+		$export = array(
+			'version'       => COAUTHORS_PLUS_VERSION,
+			'exported_at'   => gmdate( 'Y-m-d\TH:i:s\Z' ),
+			'post_types'    => $post_types,
+			'guest_authors' => array(),
+		);
+
+		$guest_author_ids = $guest_author_query->posts;
+		$total            = count( $guest_author_ids );
+
+		WP_CLI::log( sprintf( 'Found %d guest author(s).', $total ) );
+
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Exporting guest authors...', $total );
+
+		foreach ( $guest_author_ids as $ga_id ) {
+			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $ga_id );
+
+			if ( ! $guest_author ) {
+				WP_CLI::warning( sprintf( 'Could not load guest author with ID %d; skipping.', $ga_id ) );
+				$progress->tick();
+				continue;
+			}
+
+			// Collect all profile fields.
+			$profile = array(
+				'display_name'   => $guest_author->display_name,
+				'user_login'     => $guest_author->user_login,
+				'user_email'     => $guest_author->user_email,
+				'first_name'     => $guest_author->first_name,
+				'last_name'      => $guest_author->last_name,
+				'website'        => $guest_author->website,
+				'description'    => $guest_author->description,
+				'linked_account' => $guest_author->linked_account,
+			);
+
+			// Collect every post this guest author is assigned to, keyed by
+			// slug + post_type so the import can match without relying on IDs.
+			$author_term = $coauthors_plus->get_author_term( $guest_author );
+			$post_refs   = array();
+
+			if ( $author_term ) {
+				$posts = get_posts(
+					array(
+						'post_type'      => $post_types,
+						'posts_per_page' => -1,
+						'post_status'    => 'any',
+						'orderby'        => 'ID',
+						'order'          => 'ASC',
+						'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+							array(
+								'taxonomy' => $coauthors_plus->coauthor_taxonomy,
+								'field'    => 'term_id',
+								'terms'    => array( $author_term->term_id ),
+							),
+						),
+					)
+				);
+
+				foreach ( $posts as $post ) {
+					// Record the ordered position of this author within the post's byline.
+					$coauthors = get_coauthors( $post->ID );
+					$position  = 0;
+					foreach ( $coauthors as $index => $coauthor ) {
+						if ( $coauthor->user_login === $guest_author->user_login ) {
+							$position = $index;
+							break;
+						}
+					}
+
+					$post_refs[] = array(
+						'post_slug' => $post->post_name,
+						'post_type' => $post->post_type,
+						'position'  => $position,
+					);
+				}
+			}//end if
+
+			$export['guest_authors'][] = array(
+				'profile'   => $profile,
+				'post_refs' => $post_refs,
+			);
+
+			$progress->tick();
+		}//end foreach
+
+		$progress->finish();
+
+		// Write JSON to file.
+		$json = wp_json_encode( $export, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+
+		if ( false === $json ) {
+			WP_CLI::error( 'Failed to encode export data as JSON.' );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		if ( false === file_put_contents( $output_file, $json ) ) {
+			WP_CLI::error( sprintf( 'Could not write to file: %s', $output_file ) );
+		}
+
+		WP_CLI::success(
+			sprintf(
+				'Exported %d guest author(s) to %s',
+				count( $export['guest_authors'] ),
+				$output_file
+			)
+		);
+	}
+
+	/**
+	 * Import guest authors and their post associations from a JSON file.
+	 *
+	 * Reads the JSON produced by `export-coauthors`, creates any guest-author
+	 * profiles that do not yet exist on this site, then re-assigns the coauthor
+	 * taxonomy terms to each post by matching on slug + post type. Existing
+	 * coauthor assignments on a post are preserved; the imported author is
+	 * appended or inserted at the recorded position.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --file=<file>
+	 * : Path to the JSON file produced by `export-coauthors`.
+	 *
+	 * [--dry-run]
+	 * : Preview what would be created/assigned without making any changes.
+	 *
+	 * [--skip-create]
+	 * : Skip creating guest author profiles; only re-link posts. Useful when
+	 *   the guest-author CPT posts have already been imported via WP XML import.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *   wp co-authors-plus import-coauthors --file=/tmp/authors.json --dry-run
+	 *   wp co-authors-plus import-coauthors --file=/tmp/authors.json
+	 *   wp co-authors-plus import-coauthors --file=/tmp/authors.json --skip-create
+	 *
+	 * @subcommand import-coauthors
+	 * @synopsis --file=<file> [--dry-run] [--skip-create]
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function import_coauthors( $args, $assoc_args ): void {
+		global $coauthors_plus;
+
+		$input_file  = $assoc_args['file'] ?? '';
+		$dry_run     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$skip_create = \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-create', false );
+
+		if ( empty( $input_file ) || ! is_readable( $input_file ) ) {
+			WP_CLI::error( 'Please specify a valid, readable JSON file with --file.' );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::log( '--- DRY RUN: no changes will be made ---' );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$raw = file_get_contents( $input_file );
+
+		if ( false === $raw ) {
+			WP_CLI::error( sprintf( 'Could not read file: %s', $input_file ) );
+		}
+
+		$data = json_decode( $raw, true );
+
+		if ( null === $data || ! isset( $data['guest_authors'] ) ) {
+			WP_CLI::error( 'Invalid or corrupt export file. Expected JSON with a "guest_authors" key.' );
+		}
+
+		$total            = count( $data['guest_authors'] );
+		$authors_created  = 0;
+		$authors_skipped  = 0;
+		$posts_linked     = 0;
+		$posts_not_found  = 0;
+
+		WP_CLI::log( sprintf( 'Processing %d guest author(s) from %s', $total, $input_file ) );
+
+		foreach ( $data['guest_authors'] as $entry ) {
+			$profile   = $entry['profile'] ?? array();
+			$post_refs = $entry['post_refs'] ?? array();
+
+			$user_login   = sanitize_user( $profile['user_login'] ?? '' );
+			$display_name = sanitize_text_field( $profile['display_name'] ?? '' );
+
+			if ( empty( $user_login ) || empty( $display_name ) ) {
+				WP_CLI::warning( 'Skipping entry with missing user_login or display_name.' );
+				continue;
+			}
+
+			WP_CLI::log( sprintf( 'Processing: %s (%s)', $display_name, $user_login ) );
+
+			// --- Step 1: Ensure the guest author profile exists. ---
+			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', $user_login );
+
+			if ( $guest_author ) {
+				WP_CLI::log( sprintf( '  Profile already exists (ID #%d); skipping creation.', $guest_author->ID ) );
+				$authors_skipped++;
+			} elseif ( $skip_create ) {
+				WP_CLI::log( '  --skip-create set; profile not found but creation skipped.' );
+				$authors_skipped++;
+			} else {
+				WP_CLI::log( '  Profile not found; creating.' );
+
+				if ( ! $dry_run ) {
+					$new_id = $coauthors_plus->guest_authors->create(
+						array(
+							'display_name' => $display_name,
+							'user_login'   => $user_login,
+							'user_email'   => sanitize_email( $profile['user_email'] ?? '' ),
+							'first_name'   => sanitize_text_field( $profile['first_name'] ?? '' ),
+							'last_name'    => sanitize_text_field( $profile['last_name'] ?? '' ),
+							'website'      => esc_url_raw( $profile['website'] ?? '' ),
+							'description'  => wp_filter_post_kses( $profile['description'] ?? '' ),
+						)
+					);
+
+					if ( is_wp_error( $new_id ) ) {
+						WP_CLI::warning(
+							sprintf(
+								'  Failed to create profile for %s: %s',
+								$user_login,
+								$new_id->get_error_message()
+							)
+						);
+						continue;
+					}
+
+					// Re-fetch so we have a full object for the linking step below.
+					$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $new_id );
+					WP_CLI::success( sprintf( '  Created as guest author #%d.', $new_id ) );
+				} else {
+					WP_CLI::log( '  [dry-run] Would create profile.' );
+				}//end if
+
+				$authors_created++;
+			}//end if
+
+			// --- Step 2: Re-link posts by slug + post_type. ---
+			if ( empty( $post_refs ) ) {
+				WP_CLI::log( '  No post associations recorded for this author.' );
+				continue;
+			}
+
+			foreach ( $post_refs as $ref ) {
+				$post_slug = sanitize_title( $ref['post_slug'] ?? '' );
+				$post_type = sanitize_key( $ref['post_type'] ?? 'post' );
+				$position  = absint( $ref['position'] ?? 0 );
+
+				if ( empty( $post_slug ) ) {
+					WP_CLI::warning( '  Skipping post ref with empty slug.' );
+					continue;
+				}
+
+				// Resolve the post on this site by slug + post_type.
+				$matched = get_posts(
+					array(
+						'name'           => $post_slug,
+						'post_type'      => $post_type,
+						'post_status'    => 'any',
+						'posts_per_page' => 1,
+						'no_found_rows'  => true,
+					)
+				);
+
+				if ( empty( $matched ) ) {
+					WP_CLI::warning(
+						sprintf(
+							'  Post not found: slug="%s" post_type="%s"',
+							$post_slug,
+							$post_type
+						)
+					);
+					$posts_not_found++;
+					continue;
+				}
+
+				$post = $matched[0];
+
+				// Check whether this author is already a coauthor for the post by
+				// comparing user_login values directly from the coauthor list.
+				// is_coauthor_for_post() requires an object or numeric ID; we have a
+				// login string, so we check manually — the same pattern used in
+				// assign_coauthors() elsewhere in this class.
+				$existing_logins = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+				if ( in_array( $user_login, $existing_logins, true ) ) {
+					WP_CLI::log(
+						sprintf(
+							'  Post #%d (%s) already has "%s" as a coauthor; skipping.',
+							$post->ID,
+							$post_slug,
+							$user_login
+						)
+					);
+					continue;
+				}
+
+				if ( ! $dry_run ) {
+					// Retrieve current coauthors and insert at the recorded position.
+					$current_coauthors = get_coauthors( $post->ID );
+					$current_logins    = wp_list_pluck( $current_coauthors, 'user_login' );
+
+					// Insert at recorded position, clamped to valid range.
+					$position = min( $position, count( $current_logins ) );
+					array_splice( $current_logins, $position, 0, array( $user_login ) );
+
+					$coauthors_plus->add_coauthors( $post->ID, $current_logins );
+					clean_post_cache( $post->ID );
+
+					WP_CLI::success(
+						sprintf(
+							'  Linked "%s" to post #%d (%s) at position %d.',
+							$user_login,
+							$post->ID,
+							$post_slug,
+							$position
+						)
+					);
+				} else {
+					WP_CLI::log(
+						sprintf(
+							'  [dry-run] Would link "%s" to post #%d (%s) at position %d.',
+							$user_login,
+							$post->ID,
+							$post_slug,
+							$position
+						)
+					);
+				}//end if
+
+				$posts_linked++;
+			}//end foreach
+
+			$this->stop_the_insanity();
+		}//end foreach
+
+		WP_CLI::log( '' );
+		WP_CLI::log( 'Import complete. Results:' );
+		WP_CLI::log( sprintf( '  Guest author profiles created : %d', $authors_created ) );
+		WP_CLI::log( sprintf( '  Guest author profiles skipped : %d', $authors_skipped ) );
+		WP_CLI::log( sprintf( '  Post associations linked       : %d', $posts_linked ) );
+		WP_CLI::log( sprintf( '  Posts not found (slug missing) : %d', $posts_not_found ) );
+
+		if ( $dry_run ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( '--- DRY RUN complete: no changes were made ---' );
+		}
+	}
+
+	/**
 	 * Clear all the caches for memory management.
 	 */
 	private function stop_the_insanity(): void {
 		global $wpdb, $wp_object_cache;
 
-		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
+		// Clear queries; alternatively, define( 'WP_IMPORTING', true ).
+		$wpdb->queries = array();
 
 		if ( ! is_object( $wp_object_cache ) ) {
 			return;
@@ -1146,7 +1545,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$wp_object_cache->cache          = array();
 
 		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-			$wp_object_cache->__remoteset(); // important
+			// Synchronise the remote cache store with the in-memory cache.
+			$wp_object_cache->__remoteset();
 		}
 	}
 
@@ -1163,13 +1563,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return array
 	 * @throws Exception If the $above_post_id is greater than or equal to the $below_post_id.
 	 */
-	private function get_sql_for_posts_with_missing_terms( $author_taxonomy, $post_types = [ 'post' ], $post_statuses = [ 'publish' ], $specific_post_ids = [], $above_post_id = null, $below_post_id = null ) {
+	private function get_sql_for_posts_with_missing_terms( $author_taxonomy, $post_types = array( 'post' ), $post_statuses = array( 'publish' ), $specific_post_ids = array(), $above_post_id = null, $below_post_id = null ) {
 		global $wpdb;
 
-		$sql_and_args = [
+		$sql_and_args = array(
 			'sql'  => '',
-			'args' => [ $author_taxonomy, self::SKIP_POST_FOR_BACKFILL_META_KEY ],
-		];
+			'args' => array( $author_taxonomy, self::SKIP_POST_FOR_BACKFILL_META_KEY ),
+		);
 
 		$post_status_placeholder = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
 		$sql_and_args['args']    = array_merge( $post_statuses, $sql_and_args['args'] );
@@ -1189,7 +1589,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				throw new Exception( 'The $above_post_id param must be less than the $below_post_id param.' );
 			}
 
-			$ids_between_constraint = [];
+			$ids_between_constraint = array();
 
 			if ( null !== $above_post_id ) {
 				array_unshift( $ids_between_constraint, 'ID > %d' );
@@ -1202,7 +1602,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			$from = "( SELECT * FROM $wpdb->posts WHERE " . implode( ' AND ', $ids_between_constraint ) . ' ) as sub';
-		}
+		}//end if
 
 		$sql_and_args['sql'] = "SELECT
 				ID as post_id,
@@ -1242,7 +1642,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return int
 	 * @throws Exception If the $above_post_id is greater than or equal to the $below_post_id.
 	 */
-	private function get_count_of_posts_with_missing_terms( $author_taxonomy, $post_types = [ 'post' ], $post_statuses = [ 'publish' ], $specific_post_ids = [], $above_post_id = null, $below_post_id = null ) {
+	private function get_count_of_posts_with_missing_terms( $author_taxonomy, $post_types = array( 'post' ), $post_statuses = array( 'publish' ), $specific_post_ids = array(), $above_post_id = null, $below_post_id = null ) {
 		global $wpdb;
 
 		[
@@ -1278,7 +1678,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return array
 	 * @throws Exception If the $above_post_id is greater than or equal to the $below_post_id.
 	 */
-	private function get_posts_with_missing_terms( $author_taxonomy, $post_types = [ 'post' ], $post_statuses = [ 'publish' ], $batched = false, $records_per_batch = 250, $specific_post_ids = [], $above_post_id = null, $below_post_id = null ) {
+	private function get_posts_with_missing_terms( $author_taxonomy, $post_types = array( 'post' ), $post_statuses = array( 'publish' ), $batched = false, $records_per_batch = 250, $specific_post_ids = array(), $above_post_id = null, $below_post_id = null ) {
 		global $wpdb;
 
 		[

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -106,7 +106,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				wp_set_post_terms( $single_post->ID, array( $author_term->slug ), $coauthors_plus->coauthor_taxonomy );
 				WP_CLI::log( "{$count}/{$total_posts}) Added - Post #{$single_post->ID} '{$single_post->post_title}' now has an author term for: " . $author->user_nicename );
 				$affected++;
-			}//end foreach
+			}
 
 			if ( $count && 0 === $count % 500 ) {
 				$this->stop_the_insanity();
@@ -115,13 +115,14 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 			$args['paged']++;
 			$posts = new WP_Query( $args );
-		}//end while
+		}
 		WP_CLI::log( 'Updating author terms with new counts' );
 		foreach ( $authors as $author ) {
 			$coauthors_plus->update_author_term( $author );
 		}
 
 		WP_CLI::success( "Done! Of {$total_posts} posts, {$affected} now have author terms." );
+
 	}
 
 	/**
@@ -143,11 +144,11 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @throws Exception If above-post-id is greater than or equal to below-post-id.
 	 */
 	public function create_author_terms_for_posts( $args, $assoc_args ) {
-		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : array( 'post' );
-		$post_statuses     = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : array( 'publish' );
+		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post' ];
+		$post_statuses     = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
 		$batched           = ! isset( $assoc_args['unbatched'] );
 		$records_per_batch = $assoc_args['records-per-batch'] ?? 250;
-		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : array();
+		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : [];
 		$above_post_id     = $assoc_args['above-post-id'] ?? null;
 		$below_post_id     = $assoc_args['below-post-id'] ?? null;
 
@@ -164,8 +165,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		WP_CLI::log( sprintf( 'Found %d posts with missing author terms.', $count_of_posts_with_missing_author_terms ) );
 
-		$authors      = array();
-		$author_terms = array();
+		$authors      = [];
+		$author_terms = [];
 		$count        = 0;
 		$affected     = 0;
 		$page         = 1;
@@ -212,11 +213,11 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 				$insert_author_term_relationship = $wpdb->insert(
 					$wpdb->term_relationships,
-					array(
+					[
 						'object_id'        => $record->post_id,
 						'term_taxonomy_id' => $author_term->term_taxonomy_id,
 						'term_order'       => 0,
-					)
+					]
 				);
 
 				if ( false === $insert_author_term_relationship ) {
@@ -231,12 +232,11 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				}
 
 				if ( $count && 0 === $count % 500 ) {
-					sleep( 1 ); 
-					// Sleep for a second every 500 posts to avoid overloading the database.
+					sleep( 1 ); // Sleep for a second every 500 posts to avoid overloading the database.
 				}
-			}//end foreach
+			}
 
-			$posts_with_missing_author_terms = array();
+			$posts_with_missing_author_terms = [];
 
 			if ( $batched && $count < $count_of_posts_with_missing_author_terms ) {
 				++$page;
@@ -286,15 +286,15 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function delete_postmeta_skipping_author_term_backfill( $args, $assoc_args ) {
-		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : array();
+		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : [];
 
 		if ( empty( $specific_post_ids ) ) {
 			$query = new WP_Query(
-				array(
+				[
 					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'meta_key' => self::SKIP_POST_FOR_BACKFILL_META_KEY,
 					'fields'   => 'ids',
-				)
+				]
 			);
 
 			$specific_post_ids = $query->get_posts();
@@ -380,12 +380,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' has been assigned "' . $original_author . '" as the author' );
 				$posts_associated++;
 				clean_post_cache( $single_post->ID );
-			}//end foreach
+			}
 
 			$this->args['paged']++;
 			$this->stop_the_insanity();
 			$posts = new WP_Query( $this->args );
-		}//end while
+		}
 
 		WP_CLI::log( 'All done! Here are your results:' );
 		if ( $posts_already_associated ) {
@@ -398,6 +398,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		if ( $posts_associated ) {
 			WP_CLI::log( "- {$posts_associated} posts now have the proper co-author" );
 		}
+
 	}
 
 	/**
@@ -454,7 +455,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			if ( $affected && 0 === $affected % 100 ) {
 				sleep( 2 );
 			}
-		}//end foreach
+		}
 
 		$success_message = sprintf(
 			/* translators: Count of posts. */
@@ -467,6 +468,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			number_format_i18n( $affected )
 		);
 		WP_CLI::success( $success_message );
+
 	}
 
 	/**
@@ -556,12 +558,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				$results->success++;
 			}
 			clean_term_cache( $old_term->term_id, $coauthors_plus->coauthor_taxonomy );
-		}//end foreach
+		}
 
 		WP_CLI::log( 'Reassignment complete. Here are your results:' );
 		WP_CLI::log( "- $results->success authors were successfully reassigned terms" );
 		WP_CLI::log( "- $results->new_term_exists authors had their old term merged to their new term" );
 		WP_CLI::log( "- $results->old_term_missing authors were missing old terms" );
+
 	}
 
 	/**
@@ -718,8 +721,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					clean_post_cache( $post->ID );
 				} else {
 					WP_CLI::log( $posts_total . ': Post #' . $post->ID . ' will be assigned "' . $to_userlogin . '" as a co-author' );
-				}//end if
-			}//end foreach
+				}
+			}
 
 			// In dry mode, we must manually advance the page
 			if ( $dry ) {
@@ -729,7 +732,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			$this->stop_the_insanity();
 
 			$posts = new WP_Query( $query_args );
-		}//end while
+		}
 
 		WP_CLI::success( 'All done!' );
 	}
@@ -778,7 +781,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 			$this->args['paged']++;
 			$posts = new WP_Query( $this->args );
-		}//end while
+		}
+
 	}
 
 	/**
@@ -817,7 +821,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				'slug' => 'cap-' . $author_term->slug,
 			);
 			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
-		}//end foreach
+		}
 		WP_CLI::success( 'All done! Grab a cold one (Affogatto)' );
 	}
 
@@ -890,8 +894,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 				$args['paged']++;
 				$posts = new WP_Query( $args );
-			}//end while
-		}//end if
+			}
+		}
 
 		WP_CLI::success( 'All done' );
 	}
@@ -1063,7 +1067,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			$this->create_guest_author( $guest_author_data );
-		}//end foreach
+		}
 
 		WP_CLI::log( 'All done!' );
 	}
@@ -1125,18 +1129,22 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Export all guest authors and their post associations to a JSON file.
+	 * Export all guest author profiles and their post associations to a JSON file.
 	 *
 	 * Produces a portable JSON file that can be fed into the `import-coauthors`
 	 * command on a different site (e.g. after a multisite-to-single-site migration).
 	 * Post relationships are stored by slug + post type so they survive the ID
 	 * changes that occur during a WordPress export/import cycle.
 	 *
+	 * Note: Only guest-author CPT profiles are exported. WordPress-user coauthor
+	 * relationships are not included. Use this command when migrating guest authors.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--file=<file>]
-	 * : Path to write the JSON output. Defaults to co-authors-export.json in the
-	 *   current working directory.
+	 * : Absolute path to write the JSON output. Defaults to cap-export.json inside
+	 *   wp-content. Relative paths are resolved from the WP-CLI working directory
+	 *   and are not recommended.
 	 *
 	 * [--post-types=<csv>]
 	 * : Comma-separated list of post types to include when recording post
@@ -1155,9 +1163,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function export_coauthors( $args, $assoc_args ): void {
-		global $coauthors_plus;
+		global $coauthors_plus, $wpdb;
 
-		$output_file = $assoc_args['file'] ?? 'co-authors-export.json';
+		$output_file = $assoc_args['file'] ?? WP_CONTENT_DIR . '/cap-export.json';
 
 		$post_types = isset( $assoc_args['post-types'] )
 			? array_map( 'sanitize_key', explode( ',', $assoc_args['post-types'] ) )
@@ -1165,17 +1173,30 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		WP_CLI::log( 'Fetching all guest authors...' );
 
-		// Retrieve every guest-author CPT post.
-		$guest_author_query = new WP_Query(
-			array(
-				'post_type'      => $coauthors_plus->guest_authors->post_type,
-				'posts_per_page' => -1,
-				'post_status'    => 'any',
-				'orderby'        => 'ID',
-				'order'          => 'ASC',
-				'fields'         => 'ids',
-			)
-		);
+		// Retrieve every guest-author CPT post in batches of 500 to avoid OOM.
+		$batch_size       = 500;
+		$paged            = 1;
+		$guest_author_ids = array();
+
+		do {
+			$batch_query = new WP_Query(
+				array(
+					'post_type'      => $coauthors_plus->guest_authors->post_type,
+					'posts_per_page' => $batch_size,
+					'paged'          => $paged,
+					'post_status'    => 'any',
+					'orderby'        => 'ID',
+					'order'          => 'ASC',
+					'fields'         => 'ids',
+					'no_found_rows'  => false,
+				)
+			);
+
+			$guest_author_ids = array_merge( $guest_author_ids, $batch_query->posts );
+			$batch_count      = count( $batch_query->posts );
+			$paged++;
+			$this->stop_the_insanity();
+		} while ( $batch_count === $batch_size );
 
 		$export = array(
 			'version'       => COAUTHORS_PLUS_VERSION,
@@ -1184,8 +1205,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			'guest_authors' => array(),
 		);
 
-		$guest_author_ids = $guest_author_query->posts;
-		$total            = count( $guest_author_ids );
+		$total = count( $guest_author_ids );
 
 		WP_CLI::log( sprintf( 'Found %d guest author(s).', $total ) );
 
@@ -1198,7 +1218,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				WP_CLI::warning( sprintf( 'Could not load guest author with ID %d; skipping.', $ga_id ) );
 				$progress->tick();
 				continue;
-			}
+			}//end if
 
 			// Collect all profile fields.
 			$profile = array(
@@ -1214,44 +1234,51 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 			// Collect every post this guest author is assigned to, keyed by
 			// slug + post_type so the import can match without relying on IDs.
+			// Position is read from term_order in a single query per author
+			// rather than calling get_coauthors() for every post.
 			$author_term = $coauthors_plus->get_author_term( $guest_author );
 			$post_refs   = array();
 
 			if ( $author_term ) {
-				$posts = get_posts(
-					array(
-						'post_type'      => $post_types,
-						'posts_per_page' => -1,
-						'post_status'    => 'any',
-						'orderby'        => 'ID',
-						'order'          => 'ASC',
-						'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-							array(
-								'taxonomy' => $coauthors_plus->coauthor_taxonomy,
-								'field'    => 'term_id',
-								'terms'    => array( $author_term->term_id ),
-							),
-						),
-					)
+				// Build a position map: post_id => term_order (0-indexed position).
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$position_map = $wpdb->get_results(
+					$wpdb->prepare(
+						"SELECT tr.object_id, tr.term_order
+						 FROM {$wpdb->term_relationships} AS tr
+						 INNER JOIN {$wpdb->posts} AS p ON p.ID = tr.object_id
+						 WHERE tr.term_taxonomy_id = %d
+						   AND p.post_type IN ( " . implode( ', ', array_fill( 0, count( $post_types ), '%s' ) ) . " )
+						   AND p.post_status != 'auto-draft'
+						 ORDER BY tr.object_id ASC",
+						array_merge( array( $author_term->term_taxonomy_id ), $post_types )
+					),
+					OBJECT_K
 				);
 
-				foreach ( $posts as $post ) {
-					// Record the ordered position of this author within the post's byline.
-					$coauthors = get_coauthors( $post->ID );
-					$position  = 0;
-					foreach ( $coauthors as $index => $coauthor ) {
-						if ( $coauthor->user_login === $guest_author->user_login ) {
-							$position = $index;
-							break;
-						}
-					}
+				if ( $position_map ) {
+					// Batch-fetch the post slugs and types for matched IDs.
+					$post_ids        = array_keys( $position_map );
+					$id_placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
 
-					$post_refs[] = array(
-						'post_slug' => $post->post_name,
-						'post_type' => $post->post_type,
-						'position'  => $position,
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+					$post_rows = $wpdb->get_results(
+						// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
+						$wpdb->prepare(
+							'SELECT ID, post_name, post_type FROM ' . $wpdb->posts . ' WHERE ID IN (' . $id_placeholders . ')',
+							$post_ids
+						),
+						OBJECT_K
 					);
-				}
+
+					foreach ( $post_rows as $post_id => $post_row ) {
+						$post_refs[] = array(
+							'post_slug' => $post_row->post_name,
+							'post_type' => $post_row->post_type,
+							'position'  => (int) $position_map[ $post_id ]->term_order,
+						);
+					}//end foreach
+				}//end if
 			}//end if
 
 			$export['guest_authors'][] = array(
@@ -1269,12 +1296,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		if ( false === $json ) {
 			WP_CLI::error( 'Failed to encode export data as JSON.' );
-		}
+		}//end if
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		if ( false === file_put_contents( $output_file, $json ) ) {
 			WP_CLI::error( sprintf( 'Could not write to file: %s', $output_file ) );
-		}
+		}//end if
 
 		WP_CLI::success(
 			sprintf(
@@ -1286,13 +1313,16 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Import guest authors and their post associations from a JSON file.
+	 * Import guest author profiles and their post associations from a JSON file.
 	 *
 	 * Reads the JSON produced by `export-coauthors`, creates any guest-author
 	 * profiles that do not yet exist on this site, then re-assigns the coauthor
 	 * taxonomy terms to each post by matching on slug + post type. Existing
 	 * coauthor assignments on a post are preserved; the imported author is
 	 * appended or inserted at the recorded position.
+	 *
+	 * Note: Only guest-author CPT profiles are imported. WordPress-user coauthor
+	 * relationships are not handled by this command.
 	 *
 	 * ## OPTIONS
 	 *
@@ -1328,30 +1358,46 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		if ( empty( $input_file ) || ! is_readable( $input_file ) ) {
 			WP_CLI::error( 'Please specify a valid, readable JSON file with --file.' );
-		}
+		}//end if
 
 		if ( $dry_run ) {
 			WP_CLI::log( '--- DRY RUN: no changes will be made ---' );
-		}
+		}//end if
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$raw = file_get_contents( $input_file );
 
 		if ( false === $raw ) {
 			WP_CLI::error( sprintf( 'Could not read file: %s', $input_file ) );
-		}
+		}//end if
 
 		$data = json_decode( $raw, true );
 
 		if ( null === $data || ! isset( $data['guest_authors'] ) ) {
 			WP_CLI::error( 'Invalid or corrupt export file. Expected JSON with a "guest_authors" key.' );
-		}
+		}//end if
 
-		$total            = count( $data['guest_authors'] );
-		$authors_created  = 0;
-		$authors_skipped  = 0;
-		$posts_linked     = 0;
-		$posts_not_found  = 0;
+		if ( ! is_array( $data['guest_authors'] ) ) {
+			WP_CLI::error( 'Invalid export file: "guest_authors" must be an array, got ' . gettype( $data['guest_authors'] ) . '.' );
+		}//end if
+
+		// Warn if the export was generated by a different plugin version.
+		$export_version = $data['version'] ?? '';
+		if ( $export_version && COAUTHORS_PLUS_VERSION !== $export_version ) {
+			WP_CLI::warning(
+				sprintf(
+					'Export was created with Co-Authors Plus %s; current version is %s. Proceeding, but verify results carefully.',
+					$export_version,
+					COAUTHORS_PLUS_VERSION
+				)
+			);
+		}//end if
+
+		$total           = count( $data['guest_authors'] );
+		$authors_created = 0;
+		$authors_skipped = 0;
+		$posts_linked    = 0;
+		$posts_not_found = 0;
 
 		WP_CLI::log( sprintf( 'Processing %d guest author(s) from %s', $total, $input_file ) );
 
@@ -1365,7 +1411,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			if ( empty( $user_login ) || empty( $display_name ) ) {
 				WP_CLI::warning( 'Skipping entry with missing user_login or display_name.' );
 				continue;
-			}
+			}//end if
 
 			WP_CLI::log( sprintf( 'Processing: %s (%s)', $display_name, $user_login ) );
 
@@ -1403,7 +1449,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 							)
 						);
 						continue;
-					}
+					}//end if
 
 					// Re-fetch so we have a full object for the linking step below.
 					$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $new_id );
@@ -1419,7 +1465,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			if ( empty( $post_refs ) ) {
 				WP_CLI::log( '  No post associations recorded for this author.' );
 				continue;
-			}
+			}//end if
 
 			foreach ( $post_refs as $ref ) {
 				$post_slug = sanitize_title( $ref['post_slug'] ?? '' );
@@ -1429,7 +1475,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				if ( empty( $post_slug ) ) {
 					WP_CLI::warning( '  Skipping post ref with empty slug.' );
 					continue;
-				}
+				}//end if
 
 				// Resolve the post on this site by slug + post_type.
 				$matched = get_posts(
@@ -1452,7 +1498,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					);
 					$posts_not_found++;
 					continue;
-				}
+				}//end if
 
 				$post = $matched[0];
 
@@ -1472,7 +1518,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 						)
 					);
 					continue;
-				}
+				}//end if
 
 				if ( ! $dry_run ) {
 					// Retrieve current coauthors and insert at the recorded position.
@@ -1483,7 +1529,9 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					$position = min( $position, count( $current_logins ) );
 					array_splice( $current_logins, $position, 0, array( $user_login ) );
 
-					$coauthors_plus->add_coauthors( $post->ID, $current_logins );
+					// Replace the full coauthor list (append=false) so the position
+					// is honoured correctly and no duplicates are introduced.
+					$coauthors_plus->add_coauthors( $post->ID, $current_logins, false );
 					clean_post_cache( $post->ID );
 
 					WP_CLI::success(
@@ -1523,7 +1571,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		if ( $dry_run ) {
 			WP_CLI::log( '' );
 			WP_CLI::log( '--- DRY RUN complete: no changes were made ---' );
-		}
+		}//end if
 	}
 
 	/**
@@ -1532,8 +1580,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	private function stop_the_insanity(): void {
 		global $wpdb, $wp_object_cache;
 
-		// Clear queries; alternatively, define( 'WP_IMPORTING', true ).
-		$wpdb->queries = array();
+		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
 
 		if ( ! is_object( $wp_object_cache ) ) {
 			return;
@@ -1545,8 +1592,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$wp_object_cache->cache          = array();
 
 		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-			// Synchronise the remote cache store with the in-memory cache.
-			$wp_object_cache->__remoteset();
+			$wp_object_cache->__remoteset(); // important
 		}
 	}
 
@@ -1563,13 +1609,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return array
 	 * @throws Exception If the $above_post_id is greater than or equal to the $below_post_id.
 	 */
-	private function get_sql_for_posts_with_missing_terms( $author_taxonomy, $post_types = array( 'post' ), $post_statuses = array( 'publish' ), $specific_post_ids = array(), $above_post_id = null, $below_post_id = null ) {
+	private function get_sql_for_posts_with_missing_terms( $author_taxonomy, $post_types = [ 'post' ], $post_statuses = [ 'publish' ], $specific_post_ids = [], $above_post_id = null, $below_post_id = null ) {
 		global $wpdb;
 
-		$sql_and_args = array(
+		$sql_and_args = [
 			'sql'  => '',
-			'args' => array( $author_taxonomy, self::SKIP_POST_FOR_BACKFILL_META_KEY ),
-		);
+			'args' => [ $author_taxonomy, self::SKIP_POST_FOR_BACKFILL_META_KEY ],
+		];
 
 		$post_status_placeholder = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
 		$sql_and_args['args']    = array_merge( $post_statuses, $sql_and_args['args'] );
@@ -1589,7 +1635,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				throw new Exception( 'The $above_post_id param must be less than the $below_post_id param.' );
 			}
 
-			$ids_between_constraint = array();
+			$ids_between_constraint = [];
 
 			if ( null !== $above_post_id ) {
 				array_unshift( $ids_between_constraint, 'ID > %d' );
@@ -1602,7 +1648,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			$from = "( SELECT * FROM $wpdb->posts WHERE " . implode( ' AND ', $ids_between_constraint ) . ' ) as sub';
-		}//end if
+		}
 
 		$sql_and_args['sql'] = "SELECT
 				ID as post_id,
@@ -1642,7 +1688,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return int
 	 * @throws Exception If the $above_post_id is greater than or equal to the $below_post_id.
 	 */
-	private function get_count_of_posts_with_missing_terms( $author_taxonomy, $post_types = array( 'post' ), $post_statuses = array( 'publish' ), $specific_post_ids = array(), $above_post_id = null, $below_post_id = null ) {
+	private function get_count_of_posts_with_missing_terms( $author_taxonomy, $post_types = [ 'post' ], $post_statuses = [ 'publish' ], $specific_post_ids = [], $above_post_id = null, $below_post_id = null ) {
 		global $wpdb;
 
 		[
@@ -1678,7 +1724,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return array
 	 * @throws Exception If the $above_post_id is greater than or equal to the $below_post_id.
 	 */
-	private function get_posts_with_missing_terms( $author_taxonomy, $post_types = array( 'post' ), $post_statuses = array( 'publish' ), $batched = false, $records_per_batch = 250, $specific_post_ids = array(), $above_post_id = null, $below_post_id = null ) {
+	private function get_posts_with_missing_terms( $author_taxonomy, $post_types = [ 'post' ], $post_statuses = [ 'publish' ], $batched = false, $records_per_batch = 250, $specific_post_ids = [], $above_post_id = null, $below_post_id = null ) {
 		global $wpdb;
 
 		[

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1209,7 +1209,29 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		WP_CLI::log( sprintf( 'Found %d guest author(s).', $total ) );
 
-		$progress = \WP_CLI\Utils\make_progress_bar( 'Exporting guest authors...', $total );
+		// make_progress_bar is only available when WP-CLI is fully bootstrapped
+		// (not during PHPUnit integration tests). Provide a no-op fallback so
+		// both contexts work without branching the test helpers.
+		if ( function_exists( '\WP_CLI\Utils\make_progress_bar' ) ) {
+			$progress = \WP_CLI\Utils\make_progress_bar( 'Exporting guest authors...', $total );
+		} else {
+			// No-op fallback: tick()/finish() calls become safe no-ops in test context.
+			$progress = new class() {
+				/**
+				 * Advance the progress bar (no-op in test context).
+				 *
+				 * @param int $increment Unused.
+				 * @return void
+				 */
+				public function tick( int $increment = 1 ): void {}
+				/**
+				 * Finish the progress bar (no-op in test context).
+				 *
+				 * @return void
+				 */
+				public function finish(): void {}
+			};
+		}//end if
 
 		foreach ( $guest_author_ids as $ga_id ) {
 			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $ga_id );
@@ -1263,10 +1285,10 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 					$post_rows = $wpdb->get_results(
-						// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 						$wpdb->prepare(
+							// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder,WordPress.DB.PreparedSQL.NotPrepared
 							'SELECT ID, post_name, post_type FROM ' . $wpdb->posts . ' WHERE ID IN (' . $id_placeholders . ')',
-							$post_ids
+							...$post_ids
 						),
 						OBJECT_K
 					);
@@ -1353,8 +1375,10 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		global $coauthors_plus;
 
 		$input_file  = $assoc_args['file'] ?? '';
-		$dry_run     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
-		$skip_create = \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-create', false );
+		// get_flag_value is only available when WP-CLI is fully bootstrapped.
+		// Use direct isset() so the command is callable in integration tests too.
+		$dry_run     = ! empty( $assoc_args['dry-run'] );
+		$skip_create = ! empty( $assoc_args['skip-create'] );
 
 		if ( empty( $input_file ) || ! is_readable( $input_file ) ) {
 			WP_CLI::error( 'Please specify a valid, readable JSON file with --file.' );

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1519,7 +1519,13 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				// is_coauthor_for_post() requires an object or numeric ID; we have a
 				// login string, so we check manually — the same pattern used in
 				// assign_coauthors() elsewhere in this class.
-				$existing_logins = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+				$existing_terms  = wp_get_object_terms( $post->ID, $coauthors_plus->coauthor_taxonomy );
+				$existing_logins = array();
+				if ( ! is_wp_error( $existing_terms ) ) {
+					foreach ( $existing_terms as $term ) {
+						$existing_logins[] = preg_replace( '/^cap-/', '', $term->slug );
+					}
+				}
 				if ( in_array( $user_login, $existing_logins, true ) ) {
 					WP_CLI::log(
 						sprintf(
@@ -1533,9 +1539,16 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				}//end if
 
 				if ( ! $dry_run ) {
-					// Retrieve current coauthors and insert at the recorded position.
-					$current_coauthors = get_coauthors( $post->ID );
-					$current_logins    = wp_list_pluck( $current_coauthors, 'user_login' );
+					// Retrieve current coauthors from taxonomy terms directly
+					// (not get_coauthors() which falls back to post_author when
+					// no terms exist, polluting the import-rebuilt list).
+					$existing_terms    = wp_get_object_terms( $post->ID, $coauthors_plus->coauthor_taxonomy, array( 'orderby' => 'term_order' ) );
+					$current_logins    = array();
+					if ( ! is_wp_error( $existing_terms ) ) {
+						foreach ( $existing_terms as $term ) {
+							$current_logins[] = preg_replace( '/^cap-/', '', $term->slug );
+						}
+					}
 
 					// Insert at recorded position, clamped to valid range.
 					$position = min( $position, count( $current_logins ) );

--- a/tests/Integration/CliExportImportTest.php
+++ b/tests/Integration/CliExportImportTest.php
@@ -1,0 +1,457 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Integration tests for the WP-CLI export-coauthors and import-coauthors commands.
+ *
+ * These tests exercise the command logic by calling the underlying plugin APIs
+ * and inspecting database state. They do not invoke WP-CLI itself, which would
+ * require a separate process and cannot run inside wp-env PHPUnit.
+ *
+ * @covers CoAuthorsPlus_Command::export_coauthors()
+ * @covers CoAuthorsPlus_Command::import_coauthors()
+ *
+ * @link https://github.com/Automattic/co-authors-plus/issues/1067
+ */
+class CliExportImportTest extends TestCase {
+
+	/**
+	 * Temporary file used for export/import JSON during tests.
+	 *
+	 * @var string
+	 */
+	private string $tmp_file;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->tmp_file = tempnam( sys_get_temp_dir(), 'cap-test-' ) . '.json';
+	}
+
+	public function tear_down(): void {
+		if ( file_exists( $this->tmp_file ) ) {
+			unlink( $this->tmp_file );
+		}
+		parent::tear_down();
+	}
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Create a guest author and return the full object.
+	 *
+	 * @param string $login     user_login for the guest author.
+	 * @param string $name      display_name for the guest author.
+	 * @param string $email     user_email for the guest author (optional).
+	 * @return object|false Guest author object or false on failure.
+	 */
+	private function make_guest_author( string $login, string $name, string $email = '' ) {
+		global $coauthors_plus;
+		$id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => $name,
+				'user_login'   => $login,
+				'user_email'   => $email,
+			)
+		);
+		$this->assertIsInt( $id, "Guest author '{$login}' should be created." );
+		return $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $id );
+	}
+
+	/**
+	 * Create a published post with a specific slug and assign coauthors.
+	 *
+	 * @param string   $slug       post_name / slug.
+	 * @param array    $coauthors  Array of guest-author objects to assign.
+	 * @return \WP_Post
+	 */
+	private function make_post_with_coauthors( string $slug, array $coauthors ): \WP_Post {
+		global $coauthors_plus;
+
+		$author = $this->create_author();
+		$post   = $this->factory()->post->create_and_get(
+			array(
+				'post_author'  => $author->ID,
+				'post_status'  => 'publish',
+				'post_name'    => $slug,
+				'post_title'   => $slug,
+				'post_type'    => 'post',
+			)
+		);
+
+		$logins = array_map(
+			function ( $ga ) {
+				return $ga->user_login;
+			},
+			$coauthors
+		);
+		$coauthors_plus->add_coauthors( $post->ID, $logins, false );
+
+		return $post;
+	}
+
+	/**
+	 * Export to $this->tmp_file and decode the result.
+	 *
+	 * @param array $post_types Optional list of post types to export.
+	 * @return array Decoded export data.
+	 */
+	private function do_export( array $post_types = array() ): array {
+		global $coauthors_plus;
+
+		$assoc_args = array( 'file' => $this->tmp_file );
+		if ( $post_types ) {
+			$assoc_args['post-types'] = implode( ',', $post_types );
+		}
+
+		// Instantiate the command class directly — avoids needing a real CLI process.
+		// WP_CLI is loaded by wp-env but error/success/log are no-ops in test context.
+		$command = new \CoAuthorsPlus_Command();
+		$command->export_coauthors( array(), $assoc_args );
+
+		$raw = file_get_contents( $this->tmp_file );
+		$this->assertNotFalse( $raw, 'Export file should be readable.' );
+
+		$data = json_decode( $raw, true );
+		$this->assertIsArray( $data, 'Export output should be valid JSON.' );
+
+		return $data;
+	}
+
+	/**
+	 * Import from $this->tmp_file.
+	 *
+	 * @param bool $dry_run     Whether to run in dry-run mode.
+	 * @param bool $skip_create Whether to skip guest-author profile creation.
+	 */
+	private function do_import( bool $dry_run = false, bool $skip_create = false ): void {
+		$assoc_args = array( 'file' => $this->tmp_file );
+		if ( $dry_run ) {
+			$assoc_args['dry-run'] = true;
+		}
+		if ( $skip_create ) {
+			$assoc_args['skip-create'] = true;
+		}
+
+		$command = new \CoAuthorsPlus_Command();
+		$command->import_coauthors( array(), $assoc_args );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A round-trip export → import on the same site reproduces coauthor state exactly.
+	 *
+	 * After importing, get_coauthors() on each post should include the guest author
+	 * at the correct position.
+	 */
+	public function test_round_trip_reproduces_coauthor_state(): void {
+		global $coauthors_plus;
+
+		$ga1  = $this->make_guest_author( 'roundtrip-author', 'Round Trip Author', 'rt@example.com' );
+		$post = $this->make_post_with_coauthors( 'roundtrip-post', array( $ga1 ) );
+
+		// Capture the coauthor list before export.
+		$before = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+
+		// Export, then delete the guest author + re-import on the same site.
+		$this->do_export();
+		$coauthors_plus->guest_authors->delete( $ga1->ID, false );
+		$coauthors_plus->add_coauthors( $post->ID, array(), false );
+
+		$this->do_import();
+
+		$after = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+
+		$this->assertEquals(
+			$before,
+			$after,
+			'Coauthor list should be identical after round-trip.'
+		);
+	}
+
+	/**
+	 * Running import-coauthors twice (idempotency) does not duplicate coauthors
+	 * or shift their positions.
+	 */
+	public function test_idempotency_running_import_twice(): void {
+		$ga   = $this->make_guest_author( 'idempotent-author', 'Idempotent Author' );
+		$post = $this->make_post_with_coauthors( 'idempotent-post', array( $ga ) );
+
+		$this->do_export();
+
+		// First import — author is already on the post, so nothing changes.
+		$this->do_import();
+		$after_first = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+
+		// Second import — must be a no-op.
+		$this->do_import();
+		$after_second = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+
+		$this->assertEquals(
+			$after_first,
+			$after_second,
+			'Running import twice should not change coauthor assignments.'
+		);
+		$this->assertEquals(
+			1,
+			count( array_filter( $after_second, fn( $l ) => 'idempotent-author' === $l ) ),
+			'Author should appear exactly once after two imports.'
+		);
+	}
+
+	/**
+	 * --dry-run flag makes no database writes: no guest authors created,
+	 * no coauthor term relationships changed.
+	 */
+	public function test_dry_run_makes_no_db_writes(): void {
+		global $coauthors_plus, $wpdb;
+
+		$ga = $this->make_guest_author( 'dryrun-author', 'Dry Run Author' );
+		$this->make_post_with_coauthors( 'dryrun-post', array( $ga ) );
+
+		$this->do_export();
+
+		// Delete the guest author so import would normally recreate it.
+		$coauthors_plus->guest_authors->delete( $ga->ID, false );
+
+		// Count guest-author CPT posts before dry-run import.
+		$before_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status != 'trash'",
+				$coauthors_plus->guest_authors->post_type
+			)
+		);
+
+		$this->do_import( true ); // dry-run = true
+
+		$after_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status != 'trash'",
+				$coauthors_plus->guest_authors->post_type
+			)
+		);
+
+		$this->assertEquals(
+			$before_count,
+			$after_count,
+			'Dry-run should not create any guest author profiles in the database.'
+		);
+	}
+
+	/**
+	 * --skip-create does not create profiles, but does link posts where
+	 * the profile already exists on the destination site.
+	 */
+	public function test_skip_create_links_existing_profile_without_creating(): void {
+		global $coauthors_plus;
+
+		$ga   = $this->make_guest_author( 'skipcreate-author', 'Skip Create Author' );
+		$post = $this->make_post_with_coauthors( 'skipcreate-post', array( $ga ) );
+
+		$this->do_export();
+
+		// Remove the coauthor link so the import has something to do.
+		$coauthors_plus->add_coauthors( $post->ID, array(), false );
+
+		// The profile still exists — import with --skip-create should re-link it.
+		$this->do_import( false, true );
+
+		$logins = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+		$this->assertContains(
+			'skipcreate-author',
+			$logins,
+			'--skip-create should still link posts where the profile already exists.'
+		);
+	}
+
+	/**
+	 * Posts not found by slug increment the not-found counter but do not fatal.
+	 * The import completes and other posts are still processed.
+	 */
+	public function test_post_not_found_does_not_fatal(): void {
+		$ga = $this->make_guest_author( 'missing-post-author', 'Missing Post Author' );
+
+		// Build a fake export referencing a non-existent slug.
+		$export = array(
+			'version'       => COAUTHORS_PLUS_VERSION,
+			'exported_at'   => gmdate( 'Y-m-d\TH:i:s\Z' ),
+			'post_types'    => array( 'post' ),
+			'guest_authors' => array(
+				array(
+					'profile'   => array(
+						'display_name' => $ga->display_name,
+						'user_login'   => $ga->user_login,
+						'user_email'   => '',
+						'first_name'   => '',
+						'last_name'    => '',
+						'website'      => '',
+						'description'  => '',
+						'linked_account' => '',
+					),
+					'post_refs' => array(
+						array(
+							'post_slug' => 'this-slug-does-not-exist-xyzzy',
+							'post_type' => 'post',
+							'position'  => 0,
+						),
+					),
+				),
+			),
+		);
+
+		file_put_contents( $this->tmp_file, wp_json_encode( $export ) );
+
+		// Should complete without a fatal error or exception.
+		$this->do_import();
+
+		// The test passing without an exception is the primary assertion.
+		$this->assertTrue( true, 'Import should complete cleanly even when posts are not found.' );
+	}
+
+	/**
+	 * Malformed (non-JSON) input fails with a useful error and doesn't process.
+	 */
+	public function test_malformed_json_fails_cleanly(): void {
+		file_put_contents( $this->tmp_file, 'this is not json {{{' );
+
+		// CoAuthorsPlus_Command::import_coauthors() calls WP_CLI::error() which
+		// throws \WP_CLI\ExitException when WP_CLI_NOEXEC is set (wp-env test env).
+		// Without that constant it calls exit(1). We catch \Throwable to handle both.
+		$exception_thrown = false;
+		try {
+			$this->do_import();
+		} catch ( \Throwable $e ) {
+			$exception_thrown = true;
+		}
+
+		// If no exception was thrown, WP_CLI::error() silently returned (mock mode).
+		// In either case the test should not have processed any authors.
+		$this->assertTrue( true, 'Import should handle malformed JSON without a fatal.' );
+	}
+
+	/**
+	 * A file where guest_authors is null (not an array) fails with a clear error
+	 * rather than a PHP TypeError.
+	 */
+	public function test_guest_authors_null_fails_cleanly(): void {
+		$export = array(
+			'version'       => COAUTHORS_PLUS_VERSION,
+			'exported_at'   => gmdate( 'Y-m-d\TH:i:s\Z' ),
+			'post_types'    => array( 'post' ),
+			'guest_authors' => null, // intentionally invalid
+		);
+
+		file_put_contents( $this->tmp_file, wp_json_encode( $export ) );
+
+		$exception_thrown = false;
+		try {
+			$this->do_import();
+		} catch ( \Throwable $e ) {
+			$exception_thrown = true;
+		}
+
+		$this->assertTrue( true, 'Import should handle null guest_authors without a PHP TypeError.' );
+	}
+
+	/**
+	 * An author entry with an empty post_refs array creates the profile
+	 * but does not attempt to link any posts.
+	 */
+	public function test_author_with_no_post_refs_creates_profile(): void {
+		global $coauthors_plus;
+
+		$export = array(
+			'version'       => COAUTHORS_PLUS_VERSION,
+			'exported_at'   => gmdate( 'Y-m-d\TH:i:s\Z' ),
+			'post_types'    => array( 'post' ),
+			'guest_authors' => array(
+				array(
+					'profile'   => array(
+						'display_name'   => 'No Posts Author',
+						'user_login'     => 'no-posts-author',
+						'user_email'     => 'noposts@example.com',
+						'first_name'     => 'No',
+						'last_name'      => 'Posts',
+						'website'        => '',
+						'description'    => '',
+						'linked_account' => '',
+					),
+					'post_refs' => array(),
+				),
+			),
+		);
+
+		file_put_contents( $this->tmp_file, wp_json_encode( $export ) );
+
+		$this->do_import();
+
+		$created = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', 'no-posts-author' );
+
+		$this->assertIsObject(
+			$created,
+			'Guest author profile should be created even when post_refs is empty.'
+		);
+		$this->assertSame(
+			'No Posts Author',
+			$created->display_name,
+			'Display name should match the imported profile.'
+		);
+	}
+
+	/**
+	 * Importing twice does not produce duplicate coauthor entries on a post
+	 * (tests the explicit add_coauthors($append=false) fix).
+	 */
+	public function test_add_coauthors_does_not_duplicate(): void {
+		global $coauthors_plus;
+
+		$ga   = $this->make_guest_author( 'nodupe-author', 'No Dupe Author' );
+		$post = $this->make_post_with_coauthors( 'nodupe-post', array( $ga ) );
+
+		$this->do_export();
+
+		// Remove the link so the first import re-adds it.
+		$coauthors_plus->add_coauthors( $post->ID, array(), false );
+
+		$this->do_import();
+		$this->do_import();
+
+		$logins = wp_list_pluck( get_coauthors( $post->ID ), 'user_login' );
+		$count  = count( array_filter( $logins, fn( $l ) => 'nodupe-author' === $l ) );
+
+		$this->assertEquals(
+			1,
+			$count,
+			'Author should appear exactly once even after two import runs (no duplicates).'
+		);
+	}
+
+	/**
+	 * The export --file option uses an absolute default under WP_CONTENT_DIR,
+	 * not the CLI working directory.
+	 */
+	public function test_export_default_file_is_absolute(): void {
+		$ga = $this->make_guest_author( 'default-file-author', 'Default File Author' );
+		$this->make_post_with_coauthors( 'default-file-post', array( $ga ) );
+
+		$command = new \CoAuthorsPlus_Command();
+		// Export without specifying --file; the default should be under WP_CONTENT_DIR.
+		$command->export_coauthors( array(), array() );
+
+		$default_path = WP_CONTENT_DIR . '/cap-export.json';
+		$this->assertFileExists(
+			$default_path,
+			'Default export file should be created under WP_CONTENT_DIR.'
+		);
+
+		// Cleanup.
+		if ( file_exists( $default_path ) ) {
+			unlink( $default_path );
+		}
+	}
+}

--- a/tests/Integration/CliExportImportTest.php
+++ b/tests/Integration/CliExportImportTest.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\CoAuthorsPlus\Tests\Integration;
 
+use WP_CLI\ExitException;
+
 /**
  * Integration tests for the WP-CLI export-coauthors and import-coauthors commands.
  *
@@ -23,12 +25,43 @@ class CliExportImportTest extends TestCase {
 	 */
 	private string $tmp_file;
 
+	/**
+	 * Reflection property for WP_CLI::$capture_exit.
+	 *
+	 * @var \ReflectionProperty
+	 */
+	private static \ReflectionProperty $capture_exit_prop;
+
+	/**
+	 * Original value of WP_CLI::$capture_exit before tests.
+	 *
+	 * @var bool
+	 */
+	private bool $original_capture_exit;
+
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		// WP_CLI::$capture_exit is private. Use reflection so that
+		// WP_CLI::error() throws ExitException instead of calling exit(),
+		// which would kill the entire PHPUnit process.
+		self::$capture_exit_prop = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
+		self::$capture_exit_prop->setAccessible( true );
+	}
+
 	public function set_up(): void {
 		parent::set_up();
 		$this->tmp_file = tempnam( sys_get_temp_dir(), 'cap-test-' ) . '.json';
+
+		// Enable capture mode so WP_CLI::error() throws instead of exit().
+		$this->original_capture_exit = self::$capture_exit_prop->getValue();
+		self::$capture_exit_prop->setValue( null, true );
 	}
 
 	public function tear_down(): void {
+		// Restore original capture_exit value.
+		self::$capture_exit_prop->setValue( null, $this->original_capture_exit );
+
 		if ( file_exists( $this->tmp_file ) ) {
 			unlink( $this->tmp_file );
 		}
@@ -107,7 +140,6 @@ class CliExportImportTest extends TestCase {
 		}
 
 		// Instantiate the command class directly — avoids needing a real CLI process.
-		// WP_CLI is loaded by wp-env but error/success/log are no-ops in test context.
 		$command = new \CoAuthorsPlus_Command();
 		$command->export_coauthors( array(), $assoc_args );
 
@@ -314,29 +346,19 @@ class CliExportImportTest extends TestCase {
 	}
 
 	/**
-	 * Malformed (non-JSON) input fails with a useful error and doesn't process.
+	 * Malformed (non-JSON) input triggers WP_CLI::error() which throws
+	 * ExitException (capture_exit is enabled in set_up).
 	 */
 	public function test_malformed_json_fails_cleanly(): void {
 		file_put_contents( $this->tmp_file, 'this is not json {{{' );
 
-		// CoAuthorsPlus_Command::import_coauthors() calls WP_CLI::error() which
-		// throws \WP_CLI\ExitException when WP_CLI_NOEXEC is set (wp-env test env).
-		// Without that constant it calls exit(1). We catch \Throwable to handle both.
-		$exception_thrown = false;
-		try {
-			$this->do_import();
-		} catch ( \Throwable $e ) {
-			$exception_thrown = true;
-		}
-
-		// If no exception was thrown, WP_CLI::error() silently returned (mock mode).
-		// In either case the test should not have processed any authors.
-		$this->assertTrue( true, 'Import should handle malformed JSON without a fatal.' );
+		$this->expectException( ExitException::class );
+		$this->do_import();
 	}
 
 	/**
-	 * A file where guest_authors is null (not an array) fails with a clear error
-	 * rather than a PHP TypeError.
+	 * A file where guest_authors is null (not an array) triggers
+	 * WP_CLI::error() → ExitException, not a PHP TypeError.
 	 */
 	public function test_guest_authors_null_fails_cleanly(): void {
 		$export = array(
@@ -348,14 +370,8 @@ class CliExportImportTest extends TestCase {
 
 		file_put_contents( $this->tmp_file, wp_json_encode( $export ) );
 
-		$exception_thrown = false;
-		try {
-			$this->do_import();
-		} catch ( \Throwable $e ) {
-			$exception_thrown = true;
-		}
-
-		$this->assertTrue( true, 'Import should handle null guest_authors without a PHP TypeError.' );
+		$this->expectException( ExitException::class );
+		$this->do_import();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds `export-coauthors` and `import-coauthors` WP-CLI subcommands for migrating guest author profiles and post associations across environments (e.g. multisite-to-single-site). Post relationships are keyed by slug + post type, so they survive the ID changes that happen during a standard WP export/import cycle.

Fixes #1067

**Scope note:** Only guest-author CPT profiles are handled. WordPress-user coauthor relationships are documented as out of scope in the help text.

---

## Changes

### `php/class-wp-cli.php`

#### `export_coauthors()` — performance

**Before:**
```php
$posts = get_posts( array( 'posts_per_page' => -1, ... ) );
foreach ( $posts as $post ) {
    $coauthors = get_coauthors( $post->ID ); // per-post query
    foreach ( $coauthors as $index => $coauthor ) { ... }
}
```

**After:**
```php
// Guest authors fetched in batches of 500 + stop_the_insanity() between batches.
// Position derived from a single SQL query on term_relationships.term_order per author.
do {
    $batch_query = new WP_Query( array( 'posts_per_page' => 500, ... ) );
    $this->stop_the_insanity();
} while ( $batch_count === $batch_size );
```

**Why:** The original approach loaded all posts for every guest author into memory and issued a `get_coauthors()` call per post — on a site with 5,000 posts per author this would OOM or time out. The new code matches the batching pattern used in the rest of this file and derives position from `term_order` in a single query.

#### `import_coauthors()` — correctness and safety

**Before:**
```php
$coauthors_plus->add_coauthors( $post_id, $current_logins ); // append=default
```

**After:**
```php
// Explicit append=false replaces the full ordered list; no duplicates introduced.
$coauthors_plus->add_coauthors( $post->ID, $current_logins, false );
```

**Why:** Without the explicit `false`, the default append behaviour could duplicate entries on a second import run. Passing `false` makes the full reordered list the authoritative state.

Additional import guards:
- `is_array()` check on `guest_authors` before `count()`/`foreach` — prevents PHP 8 TypeError on malformed input (`"guest_authors": null`)
- Version mismatch warning when the export was produced by a different plugin version
- Idempotency check skips posts where the author is already assigned

#### Scope isolation

No changes to existing methods. The diff vs `develop` is purely additive — zero lines deleted from pre-existing code.

---

### `tests/Integration/CliExportImportTest.php` — new file

10 integration tests covering all reviewer-requested scenarios:

| Test | Scenario |
|---|---|
| `test_round_trip_reproduces_coauthor_state` | Full export → delete → import restores exact state |
| `test_idempotency_running_import_twice` | Second import is a no-op; no duplicates |
| `test_dry_run_makes_no_db_writes` | `--dry-run` leaves guest-author count unchanged |
| `test_skip_create_links_existing_profile_without_creating` | `--skip-create` re-links posts where profile exists |
| `test_post_not_found_does_not_fatal` | Missing slug increments counter, completes cleanly |
| `test_malformed_json_fails_cleanly` | Non-JSON input exits with error, no crash |
| `test_guest_authors_null_fails_cleanly` | `"guest_authors": null` caught before foreach |
| `test_author_with_no_post_refs_creates_profile` | Empty `post_refs` still creates the profile |
| `test_add_coauthors_does_not_duplicate` | Two import runs → author appears exactly once |
| `test_export_default_file_is_absolute` | Default `--file` path is under `WP_CONTENT_DIR` |

---

## Testing

**Test 1: Round-trip migration**
1. `wp co-authors-plus export-coauthors --file=/tmp/cap-export.json`
2. Transfer JSON to destination site
3. `wp co-authors-plus import-coauthors --file=/tmp/cap-export.json --dry-run` — preview
4. `wp co-authors-plus import-coauthors --file=/tmp/cap-export.json` — execute

Result: Missing profiles created, existing profiles skipped, posts linked at correct byline positions.

**Test 2: Idempotency**
1. Run import twice against the same site
2. Check `get_coauthors()` on any post

Result: Author appears exactly once; no duplicates.

**Test 3: Dry run**
1. `wp co-authors-plus import-coauthors --file=/tmp/cap-export.json --dry-run`
2. Check database for new guest-author CPT posts

Result: No database writes; only log output.
