### PR TITLE
fix(pcp): add translator comments for block sprintf __()

### DIFF
--- a/php/blocks/block-coauthor-avatar/class-block-coauthor-avatar.php
+++ b/php/blocks/block-coauthor-avatar/class-block-coauthor-avatar.php
@@ -113,6 +113,7 @@ class Block_CoAuthor_Avatar {
 				array(
 					'href'  => $link,
 					'rel'   => $rel,
+					/* translators: %s: author display name */
 					'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), $display_name ),
 				)
 			);

--- a/php/blocks/block-coauthor-image/class-block-coauthor-image.php
+++ b/php/blocks/block-coauthor-image/class-block-coauthor-image.php
@@ -116,6 +116,7 @@ class Block_CoAuthor_Image {
 				array(
 					'href'  => $link,
 					'rel'   => $attributes['rel'],
+					/* translators: %s: author display name */
 					'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), $display_name ),
 				)
 			);

--- a/php/blocks/block-coauthor-name/class-block-coauthor-name.php
+++ b/php/blocks/block-coauthor-name/class-block-coauthor-name.php
@@ -69,6 +69,7 @@ class Block_CoAuthor_Name {
 				array(
 					'href'  => $link,
 					'rel'   => $attributes['rel'],
+					/* translators: %s: author display name */
 					'title' => sprintf( __( 'Posts by %s', 'co-authors-plus' ), $display_name ),
 				)
 			);


### PR DESCRIPTION
## What

Adds `/* translators: %s: author display name */` comments above `sprintf( __( 'Posts by %s' ) )` calls in 3 block files.

## Why

PHPCS flagged `WordPress.WP.I18n.MissingTranslatorsComment` — 3 instances in block files using `sprintf` with `__()` placeholders but no translator comment.

## Files changed
- `php/blocks/block-coauthor-image/class-block-coauthor-image.php`
- `php/blocks/block-coauthor-name/class-block-coauthor-name.php`
- `php/blocks/block-coauthor-avatar/class-block-coauthor-avatar.php`

## Verification

- `php -l` on all 3 files — no syntax errors
- `composer cs` — 0 i18n translator violations