### PR TITLE
Cover --append_coauthors behaviour in assign-user-to-coauthor Behat tests

### DIFF
--- a/features/assign-user-to-coauthor.feature
+++ b/features/assign-user-to-coauthor.feature
@@ -58,3 +58,49 @@ Feature: Posts can be assigned from a user to a co-author
 		"""
 		Success: All done!
 		"""
+
+	Scenario: Succeed cleanly when the user has no posts
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And I run `wp co-authors-plus assign-user-to-coauthor --user_login=author1 --coauthor=admin`
+		Then STDOUT should contain:
+		"""
+		Success: All done! 0 posts were affected.
+		"""
+
+	Scenario: Skip a post that already has co-authors when --append_coauthors is not set
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="A post" --post_status=publish --porcelain`
+		And I run `wp co-authors-plus assign-user-to-coauthor --user_login=author1 --coauthor=admin`
+		Then STDOUT should contain:
+		"""
+		Skipping - Post #
+		"""
+		And STDOUT should contain:
+		"""
+		Success: All done! 0 posts were affected.
+		"""
+
+	Scenario: Append a co-author to a post that already has co-authors when --append_coauthors is set
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="A post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus assign-user-to-coauthor --user_login=author1 --coauthor=admin --append_coauthors`
+		Then STDOUT should contain:
+		"""
+		Updating - Adding admin's byline to post #{POST_ID}
+		"""
+		And STDOUT should contain:
+		"""
+		Success: All done! 1 post was affected.
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should contain:
+		"""
+		author1
+		"""
+		And STDOUT should contain:
+		"""
+		admin
+		"""


### PR DESCRIPTION
## Summary

The Behat feature file for `assign-user-to-coauthor` was introduced in #1266 alongside the new `--user_id` parameter, focused on covering the parameter validation paths and an orphan-post happy path. That left a gap: the `--append_coauthors` flag added in #1264 has no test coverage, and the default skip behaviour (preserved by #1264) has no regression net either.

This adds three scenarios to the existing feature file. The first asserts that running the command against a user with no posts exits cleanly with `0 posts were affected`. The second exercises the default skip path: a post already has co-authors, the flag is absent, the command logs `Skipping - Post #` and reports zero posts affected. The third covers the append path: with `--append_coauthors`, the new co-author is added, the success message reports one post affected, and a follow-up `wp term list` confirms both the existing and newly-appended author terms remain attached to the post.

The third scenario is the most important of the three — it would catch a regression where the append branch silently replaced rather than appended, which the success message alone would not detect.

## Test plan

- [x] All 10 scenarios in the feature file pass locally (56 steps, ~3 minutes via `composer behat`).
- [ ] CI Behat workflow passes on the PR.