### PR TITLE
Sync post_author before wp_insert_post on REST save

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -262,6 +262,7 @@ class CoAuthors_Plus {
 
 		// Bridge REST API saves to add_coauthors() for post_author sync and legacy filter compatibility.
 		foreach ( $this->supported_post_types() as $post_type ) {
+			add_filter( "rest_pre_insert_{$post_type}", array( $this, 'set_post_author_for_rest_save' ), 10, 2 );
 			add_action( "rest_after_insert_{$post_type}", array( $this, 'sync_coauthors_on_rest_save' ), 10, 2 );
 		}
 	}
@@ -1233,6 +1234,104 @@ class CoAuthors_Plus {
 		$data['post_author'] = apply_filters( 'coauthors_post_author_value', $data['post_author'], $postarr['ID'] );
 
 		return $data;
+	}
+
+	/**
+	 * Set post_author from coauthors data before a REST API save writes the post.
+	 *
+	 * Without this, the REST flow runs as: wp_update_post writes the post and fires
+	 * wp_insert_post (where Jetpack Sync queues the post for sync) BEFORE
+	 * rest_after_insert_{post_type} fires (where sync_coauthors_on_rest_save would
+	 * otherwise update post_author via add_coauthors). The result is that listeners
+	 * of wp_insert_post see and ship the stale post_author. The Jetpack Newsletter
+	 * preview, which is rendered on WordPress.com from synced post fields, then
+	 * displays the wrong author until a second save lands.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1269
+	 *
+	 * @param stdClass        $prepared_post Post object derived from the REST request.
+	 * @param WP_REST_Request $request       The REST request.
+	 * @return stdClass The (possibly modified) prepared post object.
+	 */
+	public function set_post_author_for_rest_save( $prepared_post, $request ) {
+		if ( ! is_object( $prepared_post ) || empty( $prepared_post->post_type ) ) {
+			return $prepared_post;
+		}
+
+		if ( ! $this->is_post_type_enabled( $prepared_post->post_type ) ) {
+			return $prepared_post;
+		}
+
+		if ( ! $this->current_user_can_set_authors() ) {
+			return $prepared_post;
+		}
+
+		$coauthor_term_ids = $request->get_param( 'coauthors' );
+		if ( ! is_array( $coauthor_term_ids ) || empty( $coauthor_term_ids ) ) {
+			return $prepared_post;
+		}
+
+		$coauthor_objects = array();
+		foreach ( $coauthor_term_ids as $term_id ) {
+			$term = get_term( (int) $term_id, $this->coauthor_taxonomy );
+			if ( ! $term || is_wp_error( $term ) ) {
+				continue;
+			}
+
+			$coauthor = $this->get_coauthor_by( 'user_nicename', $term->slug );
+			if ( $coauthor ) {
+				$coauthor_objects[] = $coauthor;
+			}
+		}
+
+		if ( empty( $coauthor_objects ) ) {
+			return $prepared_post;
+		}
+
+		$current_post_author_id = isset( $prepared_post->post_author ) ? (int) $prepared_post->post_author : 0;
+
+		// If the proposed post_author is already among the new coauthors, leave it alone.
+		if ( $current_post_author_id ) {
+			foreach ( $coauthor_objects as $coauthor ) {
+				$coauthor_user_id = $this->extract_wp_user_id( $coauthor );
+				if ( $coauthor_user_id && $coauthor_user_id === $current_post_author_id ) {
+					return $prepared_post;
+				}
+			}
+		}
+
+		// Otherwise, switch post_author to the first WP_User-backed coauthor we can find.
+		foreach ( $coauthor_objects as $coauthor ) {
+			$coauthor_user_id = $this->extract_wp_user_id( $coauthor );
+			if ( $coauthor_user_id ) {
+				$prepared_post->post_author = $coauthor_user_id;
+				return $prepared_post;
+			}
+		}
+
+		return $prepared_post;
+	}
+
+	/**
+	 * Extract the underlying WP_User ID from a coauthor object, if any.
+	 *
+	 * Coauthors can be WP_User instances, guest authors with a linked WP user
+	 * exposed via $coauthor->wp_user, or guest authors with no linked user
+	 * (in which case there is no WP_User ID and we return 0).
+	 *
+	 * @param object $coauthor A coauthor object as returned by get_coauthor_by().
+	 * @return int A WP_User ID, or 0 if the coauthor has no underlying user.
+	 */
+	private function extract_wp_user_id( $coauthor ): int {
+		if ( $coauthor instanceof WP_User ) {
+			return (int) $coauthor->ID;
+		}
+
+		if ( isset( $coauthor->wp_user ) && $coauthor->wp_user instanceof WP_User ) {
+			return (int) $coauthor->wp_user->ID;
+		}
+
+		return 0;
 	}
 
 	/**

--- a/tests/Integration/RestSavePostAuthorTimingTest.php
+++ b/tests/Integration/RestSavePostAuthorTimingTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use WP_Post;
+use WP_REST_Request;
+
+/**
+ * Regression coverage for issue #1269.
+ *
+ * The block editor REST save flow used to ship the stale `post_author` to any
+ * listener of `wp_insert_post` (notably Jetpack Sync) because CAP did not
+ * update `post_author` until `rest_after_insert_{post_type}`, which fires
+ * after `wp_insert_post`. The Jetpack Newsletter preview, rendered on
+ * WordPress.com from synced post fields, therefore showed the wrong author
+ * until a second save landed.
+ *
+ * `set_post_author_for_rest_save()` closes the gap by deriving `post_author`
+ * from the coauthors term IDs in the request at `rest_pre_insert_{post_type}`,
+ * before the post is written.
+ *
+ * @covers \CoAuthors_Plus::set_post_author_for_rest_save
+ */
+class RestSavePostAuthorTimingTest extends TestCase {
+
+	/**
+	 * The post_author value seen by `wp_insert_post` listeners during the
+	 * most recent REST save. Captured via a one-shot listener installed by
+	 * each test so we can assert what Jetpack Sync (and friends) would see.
+	 *
+	 * @var int|null
+	 */
+	private $post_author_seen_by_wp_insert_post;
+
+	public function set_up() {
+		parent::set_up();
+		$this->post_author_seen_by_wp_insert_post = null;
+	}
+
+	/**
+	 * Install a listener that records the post_author at the moment
+	 * `wp_insert_post` fires. Mirrors where Jetpack Sync queues the post.
+	 */
+	private function spy_on_wp_insert_post( int $post_id ): void {
+		$callback = function ( $captured_id, $post ) use ( $post_id ) {
+			if ( (int) $captured_id === $post_id ) {
+				$this->post_author_seen_by_wp_insert_post = (int) $post->post_author;
+			}
+		};
+		add_action( 'wp_insert_post', $callback, 5, 2 );
+	}
+
+	public function test_rest_save_updates_post_author_before_wp_insert_post_fires(): void {
+		$original = $this->create_author( 'cap-1269-original' );
+		$switch_to = $this->create_author( 'cap-1269-replacement' );
+		$post = $this->create_post( $original );
+
+		$this->_cap->update_author_term( $original );
+		$this->_cap->update_author_term( $switch_to );
+		$replacement_term = $this->_cap->get_author_term( $switch_to );
+
+		// An admin must be doing the save so current_user_can_set_authors() returns true.
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		$this->spy_on_wp_insert_post( $post->ID );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'id', $post->ID );
+		$request->set_param( 'coauthors', array( $replacement_term->term_id ) );
+		$request->set_param( 'title', 'After switching primary author' );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			$switch_to->ID,
+			$this->post_author_seen_by_wp_insert_post,
+			'wp_insert_post listeners must see the new co-author as post_author, not the previous one.'
+		);
+
+		$this->assertSame(
+			$switch_to->ID,
+			(int) get_post( $post->ID )->post_author,
+			'post_author in the DB after the save must reflect the new co-author.'
+		);
+	}
+
+	public function test_rest_save_uses_linked_wp_user_for_guest_author_coauthor(): void {
+		$linked_user = $this->create_author( 'linked-user-1269' );
+		$original    = $this->create_author( 'original-1269-2' );
+		$post        = $this->create_post( $original );
+
+		// Guest author with a linked WP user account.
+		$guest_id = $this->_cap->guest_authors->create(
+			array(
+				'display_name'   => 'Linked Guest',
+				'user_login'     => 'guest-linked-1269',
+				'linked_account' => $linked_user->user_login,
+			)
+		);
+
+		$guest = $this->_cap->guest_authors->get_guest_author_by( 'id', $guest_id );
+		$this->_cap->update_author_term( $guest );
+		$guest_term = $this->_cap->get_author_term( $guest );
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		$this->spy_on_wp_insert_post( $post->ID );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'id', $post->ID );
+		$request->set_param( 'coauthors', array( $guest_term->term_id ) );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			$linked_user->ID,
+			$this->post_author_seen_by_wp_insert_post,
+			'A guest author with a linked WP user must surface that user as post_author at wp_insert_post.'
+		);
+	}
+
+	public function test_rest_save_leaves_post_author_unchanged_when_still_a_coauthor(): void {
+		$author    = $this->create_author( 'cap-1269-stays' );
+		$secondary = $this->create_author( 'cap-1269-secondary' );
+		$post      = $this->create_post( $author );
+
+		$this->_cap->update_author_term( $author );
+		$this->_cap->update_author_term( $secondary );
+		$author_term    = $this->_cap->get_author_term( $author );
+		$secondary_term = $this->_cap->get_author_term( $secondary );
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		$this->spy_on_wp_insert_post( $post->ID );
+
+		// Add a secondary coauthor; the original author is still primary.
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'id', $post->ID );
+		$request->set_param( 'coauthors', array( $author_term->term_id, $secondary_term->term_id ) );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			$author->ID,
+			$this->post_author_seen_by_wp_insert_post,
+			'When the existing post_author remains in the coauthors list, post_author must not be reassigned.'
+		);
+	}
+
+	public function test_rest_save_leaves_post_author_unchanged_when_no_coauthors_param(): void {
+		$author = $this->create_author( 'cap-1269-no-coauthors-param' );
+		$post   = $this->create_post( $author );
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		$this->spy_on_wp_insert_post( $post->ID );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'id', $post->ID );
+		$request->set_param( 'title', 'No coauthors data in this save' );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			$author->ID,
+			$this->post_author_seen_by_wp_insert_post,
+			'When no coauthors taxonomy data is sent, post_author must be preserved as-is.'
+		);
+	}
+
+	public function test_rest_save_leaves_post_author_unchanged_for_guest_only_coauthor(): void {
+		$author = $this->create_author( 'cap-1269-guest-only' );
+		$post   = $this->create_post( $author );
+
+		// Guest author with NO linked WP user — there is no WP_User to surface.
+		$guest_id = $this->_cap->guest_authors->create(
+			array(
+				'display_name' => 'Standalone Guest',
+				'user_login'   => 'guest-only-1269',
+			)
+		);
+		$guest = $this->_cap->guest_authors->get_guest_author_by( 'id', $guest_id );
+		$this->_cap->update_author_term( $guest );
+		$guest_term = $this->_cap->get_author_term( $guest );
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		$this->spy_on_wp_insert_post( $post->ID );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post->ID );
+		$request->set_param( 'id', $post->ID );
+		$request->set_param( 'coauthors', array( $guest_term->term_id ) );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			$author->ID,
+			$this->post_author_seen_by_wp_insert_post,
+			'A guest-only coauthor cannot replace post_author because there is no underlying WP_User. This is a known gap that requires a wpcom-side fix; see #1269.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The Jetpack Newsletter preview rendered from the block editor displays the post creator's name rather than the assigned co-author until a second save lands. The reporter on the WordPress.org forum traced the regression to CAP 4.0.x.

