### PR TITLE
fix(pcp): input sanitization + trigger_error

### DIFF
--- a/php/class-coauthors-iterator.php
+++ b/php/class-coauthors-iterator.php
@@ -25,7 +25,7 @@ class CoAuthorsIterator {
 		}
 
 		if ( ! $postID ) {
-			trigger_error( esc_html( 'No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?' ) ); // return null;
+			wp_trigger_error( __METHOD__, 'No post ID provided for CoAuthorsIterator constructor. Are you not in a loop or is $post not set?' );
 		}
 
 		$this->original_authordata = $authordata;

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1199,7 +1199,7 @@ class CoAuthors_Plus {
 
 		// This action happens when a post is saved while editing a post
 		if (
-			isset( $_REQUEST['coauthors-nonce'], $_POST['coauthors'] )
+			isset( $_REQUEST['coauthors-nonce'], $_POST['coauthors'][0] )
 			&& is_array( $_POST['coauthors'] )
 			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['coauthors-nonce'] ) ), 'coauthors-edit' )
 			&& $this->current_user_can_set_authors()


### PR DESCRIPTION
## What

Two PCP fixes in one PR:

1. **Phase 5 (input-sanitization)**: Validates `$_POST['coauthors'][0]` array index before access — resolves `WordPress.Security.ValidatedSanitizedInput.InputNotValidated`
2. **Phase 12 (misc)**: Replaces `trigger_error()` with `wp_trigger_error()` in `CoAuthorsIterator` constructor — plugin requires WP 6.4+ so `wp_trigger_error()` is available

## Files changed
- `php/class-coauthors-plus.php` — `isset()` check on array index
- `php/class-coauthors-iterator.php` — `wp_trigger_error()` replacement

## Verification
- `php -l` on all files — no syntax errors
- `composer cs` — 0 related violations