### PR TITLE
Keep post_author on first co-author after a block-editor reorder

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -40,6 +40,20 @@ class CoAuthors_Plus {
 	private $is_rest_save = false;
 
 	/**
+	 * Whether a REST API save is in flight for the current request.
+	 *
+	 * Set at rest_pre_insert_{post_type} (before the post is written) and reset
+	 * at rest_after_insert_{post_type}. While true, coauthors_set_post_author_field()
+	 * must not re-derive post_author from the existing author terms, because the
+	 * REST flow updates those terms only after the post is written — at this point
+	 * they still hold the previous order. The REST path sets post_author itself via
+	 * set_post_author_for_rest_save(), so it needs no help here.
+	 *
+	 * @var bool
+	 */
+	private $processing_rest_save = false;
+
+	/**
 	 * @var CoAuthors_Guest_Authors
 	 */
 	public $guest_authors;
@@ -1254,10 +1268,33 @@ class CoAuthors_Plus {
 			return $data;
 		}
 
+		// Consume the REST in-flight guard for this write. While a REST save is in
+		// flight, the author terms still hold their previous order, so the
+		// re-derivation below would set a stale post_author; the REST path handles
+		// post_author itself in set_post_author_for_rest_save().
+		$processing_rest_save       = $this->processing_rest_save;
+		$this->processing_rest_save = false;
+
+		// Whether this save carries co-author data from the classic meta box form.
+		$has_coauthor_form_data = isset( $_REQUEST['coauthors-nonce'], $_POST['coauthors'][0] ) && is_array( $_POST['coauthors'] );
+
+		/*
+		 * Whether to re-derive post_author from the post's first co-author term.
+		 *
+		 * A non-REST save (e.g. Gutenberg's meta-box-loader request, which runs
+		 * after the block editor's REST save) carries no co-author data and would
+		 * otherwise let core overwrite post_author with the editing user or a
+		 * stale page-load value. Re-deriving here keeps post_author consistent
+		 * with the saved author order, whichever request writes last. See #1297.
+		 */
+		$reassert_from_terms = ! $processing_rest_save
+			&& ! $has_coauthor_form_data
+			&& ! empty( $postarr['ID'] )
+			&& $this->has_author_terms( (int) $postarr['ID'] );
+
 		// This action happens when a post is saved while editing a post
 		if (
-			isset( $_REQUEST['coauthors-nonce'], $_POST['coauthors'][0] )
-			&& is_array( $_POST['coauthors'] )
+			$has_coauthor_form_data
 			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['coauthors-nonce'] ) ), 'coauthors-edit' )
 			&& $this->current_user_can_set_authors()
 		) {
@@ -1277,6 +1314,13 @@ class CoAuthors_Plus {
 				} elseif ( 'wpuser' === $author_data->type ) {
 					$data['post_author'] = $author_data->ID;
 				}
+			}
+		}
+
+		if ( $reassert_from_terms ) {
+			$first_author_id = $this->get_first_coauthor_user_id( (int) $postarr['ID'] );
+			if ( $first_author_id ) {
+				$data['post_author'] = $first_author_id;
 			}
 		}
 
