### PR TITLE
fix(pcp): escape _deprecated_hook() message strings

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1365,7 +1365,7 @@ class CoAuthors_Plus {
 					'coauthors_post_list_pluck_field',
 					'Co-Authors Plus 4.0',
 					'set_object_terms',
-					__( 'This filter is deprecated when saving via the REST API and will be removed in a future version. Use the set_object_terms action for the author taxonomy instead.', 'co-authors-plus' )
+					esc_html__( 'This filter is deprecated when saving via the REST API and will be removed in a future version. Use the set_object_terms action for the author taxonomy instead.', 'co-authors-plus' )
 				);
 			}
 			$field              = apply_filters( 'coauthors_post_list_pluck_field', 'user_login' );
@@ -1393,7 +1393,7 @@ class CoAuthors_Plus {
 					'coauthors_post_get_coauthor_by_field',
 					'Co-Authors Plus 4.0',
 					'set_object_terms',
-					__( 'This filter is deprecated when saving via the REST API and will be removed in a future version. Use the set_object_terms action for the author taxonomy instead.', 'co-authors-plus' )
+					esc_html__( 'This filter is deprecated when saving via the REST API and will be removed in a future version. Use the set_object_terms action for the author taxonomy instead.', 'co-authors-plus' )
 				);
 			}
 			$field = apply_filters( 'coauthors_post_get_coauthor_by_field', $query_type, $author_name );


### PR DESCRIPTION
## What

Wraps two `__()` calls inside `_deprecated_hook()` with `esc_html__()` to satisfy `WordPress.Security.EscapeOutput.OutputNotEscaped`.

## Why

PHPCS `composer cs` flagged exactly 2 violations in `php/class-coauthors-plus.php` (both inside `add_coauthors()`). The 4th parameter of `_deprecated_hook()` reaches `trigger_error()` which outputs the string without escaping. Both messages are plain text (no HTML tags), so `esc_html__` is the correct escaping function.

## How

| Location | Before | After |
|----------|--------|-------|
| L1368 | `__( 'This filter is deprecated…', 'co-authors-plus' )` | `esc_html__( 'This filter is deprecated…', 'co-authors-plus' )` |
| L1396 | Same message, same fix | Same change |

## Verification

- `php -l php/class-coauthors-plus.php` — no syntax errors
- `composer cs` — 0 `EscapeOutput` errors