### PR TITLE
Add --append_coauthors flag to assign-user-to-coauthor WP-CLI command

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -403,19 +403,19 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 	/**
 	 * Assign posts associated with a WordPress user to a co-author
-	 * Only apply the changes if there aren't yet co-authors associated with the post
 	 *
 	 * @since 3.0
 	 *
 	 * @subcommand assign-user-to-coauthor
-	 * @synopsis --user_login=<user-login> --coauthor=<co-author>
+	 * @synopsis --user_login=<user-login> --coauthor=<co-author> [--append_coauthors]
 	 */
 	public function assign_user_to_coauthor( $args, $assoc_args ): void {
 		global $coauthors_plus, $wpdb;
 
 		$defaults   = array(
-			'user_login' => '',
-			'coauthor'   => '',
+			'user_login'       => '',
+			'coauthor'         => '',
+			'append_coauthors' => false,
 		);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
@@ -436,7 +436,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
 			$coauthors = cap_get_coauthor_terms_for_post( $post_id );
-			if ( ! empty( $coauthors ) ) {
+			if ( ! empty( $coauthors ) && ! $assoc_args['append_coauthors'] ) {
 				WP_CLI::log(
 					sprintf(
 						/* translators: 1: Post ID, 2: Comma-separated list of co-author slugs. */
@@ -448,7 +448,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				continue;
 			}
 
-			$coauthors_plus->add_coauthors( $post_id, array( $coauthor->user_login ) );
+			$coauthors_plus->add_coauthors( $post_id, array( $coauthor->user_login ), $assoc_args['append_coauthors'] );
 			/* translators: 1: Co-author login, 2: Post ID */
 			WP_CLI::log( sprintf( __( "Updating - Adding %1\$s's byline to post #%2\$d", 'co-authors-plus' ), $coauthor->user_login, $post_id ) );
 			$affected++;


### PR DESCRIPTION
## Summary

The `wp co-authors-plus assign-user-to-coauthor` command silently skips any post that already has co-authors assigned, with no way to override. Its sibling `assign-coauthors` has had an `--append_coauthors` flag for years, so the asymmetry forces operators to fall back to ad-hoc scripts whenever they need to add a byline to posts that already have one.

This adds the same `--append_coauthors` flag to `assign-user-to-coauthor`. When set, posts with existing co-authors are no longer skipped, and the new co-author is appended rather than replacing what is already there. Default behaviour is unchanged.

The work is a rebase of #699 by Rob Skilling, originally opened in 2019. Two maintainers asked for a rebase at the time, but the dxw fork has since been archived and is read-only, so we cannot push to that branch. This PR supersedes #699 with the original commit cherry-picked onto current `develop` so authorship is preserved. While rebasing I also updated the code to current style (`WP_CLI::log`, numbered placeholders with translator comments) and wired `\$assoc_args['append_coauthors']` through to `add_coauthors()` rather than hardcoding `true`, matching how `assign_coauthors()` handles the same flag.

## Test plan

- [ ] Without the flag, running `assign-user-to-coauthor` on a post that already has co-authors still skips the post (existing behaviour preserved).
- [ ] With `--append_coauthors`, the new co-author is appended to the existing list rather than the post being skipped.
- [ ] On a post with no co-authors, behaviour is identical with or without the flag.