### PR TITLE
fix(author): preserve feed flags when resetting query flags in fix_author_page

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1943,13 +1943,20 @@ class CoAuthors_Plus {
 			// is definitively an author archive. Reset all query flags to a clean
 			// state — mirroring how core handles flag transitions internally — then
 			// re-assert only the flags that should remain true. Preserve is_paged so
-			// that paginated author archives can still trigger 404 when out of range.
+			// that paginated author archives can still trigger 404 when out of range,
+			// and preserve feed flags so author RSS/Atom feeds are still served.
 			// See https://github.com/Automattic/co-authors-plus/issues/1109.
-			$is_paged = $wp_query->is_paged;
+			$is_feed         = $wp_query->is_feed;
+			$is_comment_feed = $wp_query->is_comment_feed;
+			$is_trackback    = $wp_query->is_trackback;
+			$is_paged        = $wp_query->is_paged;
 			$wp_query->init_query_flags();
-			$wp_query->is_author  = true;
-			$wp_query->is_archive = true;
-			$wp_query->is_paged   = $is_paged;
+			$wp_query->is_author        = true;
+			$wp_query->is_archive       = true;
+			$wp_query->is_feed          = $is_feed;
+			$wp_query->is_comment_feed  = $is_comment_feed;
+			$wp_query->is_trackback     = $is_trackback;
+			$wp_query->is_paged         = $is_paged;
 
 			if ( ! is_paged() ) {
 				add_filter( 'pre_handle_404', '__return_true' );

--- a/tests/Integration/AuthorQueriedObjectTest.php
+++ b/tests/Integration/AuthorQueriedObjectTest.php
@@ -180,4 +180,79 @@ class AuthorQueriedObjectTest extends TestCase {
 		// warnings in #1109. With flags cleared, it exits early and returns null — no warning.
 		$this->assertNull( single_term_title( '', false ), 'single_term_title() must return null on a guest author page without PHP warnings.' );
 	}
+
+	/**
+	 * On author feed URLs, fix_author_page() must preserve is_feed while still
+	 * clearing other conflicting query flags.
+	 *
+	 * WordPress sets is_feed=true for requests such as /author/USERNAME/feed/ or
+	 * ?author=1&feed=rss2. The 4.0.2 query-flag reset in fix_author_page() cleared
+	 * this flag, causing the HTML author archive to be served instead of the feed.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1301
+	 */
+	public function test__author_feed_preserves_is_feed_after_fix_author_page(): void {
+		global $coauthors_plus, $wp_query;
+
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'user_login'   => 'test-guest-1301',
+				'display_name' => 'Test Guest 1301',
+			)
+		);
+		$guest_author    = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
+
+		$this->assertNotFalse( $guest_author, 'Guest author should exist.' );
+
+		$wp_query->is_author        = true;
+		$wp_query->is_archive       = true;
+		$wp_query->is_feed          = true;
+		$wp_query->is_comment_feed  = false;
+		$wp_query->is_trackback     = false;
+		$wp_query->is_category      = true;
+
+		set_query_var( 'author_name', $guest_author->user_nicename );
+		$coauthors_plus->fix_author_page( '' );
+
+		$this->assertTrue( is_author(), 'is_author() must remain true on an author feed.' );
+		$this->assertTrue( is_archive(), 'is_archive() must remain true on an author feed.' );
+		$this->assertTrue( is_feed(), 'is_feed() must remain true on an author feed.' );
+		$this->assertFalse( is_comment_feed(), 'is_comment_feed() must remain false on an author feed.' );
+		$this->assertFalse( is_trackback(), 'is_trackback() must remain false on an author feed.' );
+		$this->assertFalse( is_category(), 'is_category() must be cleared on an author feed.' );
+	}
+
+	/**
+	 * On a plain author archive, fix_author_page() must not force is_feed to true.
+	 */
+	public function test__author_page_does_not_force_is_feed(): void {
+		global $coauthors_plus, $wp_query;
+
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'user_login'   => 'test-guest-1301-plain',
+				'display_name' => 'Test Guest 1301 Plain',
+			)
+		);
+		$guest_author    = $coauthors_plus->guest_authors->get_guest_author_by( 'id', $guest_author_id );
+
+		$this->assertNotFalse( $guest_author, 'Guest author should exist.' );
+
+		$wp_query->is_author       = true;
+		$wp_query->is_archive      = true;
+		$wp_query->is_feed         = false;
+		$wp_query->is_comment_feed = false;
+		$wp_query->is_trackback    = false;
+		$wp_query->is_category     = true;
+
+		set_query_var( 'author_name', $guest_author->user_nicename );
+		$coauthors_plus->fix_author_page( '' );
+
+		$this->assertTrue( is_author(), 'is_author() must remain true on a plain author page.' );
+		$this->assertTrue( is_archive(), 'is_archive() must remain true on a plain author page.' );
+		$this->assertFalse( is_feed(), 'is_feed() must remain false on a plain author page.' );
+		$this->assertFalse( is_comment_feed(), 'is_comment_feed() must remain false on a plain author page.' );
+		$this->assertFalse( is_trackback(), 'is_trackback() must remain false on a plain author page.' );
+		$this->assertFalse( is_category(), 'is_category() must be cleared on a plain author page.' );
+	}
 }


