### PR TITLE
fix: author archive feed outputting as HTML (Regression in 4.0.2)

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1857,10 +1857,12 @@ class CoAuthors_Plus {
 			// that paginated author archives can still trigger 404 when out of range.
 			// See https://github.com/Automattic/co-authors-plus/issues/1109.
 			$is_paged = $wp_query->is_paged;
+			$is_feed = $wp_query->is_feed;
 			$wp_query->init_query_flags();
 			$wp_query->is_author  = true;
 			$wp_query->is_archive = true;
 			$wp_query->is_paged   = $is_paged;
+			$wp_query->is_feed    = $is_feed;
 
 			if ( ! is_paged() ) {
 				add_filter( 'pre_handle_404', '__return_true' );

--- a/tests/Integration/AuthorQueriedObjectTest.php
+++ b/tests/Integration/AuthorQueriedObjectTest.php
@@ -180,4 +180,43 @@ class AuthorQueriedObjectTest extends TestCase {
 		// warnings in #1109. With flags cleared, it exits early and returns null — no warning.
 		$this->assertNull( single_term_title( '', false ), 'single_term_title() must return null on a guest author page without PHP warnings.' );
 	}
+
+	/**
+	 * On author archive feed requests, the is_feed flag must be preserved
+	 * even after the query flags initialization runs.
+	 *
+	 * Regression introduced in v4.0.2 (#1250) cleared all query flags using
+	 * init_query_flags(), but inadvertently destroyed the feed state.
+	 *
+	 * @covers CoAuthors_Plus::fix_author_page()
+	 */
+	public function test_fix_author_page_preserves_is_feed_flag_on_feed_requests(): void {
+		global $coauthors_plus, $wp_query;
+
+		// Create a temporary guest author to ensure the archive query is recognized as valid.
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'user_login'   => 'test-feed-guest',
+				'display_name' => 'Test Feed Guest',
+			)
+		);
+		$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
+		$this->assertNotFalse( $guest_author, 'Guest author should exist for the test query.' );
+
+		// Simulate an author archive feed request state using the real guest author's nicename.
+		$wp_query->is_author  = true;
+		$wp_query->is_archive = true;
+		$wp_query->is_feed    = true;
+		set_query_var( 'author_name', $guest_author->user_nicename );
+
+		// Trigger fix_author_page() — the method hooked to posts_selection.
+		$coauthors_plus->fix_author_page( '' );
+
+		// Core author archive flags must remain true.
+		$this->assertTrue( is_author(), 'is_author() must remain true after fix_author_page() runs.' );
+		$this->assertTrue( is_archive(), 'is_archive() must remain true after fix_author_page() runs.' );
+
+		// The is_feed flag must be correctly preserved — this was the source of the HTML rendering bug.
+		$this->assertTrue( is_feed(), 'is_feed() must remain true on an author feed request.' );
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes a critical regression introduced in **v4.0.2 (via #1250)**, where author archive feeds (e.g., `/author/username/feed/`) unexpectedly render as the standard author archive HTML page instead of the XML/RSS feed output.

In **PR #1250**, `CoAuthors_Plus::fix_author_page()` introduced `$wp_query->init_query_flags();` to clear conflicting query flags on guest author pages. However, this sequence permanently drops the necessary `is_feed` flag to `false` because the method does not preserve or re-assert it after initialization. 

Just like `$is_paged`, this PR preserves `$wp_query->is_feed` before running `init_query_flags()` and safely restores it right after. This ensures that author feeds continue to serve valid XML without interfering with the original fix implemented in #1250.

## Deploy Notes

There are no new dependencies or structural database changes added in this PR. It is a pure logic fix for an existing class method.

## Steps to Test

1. Ensure you are using Co-Authors Plus **v4.0.2** or higher.
1. Create a post and assign it to an author (either a standard WP User or a Guest Author).
1. Visit the author's feed URL in your browser or via cURL (e.g., `https://your-local-site.test/author/username/feed/`).
1. **Expected Behavior (Before this PR):** The URL returns the full HTML page of the author's archive, even though the HTTP header `Content-Type` is set to `application/rss+xml`.
1. **Expected Behavior (After this PR):** The URL correctly outputs the raw XML/RSS feed markup as expected.