### PR TITLE
fix(pcp): add ABSPATH direct-access guards

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Co-Authors Plus
  *

--- a/php/class-coauthors-wp-list-table.php
+++ b/php/class-coauthors-wp-list-table.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Our class extends the WP_List_Table class, so we need to make sure that it's there
 
 require_once ABSPATH . 'wp-admin/includes/screen.php';

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Manage co-authors and guest authors.
  *

--- a/php/integrations/amp.php
+++ b/php/integrations/amp.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 add_action( 'pre_amp_render_post', 'cap_add_amp_actions' );
 function cap_add_amp_actions() {

--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * The main file for the Yoast integration
  */

--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -1,4 +1,6 @@
 <?php
+namespace CoAuthors\Integrations;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -6,8 +8,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * The main file for the Yoast integration
  */
-
-namespace CoAuthors\Integrations;
 
 use CoAuthors\Integrations\Yoast\CoAuthor;
 use Yoast\WP\SEO\Config\Schema_Types;

--- a/template-tags.php
+++ b/template-tags.php
@@ -1,4 +1,7 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Get all co-authors for a given post.

--- a/upgrade.php
+++ b/upgrade.php
@@ -1,4 +1,8 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Run upgrade routines based on the previously installed version.
  *


### PR DESCRIPTION
## Summary
Fixes PCP errors/warnings — Phase 1: direct-access

Adds `if ( ! defined( 'ABSPATH' ) ) { exit; }` guard to all PHP files that were missing it, per Plugin Check rule `PluginCheck.CodeAnalysis.DirectFileAccess`.

## Changes
| File | Change |
|------|--------|
| `co-authors-plus.php` | Added ABSPATH guard (L2) |
| `template-tags.php` | Added ABSPATH guard (L2) |
| `upgrade.php` | Added ABSPATH guard (L2) |
| `php/integrations/yoast.php` | Added ABSPATH guard (L2) |
| `php/integrations/amp.php` | Added ABSPATH guard (L2-4, curly braces per PHPCS) |
| `php/class-coauthors-wp-list-table.php` | Added ABSPATH guard (L2) |
| `php/class-wp-cli.php` | Added ABSPATH guard (L2) |

**Skipped:** `php/integrations/amp/meta-author.php` — mixed PHP/HTML template file, guard pattern not applicable.

## Testing
- [x] PHPCS passes — no new errors introduced (all errors are pre-existing)
- [ ] Existing unit tests pass (CI will verify)
- [ ] Manually verified in WP admin

## Related
Plugin Check rule: `PluginCheck.CodeAnalysis.DirectFileAccess`