### PR TITLE
Document four legacy template-tag and upgrade functions

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * Get all co-authors for a given post.
+ *
+ * If the post has co-author terms assigned, returns the matching co-author
+ * objects (guest authors or WP users). Otherwise, falls back to the WordPress
+ * post author unless `$force_guest_authors` is enabled. Duplicates that arise
+ * from a guest author being linked to a WP user account are removed.
+ *
+ * @param int $post_id Optional. Post ID to fetch co-authors for. Defaults to the current post in the loop.
+ * @return array List of co-author objects, filtered through the `get_coauthors` filter.
+ */
 function get_coauthors( $post_id = 0 ) {
 	global $post, $post_ID, $coauthors_plus, $wpdb;
 
@@ -85,7 +96,35 @@ function is_coauthor_for_post( $user, $post_id = 0 ) {
 	return false;
 }
 
-// Helper function for the following new template tags
+/**
+ * Render or return a list of co-author values joined by configurable separators.
+ *
+ * Shared helper behind the various `coauthors_*()` template tags. Iterates over
+ * the co-authors of the current post and resolves each value via the chosen
+ * strategy:
+ *
+ * - `tag`: call `$tag` as a function (e.g. `get_the_author_meta`) with `$tag_args`.
+ * - `field`: read property `$tag` directly from the co-author object.
+ * - `callback`: call `$tag` with the current co-author object.
+ *
+ * Separators default to the `COAUTHORS_DEFAULT_*` constants when defined, and
+ * each is filterable via `coauthors_default_before`, `coauthors_default_between`,
+ * `coauthors_default_between_last`, and `coauthors_default_after`.
+ *
+ * @param string|callable $tag        Field name, function name, or callable, depending on `$type`.
+ * @param string          $type       Resolution strategy: 'tag', 'field', or 'callback'. Default 'tag'.
+ * @param array           $separators {
+ *     Optional separator overrides. Any missing key falls back to the matching filter.
+ *
+ *     @type string $before      Output before the list.
+ *     @type string $between     Delimiter between co-authors.
+ *     @type string $betweenLast Delimiter before the final co-author.
+ *     @type string $after       Output after the list.
+ * }
+ * @param mixed           $tag_args   Optional. Extra argument passed when `$type` is 'tag'. Default null.
+ * @param bool            $echo       Optional. Whether to echo the result. Default true.
+ * @return string The assembled output.
+ */
 function coauthors__echo( $tag, $type = 'tag', $separators = array(), $tag_args = null, $echo = true ) {
 
 	// Define the standard output separator. Constant support is for backwards compat.
@@ -519,7 +558,15 @@ function get_the_coauthor_meta( $field, $user_id = false ) {
 	return $meta;
 }
 
-
+/**
+ * Echo the requested meta field for each co-author of the current post.
+ *
+ * Each value is HTML-escaped before output. Values are concatenated with no
+ * separator between them.
+ *
+ * @param string $field   The user field to retrieve. See get_the_coauthor_meta() for accepted values.
+ * @param int    $user_id Optional. Restrict output to a single co-author by ID. Default 0 (all co-authors).
+ */
 function the_coauthor_meta( $field, $user_id = 0 ) {
 	// TODO: need before after options
 	$coauthor_meta = get_the_coauthor_meta( $field, $user_id );

--- a/upgrade.php
+++ b/upgrade.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Run upgrade routines based on the previously installed version.
+ *
+ * Dispatches to the relevant `coauthors_plus_upgrade_*()` routine for each
+ * version threshold the stored installation has crossed.
+ *
+ * @param float|string $from The previously installed plugin version.
+ */
 function coauthors_plus_upgrade( $from ) {
 	// TODO: handle upgrade failures
 


### PR DESCRIPTION
## Summary

A handful of long-standing functions in `template-tags.php` and `upgrade.php` have never had docblocks, leaving IDE assistance and the public surface a little thinner than it ought to be. While reviewing the long-stale [#542](https://github.com/Automattic/co-authors-plus/pull/542) ("PHPDoc improvements", opened 2018, conflicting), it became clear that the genuine documentation gains in that PR were minimal and that the four functions which still lack any docblock are not actually covered by it. Closing #542 in favour of this small, scoped change.

The four functions documented here are `get_coauthors()`, `coauthors__echo()` and `the_coauthor_meta()` in `template-tags.php`, plus `coauthors_plus_upgrade()` in `upgrade.php`. The wording is grounded in what each function actually does today: the term-then-fallback resolution and de-duplication in `get_coauthors()`, the three resolution strategies and filterable separators in `coauthors__echo()`, the per-co-author escaped echo in `the_coauthor_meta()`, and the version-threshold dispatch in `coauthors_plus_upgrade()`.

There are no behaviour changes — purely PHPDocs.

## Test plan

- [ ] Confirm static analysis and linting still pass.
- [ ] Spot-check the new docblocks in an IDE to verify parameter hints render as expected.