The newsletter preview is rendered on WordPress.com and proxied to the editor; it reads the `post_author` field that Jetpack Sync ships from the local site. In CAP's REST save flow, `sync_coauthors_on_rest_save()` is hooked on `rest_after_insert_{post_type}`, which fires *after* `wp_insert_post`. Jetpack Sync (and any other listener of `wp_insert_post`) therefore queues the post with the previous `post_author` on the first save, and only catches up on the second.

This change adds a `rest_pre_insert_{post_type}` filter that resolves the proposed `post_author` from the coauthors term IDs in the request before `wp_update_post` writes the post. By the time `wp_insert_post` fires, the WP_User-backed primary co-author is already in place, so the preview shows the correct author on the first save.

Guest authors with no linked WP user account remain a known limitation: there is no `WP_User` to surface, so `post_author` cannot be made to match a pure guest byline from the CAP side. Closing that gap requires a wpcom-side change to honour co-author data in the preview render. Worth raising as a separate follow-up.

Closes #1269 for the WP_User co-author case.

## Test plan

- [x] New `RestSavePostAuthorTimingTest` covers the timing fix end-to-end via a `wp_insert_post` listener that captures the synced value
- [x] Tests cover: WP_User co-author switch, guest author with linked WP user, post_author still in coauthors (no change), no `coauthors` param (no change), guest-only coauthor (known limitation)
- [x] Full integration suite passes (two pre-existing failures in `AuthorQueriedObjectTest` reproduce on `develop` and are unrelated)
- [ ] Manual smoke test of the four reproduction scenarios with Jetpack + Jetpack Newsletter is still valuable to confirm wpcom's preview now matches