### PR TITLE
fix(editor): normalize coauthors entity store values to term IDs

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -157,24 +157,24 @@ describe( 'Utility - extractTermIds', () => {
 		expect( result ).toStrictEqual( [ 42, 43 ] );
 	} );
 
-	it( 'extracts user_id from objects (co-author objects)', () => {
-		const result = extractTermIds( [ { user_id: 8703 }, { user_id: 16 } ] );
-		expect( result ).toStrictEqual( [ 8703, 16 ] );
-	} );
-
-	it( 'extracts id from objects', () => {
-		const result = extractTermIds( [ { id: 5 } ] );
-		expect( result ).toStrictEqual( [ 5 ] );
-	} );
-
-	it( 'extracts ID from objects', () => {
-		const result = extractTermIds( [ { ID: 99 } ] );
-		expect( result ).toStrictEqual( [ 99 ] );
+	it( 'filters out objects that only have user_id, id or ID', () => {
+		const result = extractTermIds( [
+			{ user_id: 8703 },
+			{ id: 5 },
+			{ ID: 99 },
+		] );
+		expect( result ).toStrictEqual( [] );
 	} );
 
 	it( 'handles mixed integer and object entries', () => {
-		const result = extractTermIds( [ 42, { user_id: 43 }, { term_id: 44 } ] );
-		expect( result ).toStrictEqual( [ 42, 43, 44 ] );
+		const result = extractTermIds( [
+			42,
+			{ user_id: 43 },
+			{ id: 5 },
+			{ ID: 99 },
+			{ term_id: 44 },
+		] );
+		expect( result ).toStrictEqual( [ 42, 44 ] );
 	} );
 
 	it( 'filters out objects with no recognizable ID property', () => {

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -3,6 +3,7 @@ import {
 	removeItem,
 	addItemByValue,
 	buildCoauthorTermIds,
+	extractTermIds,
 } from '../utils';
 import {
 	selectedAuthors,
@@ -142,5 +143,57 @@ describe( 'Utility - buildCoauthorTermIds', () => {
 			undefined
 		);
 		expect( result ).toStrictEqual( [ 10 ] );
+	} );
+} );
+
+describe( 'Utility - extractTermIds', () => {
+	it( 'returns integer IDs unchanged', () => {
+		const result = extractTermIds( [ 42, 43, 44 ] );
+		expect( result ).toStrictEqual( [ 42, 43, 44 ] );
+	} );
+
+	it( 'extracts term_id from objects', () => {
+		const result = extractTermIds( [ { term_id: 42 }, { term_id: 43 } ] );
+		expect( result ).toStrictEqual( [ 42, 43 ] );
+	} );
+
+	it( 'extracts user_id from objects (co-author objects)', () => {
+		const result = extractTermIds( [ { user_id: 8703 }, { user_id: 16 } ] );
+		expect( result ).toStrictEqual( [ 8703, 16 ] );
+	} );
+
+	it( 'extracts id from objects', () => {
+		const result = extractTermIds( [ { id: 5 } ] );
+		expect( result ).toStrictEqual( [ 5 ] );
+	} );
+
+	it( 'extracts ID from objects', () => {
+		const result = extractTermIds( [ { ID: 99 } ] );
+		expect( result ).toStrictEqual( [ 99 ] );
+	} );
+
+	it( 'handles mixed integer and object entries', () => {
+		const result = extractTermIds( [ 42, { user_id: 43 }, { term_id: 44 } ] );
+		expect( result ).toStrictEqual( [ 42, 43, 44 ] );
+	} );
+
+	it( 'filters out objects with no recognizable ID property', () => {
+		const result = extractTermIds( [
+			{ display_name: 'John Doe', user_nicename: 'john-doe' },
+			42,
+		] );
+		expect( result ).toStrictEqual( [ 42 ] );
+	} );
+
+	it( 'returns empty array for undefined input', () => {
+		expect( extractTermIds( undefined ) ).toStrictEqual( [] );
+	} );
+
+	it( 'returns empty array for empty array input', () => {
+		expect( extractTermIds( [] ) ).toStrictEqual( [] );
+	} );
+
+	it( 'returns empty array for non-array input', () => {
+		expect( extractTermIds( 'not an array' ) ).toStrictEqual( [] );
 	} );
 } );

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -20,6 +20,7 @@ import AuthorsSelection from '../author-selection';
 import {
 	addItemByValue,
 	buildCoauthorTermIds,
+	extractTermIds,
 	formatAuthorData,
 } from '../../utils';
 
@@ -48,12 +49,13 @@ const CoAuthors = () => {
 	/**
 	 * Read co-author term IDs from the core entity store.
 	 * Returns undefined until the post entity has loaded, then an array of term IDs.
+	 * Normalizes the value to handle both integer IDs and author objects.
 	 */
 	const { coauthorTermIds, hasResolvedPost } = useSelect( ( select ) => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const coauthors = getEditedPostAttribute( 'coauthors' );
 		return {
-			coauthorTermIds: coauthors,
+			coauthorTermIds: extractTermIds( coauthors ),
 			hasResolvedPost: coauthors !== undefined,
 		};
 	}, [] );

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,7 @@ export const extractTermIds = ( coauthors ) => {
 				return item;
 			}
 			if ( item && 'object' === typeof item ) {
-				return item.term_id ?? item.id ?? item.user_id ?? item.ID ?? null;
+				return item.term_id ?? null;
 			}
 			return null;
 		} )

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,35 @@
 import { applyFilters } from '@wordpress/hooks';
 
 /**
+ * Normalize the raw coauthors value from the core entity store into
+ * an array of integer term IDs.
+ *
+ * The entity store may return plain integers [42, 43] or full objects
+ * with various ID properties depending on the WordPress version and
+ * active plugins. This function handles both formats.
+ *
+ * @param {Array|undefined} coauthors Raw value from getEditedPostAttribute.
+ * @return {Array} Array of integer term IDs.
+ */
+export const extractTermIds = ( coauthors ) => {
+	if ( ! Array.isArray( coauthors ) || 0 === coauthors.length ) {
+		return [];
+	}
+
+	return coauthors
+		.map( ( item ) => {
+			if ( Number.isInteger( item ) ) {
+				return item;
+			}
+			if ( item && 'object' === typeof item ) {
+				return item.term_id ?? item.id ?? item.user_id ?? item.ID ?? null;
+			}
+			return null;
+		} )
+		.filter( ( id ) => Number.isInteger( id ) );
+};
+
+/**
  * Move an item up or down in an array.
  *
  * @param {string} targetItem Item to move.


### PR DESCRIPTION
## Summary

After the 4.0.0 migration to WordPress core entity store, `getEditedPostAttribute('coauthors')` returns full author objects instead of integer term IDs in some environments. This causes the `/coauthors/v1/authors-by-term-ids` REST call to send `[object Object]` in the query string, resulting in empty responses and a permanent spinner in the sidebar.

Fixes #1277

## Changes

### src/utils.js — Tighten `extractTermIds()` to trust only `term_id`

After feedback from @GaryJones, the fallback chain is now restricted to plain integers and the `term_id` property of objects. The previous `term_id ?? id ?? user_id ?? ID` chain could resolve to a different author's term because `/coauthors/v1/authors-by-term-ids` calls `get_term($id, 'author')` — which treats every value as a taxonomy **term** ID, not a user ID. Substituting a `user_id` therefore risks rendering the wrong authors silently.

Objects that only carry `user_id`, `id`, or `ID` are now filtered out. Rendering nothing is safer than rendering the wrong author.

```js
export const extractTermIds = ( coauthors ) => {
	if ( ! Array.isArray( coauthors ) || 0 === coauthors.length ) {
		return [];
	}

	return coauthors
		.map( ( item ) => {
			if ( Number.isInteger( item ) ) {
				return item;
			}
			if ( item && 'object' === typeof item ) {
				return item.term_id ?? null;
			}
			return null;
		} )
		.filter( ( id ) => Number.isInteger( id ) );
};
```

### src/components/co-authors/index.jsx — Normalize at read point

**Before:**
```js
coauthorTermIds: coauthors,
```

**After:**
```js
coauthorTermIds: extractTermIds( coauthors ),
```

**Why:** The `useCoauthorDetails` hook and `buildCoauthorTermIds()` both expect and produce integer arrays. Normalizing here preserves that contract without modifying the hook.

### src/__tests__/utils.test.js — Updated tests

Removed tests that asserted the unsafe `user_id`/`id`/`ID` fallback behaviour. Added a test that confirms these shapes are now filtered out, and updated the mixed-entry test to reflect the new contract. All 22 unit tests pass.

## Root cause note (for follow-up)

The objects reported in #1277 carry only `user_id` (`{display_name, user_nicename, user_url, user_id}`) — no `term_id`. With the tightened helper, affected sites will see an empty panel rather than the previous spinner or the silent-wrong-author outcome. The boundary fix here papers over the symptom; the underlying cause (what serialises the `coauthors` taxonomy field as user objects on certain sites) is worth a separate investigation. Likely candidates: a WordPress core REST taxonomy representation change or a third-party plugin filtering `rest_prepare_{$post_type}`.

## Deploy Notes

No new dependencies. No changes to PHP runtime requirements, no schema changes, no database migrations. JS-only fix in the editor sidebar. The `/coauthors/v1/authors-by-term-ids` REST route is unchanged.

## Steps to Test

1. Check out the branch and build: `npm install && npm run build`.
2. On a site with co-authors, open the block editor for a post that has at least one co-author assigned.
3. Verify the Co-Authors sidebar panel renders the assigned authors (no spinner, no permanent loading state).
4. DevTools → Network → filter for `authors-by-term-ids` → confirm the `ids` query parameter contains integers, not `[object Object]`.
5. Add, remove, and reorder co-authors from the sidebar. Save the post and reload — changes persist.
6. Run unit tests: `npm run test:unit` — expect 22 passed.
7. Edge case (regression check): on a site where the entity store returns `user_id`-only objects (see #1277), the panel should now render empty rather than show the wrong author or spin forever.

## AI Usage Disclosure

- [x] This PR was developed with AI assistance.
- [x] AI tools were used for code review feedback analysis, test design, and PR description drafting.

AI was used to:
- Diagnose the namespace mismatch between `user_id` and `term_id` raised by @GaryJones.
- Draft the tightened `extractTermIds` contract and corresponding test updates.
- Audit the PR description against the repo template.