### PR TITLE
fix(pcp): migrate get_terms() to single-array form

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1824,7 +1824,7 @@ class CoAuthors_Plus {
 		);
 		$args = apply_filters( 'coauthors_search_authors_get_terms_args', $args );
 		add_filter( 'terms_clauses', array( $this, 'filter_terms_clauses' ) );
-		$found_terms = get_terms( $this->coauthor_taxonomy, $args );
+		$found_terms = get_terms( array_merge( array( 'taxonomy' => $this->coauthor_taxonomy ), $args ) );
 		remove_filter( 'terms_clauses', array( $this, 'filter_terms_clauses' ) );
 
 		if ( empty( $found_terms ) ) {

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -839,7 +839,10 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	public function migrate_author_terms( $args, $assoc_args ): void {
 		global $coauthors_plus;
 
-		$author_terms = get_terms( $coauthors_plus->coauthor_taxonomy, array( 'hide_empty' => false ) );
+		$author_terms = get_terms( array(
+			'taxonomy'   => $coauthors_plus->coauthor_taxonomy,
+			'hide_empty' => false,
+		) );
 		WP_CLI::log( 'Now migrating up to ' . count( $author_terms ) . ' terms' );
 		foreach ( $author_terms as $author_term ) {
 			// Term is already prefixed. We're good.
@@ -876,7 +879,10 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 */
 	public function update_author_terms(): void {
 		global $coauthors_plus;
-		$author_terms = get_terms( $coauthors_plus->coauthor_taxonomy, array( 'hide_empty' => false ) );
+		$author_terms = get_terms( array(
+			'taxonomy'   => $coauthors_plus->coauthor_taxonomy,
+			'hide_empty' => false,
+		) );
 		WP_CLI::log( 'Now updating ' . count( $author_terms ) . ' terms' );
 		foreach ( $author_terms as $author_term ) {
 			$old_count = $author_term->count;

--- a/template-tags.php
+++ b/template-tags.php
@@ -607,7 +607,7 @@ function coauthors_get_users( $args = array() ) {
 		 */
 		'hide_empty' => (bool) $args['authors_with_posts_only'],
 	);
-	$author_terms = get_terms( $coauthors_plus->coauthor_taxonomy, $term_args );
+	$author_terms = get_terms( array_merge( array( 'taxonomy' => $coauthors_plus->coauthor_taxonomy ), $term_args ) );
 
 	$authors = array();
 	foreach ( $author_terms as $author_term ) {


### PR DESCRIPTION
## What

Migrates 4 instances of deprecated two-parameter `get_terms( $taxonomy, $args )` to the modern single-array form.

## Files changed
- `php/class-wp-cli.php` — 2 calls (lines 842, 879)
- `php/class-coauthors-plus.php` — 1 call (line 1827)
- `template-tags.php` — 1 call (line 610)

## Verification
- `php -l` on all 3 files — no syntax errors
- Modern `get_terms()` accepts single array with `taxonomy` key