@@ -1310,6 +1354,11 @@ class CoAuthors_Plus {
 	 * @return stdClass The (possibly modified) prepared post object.
 	 */
 	public function set_post_author_for_rest_save( $prepared_post, $request ) {
+		// Flag the REST save so coauthors_set_post_author_field() does not later
+		// re-derive post_author from author terms that have not yet been reordered.
+		// Reset in sync_coauthors_on_rest_save() (rest_after_insert_{post_type}).
+		$this->processing_rest_save = true;
+
 		if ( ! is_object( $prepared_post ) || empty( $prepared_post->post_type ) ) {
 			return $prepared_post;
 		}
@@ -1391,6 +1440,43 @@ class CoAuthors_Plus {
 	}
 
 	/**
+	 * Get the WP_User ID of a post's first co-author term.
+	 *
+	 * Walks the author terms in their stored order and returns the underlying
+	 * WP_User ID of the first co-author that has one. Guest authors with no
+	 * linked WP user are skipped, since they cannot be a valid post_author.
+	 *
+	 * @param int $post_id Post to inspect.
+	 * @return int The first co-author's WP_User ID, or 0 if none can be found.
+	 */
+	private function get_first_coauthor_user_id( int $post_id ): int {
+		$terms = wp_get_object_terms(
+			$post_id,
+			$this->coauthor_taxonomy,
+			array(
+				'orderby' => 'term_order',
+				'order'   => 'ASC',
+			)
+		);
+
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return 0;
+		}
+
+		foreach ( $terms as $term ) {
+			$coauthor = $this->get_coauthor_by( 'user_nicename', $term->slug );
+			if ( $coauthor ) {
+				$user_id = $this->extract_wp_user_id( $coauthor );
+				if ( $user_id ) {
+					return $user_id;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Sync co-authors when a post is saved via the REST API.
 	 *
 	 * Bridges the REST API save flow to add_coauthors() so that post_author
@@ -1407,6 +1493,9 @@ class CoAuthors_Plus {
 	 * @param WP_REST_Request $request Request object.
 	 */
 	public function sync_coauthors_on_rest_save( $post, $request ): void {
+		// The REST write has completed, so the in-flight guard can be cleared.
+		$this->processing_rest_save = false;
+
 		$params = $request->get_params();
 
 		// Only process if coauthors taxonomy data was included in the request.

--- a/tests/Integration/RestSaveReorderPostAuthorTest.php
+++ b/tests/Integration/RestSaveReorderPostAuthorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+use WP_REST_Request;
+
+/**
+ * Regression coverage for issue #1297 (VIPPLUG-26).
+ *
+ * Reordering the co-authors of a post in the block editor so that a *different*
+ * existing co-author becomes first must move the core `post_author` column to
+ * that new first co-author. Before the fix, post_author tracked membership
+ * only: as long as the previous primary author remained somewhere in the
+ * co-author list, post_author was left pointing at them, so a reorder left
+ * post_author stale.
+ *
+ * @covers \CoAuthors_Plus::set_post_author_for_rest_save
+ */
+class RestSaveReorderPostAuthorTest extends TestCase {
+
+	/**
+	 * Save the given ordered co-author terms via the REST API, as the block
+	 * editor does, and return the resulting post_author.
+	 *
+	 * @param int   $post_id  Post being saved.
+	 * @param int[] $term_ids Ordered author term IDs.
+	 * @return int post_author after the save.
+	 */
+	private function rest_save_coauthors( int $post_id, array $term_ids ): int {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $post_id );
+		$request->set_param( 'id', $post_id );
+		$request->set_param( 'coauthors', $term_ids );
+
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		return (int) get_post( $post_id )->post_author;
+	}
+
+	public function test_reordering_coauthors_moves_post_author_to_new_first(): void {
+		$author_a = $this->create_author( 'cap-1297-a' );
+		$author_b = $this->create_author( 'cap-1297-b' );
+		$post     = $this->create_post( $author_a );
+
+		$this->_cap->update_author_term( $author_a );
+		$this->_cap->update_author_term( $author_b );
+		$term_a = $this->_cap->get_author_term( $author_a );
+		$term_b = $this->_cap->get_author_term( $author_b );
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		// Establish A, then B (A primary).
+		$this->assertSame(
+			$author_a->ID,
+			$this->rest_save_coauthors( $post->ID, array( $term_a->term_id, $term_b->term_id ) ),
+			'post_author should be A while A is the first co-author.'
+		);
+
+		// Reorder so B is first; A remains a co-author.
+		$this->assertSame(
+			$author_b->ID,
+			$this->rest_save_coauthors( $post->ID, array( $term_b->term_id, $term_a->term_id ) ),
+			'post_author should move to B after B becomes the first co-author.'
+		);
+
+		// The author terms should be stored in the new order, B then A.
+		$terms = wp_get_object_terms(
+			$post->ID,
+			$this->_cap->coauthor_taxonomy,
+			array(
+				'orderby' => 'term_order',
+				'order'   => 'ASC',
+				'fields'  => 'slugs',
+			)
+		);
+		$this->assertSame(
+			array(
+				$this->_cap->get_author_term( $author_b )->slug,
+				$this->_cap->get_author_term( $author_a )->slug,
+			),
+			$terms,
+			'Author terms should be ordered B, A after the reorder.'
+		);
+	}
+
+	/**
+	 * The block editor's REST save sets post_author correctly, but Gutenberg then
+	 * fires a second, non-REST "meta-box-loader" save (action=editpost) that carries
+	 * no co-author data. Core's edit_post() falls back to the editing user for
+	 * post_author on that request, reverting the value the REST save just stored.
+	 * CAP must re-derive post_author from the first co-author term on that save.
+	 */
+	public function test_non_rest_save_reasserts_post_author_from_first_coauthor(): void {
+		$author_a = $this->create_author( 'cap-1297-mbl-a' );
+		$author_b = $this->create_author( 'cap-1297-mbl-b' );
+		$post     = $this->create_post( $author_a );
+
+		// Store co-authors as B, A. add_coauthors() keeps post_author as A here
+		// (A is still a co-author), reproducing the stale state after a reorder.
+		$this->_cap->add_coauthors(
+			$post->ID,
+			array( $author_b->user_nicename, $author_a->user_nicename )
+		);
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		// Simulate the meta-box-loader save: a non-REST update with no co-author
+		// data, where core would set post_author to the editing user.
+		unset( $_POST['coauthors'], $_REQUEST['coauthors-nonce'] );
+		wp_update_post(
+			array(
+				'ID'          => $post->ID,
+				'post_author' => $admin->ID,
+			)
+		);
+
+		$this->assertSame(
+			$author_b->ID,
+			(int) get_post( $post->ID )->post_author,
+			'A non-REST save must re-assert post_author from the first co-author, not revert it.'
+		);
+	}
+
+	public function test_reordering_back_moves_post_author_back(): void {
+		$author_a = $this->create_author( 'cap-1297-back-a' );
+		$author_b = $this->create_author( 'cap-1297-back-b' );
+		$post     = $this->create_post( $author_a );
+
+		$this->_cap->update_author_term( $author_a );
+		$this->_cap->update_author_term( $author_b );
+		$term_a = $this->_cap->get_author_term( $author_a );
+		$term_b = $this->_cap->get_author_term( $author_b );
+
+		$admin = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin->ID );
+
+		$this->rest_save_coauthors( $post->ID, array( $term_b->term_id, $term_a->term_id ) );
+		$this->assertSame(
+			$author_a->ID,
+			$this->rest_save_coauthors( $post->ID, array( $term_a->term_id, $term_b->term_id ) ),
+			'post_author should move back to A when A becomes the first co-author again.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

On a post with multiple co-authors, reordering them in the block editor so a different existing co-author becomes first was not reflected in the core `post_author` column. The author terms saved in the new order, but `post_author` stayed pointing at the previous author, so anything relying on it (`the_author()`, the REST `author` field, author archives) showed the wrong person.

The cause is that a single **Update** issues two writes. The block editor's REST save (`POST /wp/v2/posts/{id}`) stores the new first co-author in `post_author` correctly. Gutenberg then fires a second, non-REST meta-box-loader request (`action=editpost`) to persist meta boxes. That request carries no co-author data and, because Co-Authors Plus removes the core Author box and renders no meta box of its own in the block editor, no `post_author` field either. Core's `edit_post()` therefore falls back to setting `post_author` to the editing user. As the later write, it wins and reverts what the REST save just stored. This is why 3.7.x was unaffected — authors were saved atomically through the meta-box form in one request, before [#1217](https://github.com/Automattic/co-authors-plus/issues/1217) moved author editing onto the REST save.

The fix re-derives `post_author` from the post's first co-author term on non-REST saves that carry no co-author data, so the column lands on the first co-author whichever request writes last and stays consistent with the saved author order. Guest authors with no linked WP user are skipped, matching the existing limitation that they cannot back `post_author`. A flag set during the REST save prevents this re-derivation from running mid-flight, when the author terms have not yet been reordered and the REST path is already setting `post_author` itself.

Worth a reviewer's attention: the re-derivation applies to all non-REST saves of a Co-Authors Plus post, not only the meta-box-loader. In practice this means a Quick Edit or Bulk Edit change to the Author field is now reconciled back to the first co-author. That is consistent with the plugin's model, where the visible byline already comes from the co-author terms rather than `post_author`, but it is a deliberate behaviour choice rather than an accident.

## Test plan

New integration coverage in `RestSaveReorderPostAuthorTest`:

- Reordering co-authors via REST moves `post_author` to the new first author, and back again.
- A non-REST save (the meta-box-loader scenario) re-asserts `post_author` from the first co-author instead of reverting it.

Verified locally against the wp-env test environment: the full single-site suite (248 tests) and the affected multisite tests pass, and the new meta-box-loader test fails without the fix.

Fixes #1297