### PR DESCRIPTION
## Summary

`fix_author_page()` in 4.0.2 calls `$wp_query->init_query_flags()` to clear conflicting flags like `is_category` on guest author URLs (#1109). That reset also clears `is_feed`, so author feed requests like `/author/USERNAME/feed/` get served as the HTML author archive. This restores the feed flags alongside the existing `is_paged` preservation.

Fixes #1301

## Changes

### `php/class-coauthors-plus.php` — `fix_author_page()`

**Before:**
```php
$wp_query->init_query_flags();
$wp_query->is_author  = true;
$wp_query->is_archive = true;
$wp_query->is_paged   = $is_paged;
```

**After:**
```php
$is_feed         = $wp_query->is_feed;
$is_comment_feed = $wp_query->is_comment_feed;
$is_trackback    = $wp_query->is_trackback;
$is_paged        = $wp_query->is_paged;
$wp_query->init_query_flags();
$wp_query->is_author        = true;
$wp_query->is_archive       = true;
$wp_query->is_feed          = $is_feed;
$wp_query->is_comment_feed  = $is_comment_feed;
$wp_query->is_trackback     = $is_trackback;
$wp_query->is_paged         = $is_paged;
```

**Why:** Same pattern as the existing `is_paged` capture. The 4.0.2 reset that fixed #1109 dropped `is_feed` to `false`, so feed requests landed on the HTML author template. Preserving feed-related flags keeps the #1109 fix intact and restores author feeds.

### `tests/Integration/AuthorQueriedObjectTest.php`

**Added** `test__author_feed_preserves_is_feed_after_fix_author_page` and `test__author_page_does_not_force_is_feed`.

**Why:** Regression coverage. First test proves `is_feed()` survives `fix_author_page()` when a conflicting flag like `is_category` is also set. Second test guards the opposite case so a plain author page is not incorrectly served as a feed.

## Testing

**Test 1: Author RSS feed (the reported issue)**
1. Visit `/author/USERNAME/feed/`.
2. Confirm response is RSS XML (`<rss version="2.0">`), not the HTML author archive.

**Test 2: Guest author feed**
1. Create a guest author.
2. Visit `/author/GUEST-SLUG/feed/`.
3. Confirm RSS XML with the guest author's posts.

**Test 3: Query-string feed**
1. Visit `/?author=USERID&feed=rss2`.
2. Confirm RSS XML.

**Test 4: #1109 fix still works**
1. Visit `/author/USERNAME/?cat=1`.
2. Confirm no PHP warnings, page renders normally.

**Test 5: Pagination still 404s when out of range**
1. Visit `/author/USERNAME/page/9999/feed/`.
2. Confirm 404, not a feed of the previous page.

**Automated tests**
- `composer lint` — pass
- `composer test:integration` — 250 tests, 907 assertions, 1 skip (npm build assets)
- `composer test:integration-ms` — 252 tests, 919 assertions, 1 skip
- `composer cs` — no new issues
- `npm run build` — production assets built

## Screenshots

<img width="1920" height="1050" alt="SCR-20260621-otwv" src="https://github.com/user-attachments/assets/b1b60d6a-349a-40c5-bb33-89e2c783099b" />
<img width="1920" height="1050" alt="SCR-20260621-oubl" src="https://github.com/user-attachments/assets/dab9f062-ebb1-4570-806b-fce3c0f2156a" />
<img width="1920" height="1050" alt="SCR-20260621-ougd" src="https://github.com/user-attachments/assets/df397114-f46e-49d0-b577-715fef3016dc" />
