### PR TITLE
Accept --user_id in assign-user-to-coauthor for orphaned posts

### DIFF
--- a/features/assign-user-to-coauthor.feature
+++ b/features/assign-user-to-coauthor.feature
@@ -1,0 +1,60 @@
+Feature: Posts can be assigned from a user to a co-author
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp co-authors-plus create-guest-authors`
+
+	Scenario: Error when neither --user_login nor --user_id is supplied
+		When I try `wp co-authors-plus assign-user-to-coauthor --coauthor=admin`
+		Then STDERR should be:
+		"""
+		Error: Please specify exactly one of --user_login or --user_id.
+		"""
+
+	Scenario: Error when both --user_login and --user_id are supplied
+		When I try `wp co-authors-plus assign-user-to-coauthor --user_login=admin --user_id=1 --coauthor=admin`
+		Then STDERR should be:
+		"""
+		Error: Please specify exactly one of --user_login or --user_id.
+		"""
+
+	Scenario: Error on a non-existent --user_login
+		When I try `wp co-authors-plus assign-user-to-coauthor --user_login=not-a-user --coauthor=admin`
+		Then STDERR should be:
+		"""
+		Error: Please specify a valid user_login.
+		"""
+
+	Scenario: Error on a non-positive --user_id
+		When I try `wp co-authors-plus assign-user-to-coauthor --user_id=0 --coauthor=admin`
+		Then STDERR should be:
+		"""
+		Error: Please specify a positive integer for user_id.
+		"""
+
+	Scenario: Error on a non-numeric --user_id
+		When I try `wp co-authors-plus assign-user-to-coauthor --user_id=abc --coauthor=admin`
+		Then STDERR should be:
+		"""
+		Error: Please specify a positive integer for user_id.
+		"""
+
+	Scenario: Error on a missing co-author
+		When I try `wp co-authors-plus assign-user-to-coauthor --user_id=1 --coauthor=not-a-coauthor`
+		Then STDERR should be:
+		"""
+		Error: Please specify a valid co-author login
+		"""
+
+	Scenario: Assign orphaned posts to a co-author by --user_id
+		When I run `wp post create --post_author=999 --post_status=publish --post_title="Orphan post" --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus assign-user-to-coauthor --user_id=999 --coauthor=admin`
+		Then STDOUT should contain:
+		"""
+		Updating - Adding admin's byline to post #{POST_ID}
+		"""
+		And STDOUT should contain:
+		"""
+		Success: All done!
+		"""

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -402,29 +402,50 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Assign posts associated with a WordPress user to a co-author
+	 * Assign posts associated with a WordPress user to a co-author.
+	 *
+	 * Identify the source author by either `--user_login` or `--user_id`.
+	 * `--user_id` is useful when the underlying WordPress user has been
+	 * deleted, so a login lookup is no longer possible but `post_author`
+	 * still references the original ID.
 	 *
 	 * @since 3.0
 	 *
 	 * @subcommand assign-user-to-coauthor
-	 * @synopsis --user_login=<user-login> --coauthor=<co-author> [--append_coauthors]
+	 * @synopsis [--user_login=<user-login>] [--user_id=<user-id>] --coauthor=<co-author> [--append_coauthors]
 	 */
 	public function assign_user_to_coauthor( $args, $assoc_args ): void {
 		global $coauthors_plus, $wpdb;
 
 		$defaults   = array(
 			'user_login'       => '',
+			'user_id'          => '',
 			'coauthor'         => '',
 			'append_coauthors' => false,
 		);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$user     = get_user_by( 'login', $assoc_args['user_login'] );
-		$coauthor = $coauthors_plus->get_coauthor_by( 'login', $assoc_args['coauthor'] );
+		$has_login = '' !== $assoc_args['user_login'];
+		$has_id    = '' !== $assoc_args['user_id'];
 
-		if ( ! $user ) {
-			WP_CLI::error( __( 'Please specify a valid user_login', 'co-authors-plus' ) );
+		if ( $has_login === $has_id ) {
+			WP_CLI::error( __( 'Please specify exactly one of --user_login or --user_id.', 'co-authors-plus' ) );
 		}
+
+		if ( $has_login ) {
+			$user = get_user_by( 'login', $assoc_args['user_login'] );
+			if ( ! $user ) {
+				WP_CLI::error( __( 'Please specify a valid user_login.', 'co-authors-plus' ) );
+			}
+			$user_id = (int) $user->ID;
+		} else {
+			$user_id = (int) $assoc_args['user_id'];
+			if ( $user_id <= 0 ) {
+				WP_CLI::error( __( 'Please specify a positive integer for user_id.', 'co-authors-plus' ) );
+			}
+		}
+
+		$coauthor = $coauthors_plus->get_coauthor_by( 'login', $assoc_args['coauthor'] );
 
 		if ( ! $coauthor ) {
 			WP_CLI::error( __( 'Please specify a valid co-author login', 'co-authors-plus' ) );
@@ -432,7 +453,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		$post_types = implode( "','", $coauthors_plus->supported_post_types() );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ('{$post_types}')", $user->ID ) );
+		$posts    = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author=%d AND post_type IN ('{$post_types}')", $user_id ) );
 		$affected = 0;
 		foreach ( $posts as $post_id ) {
 			$coauthors = cap_get_coauthor_terms_for_post( $post_id );


### PR DESCRIPTION
## Summary

The `assign-user-to-coauthor` WP-CLI subcommand has long required a `--user_login` to identify the source author, which is fine until the underlying WordPress user has been deleted. At that point a login lookup is impossible, but `wp_posts.post_author` still references the original numeric ID, so the orphaned posts cannot be reattached to a co-author through the existing command. This is the use case PR #698 set out to address back in 2020.

This change adds a parallel `--user_id` flag. Exactly one of `--user_login` or `--user_id` is now required, and a non-positive integer is rejected up front so a typo surfaces as a clear error rather than a silent zero-affected run. The command never validates that the supplied ID corresponds to a live user — that would defeat the purpose of the flag, since the entire point is to recover from a deletion.

The implementation supersedes #698, which has been stale for several years and predates the later addition of `--append_coauthors`. Rather than rebase the original five-line patch through five years of accumulated review feedback, this PR applies the suggested changes against current `develop` and adds Behat coverage for the new flag, the error paths, and the orphan-post happy path.

## Test plan

- [ ] `composer behat` passes the new `assign-user-to-coauthor.feature` scenarios
- [ ] `wp co-authors-plus assign-user-to-coauthor --coauthor=admin` errors with the new mutual-exclusion message
- [ ] `wp co-authors-plus assign-user-to-coauthor --user_login=admin --user_id=1 --coauthor=admin` errors with the same message
- [ ] `wp co-authors-plus assign-user-to-coauthor --user_id=0 --coauthor=admin` errors on the non-positive integer
- [ ] Creating a post with `--post_author=999` (no user with that ID) and running `--user_id=999 --coauthor=admin` reattaches the orphan
- [ ] `wp co-authors-plus assign-user-to-coauthor --user_login=admin --coauthor=admin` still works as before for the existing flow

Closes #698.