### PR TITLE
fix(author-query): add coauthors_plus_is_author_query filter for opt-out

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -885,16 +885,24 @@ class CoAuthors_Plus {
 	 */
 	protected function is_author_query( WP_Query $query ): bool {
 		if ( $query->is_author() ) {
-			return true;
+			$is_author = true;
+		} else {
+			// `author__in` with a non-empty array of IDs.
+			$author_in = $query->get( 'author__in' );
+			$is_author = is_array( $author_in ) && ! empty( $author_in );
 		}
 
-		// `author__in` with a non-empty array of IDs.
-		$author_in = $query->get( 'author__in' );
-		if ( is_array( $author_in ) && ! empty( $author_in ) ) {
-			return true;
-		}
-
-		return false;
+		/**
+		 * Allow callers to opt a specific query out of Co-Authors Plus' author SQL rewrite.
+		 *
+		 * Returning false leaves the query as a standard `post_author` query, so
+		 * it avoids the taxonomy JOIN, the per-term OR-chain, and the HAVING clause
+		 * that are used to find co-authored posts.
+		 *
+		 * @param bool     $is_author Whether CAP would otherwise rewrite this query.
+		 * @param WP_Query $query     The query being evaluated.
+		 */
+		return (bool) apply_filters( 'coauthors_plus_is_author_query', $is_author, $query );
 	}
 
 	/**

--- a/tests/Integration/AuthorMultiQueryTest.php
+++ b/tests/Integration/AuthorMultiQueryTest.php
@@ -161,4 +161,43 @@ class AuthorMultiQueryTest extends TestCase {
 		$this->assertCount( 1, $query->posts, 'Single author ID query must still work after fix.' );
 		$this->assertEquals( $post->ID, $query->posts[0]->ID );
 	}
+
+	/**
+	 * The `coauthors_plus_is_author_query` filter can opt a query out of the
+	 * CAP taxonomy rewrite so the query behaves as a standard `post_author` query.
+	 *
+	 * When the filter returns false, co-authored posts where the user is only a
+	 * taxonomy term must not be returned. This is the opt-out path requested in
+	 * issue #1296.
+	 */
+	public function test_filter_coauthors_plus_is_author_query_can_opt_out(): void {
+		$author1 = $this->create_author( 'opt_out_a1' );
+		$author2 = $this->create_author( 'opt_out_a2' );
+
+		$post = $this->create_post( $author1 );
+		$this->_cap->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		add_filter(
+			'coauthors_plus_is_author_query',
+			function ( $is_author, $query ) {
+				return false;
+			},
+			10,
+			2
+		);
+
+		$query = new \WP_Query(
+			array(
+				'author__in' => array( $author2->ID ),
+			)
+		);
+
+		remove_all_filters( 'coauthors_plus_is_author_query' );
+
+		$this->assertCount(
+			0,
+			$query->posts,
+			'Opting out via coauthors_plus_is_author_query must leave the query as a post_author query and skip co-authored posts.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Issue #1296 reports that 4.0.x rewrites every programmatic `author__in` query into a taxonomy JOIN + per-term OR-chain, with no way to opt out. This change adds a `coauthors_plus_is_author_query` filter inside `is_author_query()` so callers can keep a specific `WP_Query` as a standard `post_author` query.

Fixes #1296

## Changes

### `php/class-coauthors-plus.php`

**Before:**
```php
protected function is_author_query( WP_Query $query ): bool {
    if ( $query->is_author() ) {
        return true;
    }

    $author_in = $query->get( 'author__in' );
    if ( is_array( $author_in ) && ! empty( $author_in ) ) {
        return true;
    }

    return false;
}
```

**After:**
```php
protected function is_author_query( WP_Query $query ): bool {
    if ( $query->is_author() ) {
        $is_author = true;
    } else {
        $author_in = $query->get( 'author__in' );
        $is_author = is_array( $author_in ) && ! empty( $author_in );
    }

    return (bool) apply_filters( 'coauthors_plus_is_author_query', $is_author, $query );
}
```

**Why:** The gate is used by `posts_join_filter`, `posts_where_filter`, and `posts_groupby_filter`, so one filter opt-out covers all three. The default value preserves existing behavior.

### `tests/Integration/AuthorMultiQueryTest.php`

**After:** added `test_filter_coauthors_plus_is_author_query_can_opt_out()`.

**Why:** It confirms that when the filter returns `false`, an `author__in` query for a co-author who is not the `post_author` returns no results, proving the rewrite was skipped.

## Testing

**Test 1: Opt-out filter works**
1. Create a post owned by author A, with author B as a co-author.
2. Run `new WP_Query( array( 'author__in' => array( B ) ) )` without the filter: 1 post found.
3. Add `add_filter( 'coauthors_plus_is_author_query', '__return_false', 10, 2 )` and rerun: 0 posts found.
4. Remove the filter: 1 post found again.

**Test 2: Automated regression suite**
- `composer test:integration` passed: 249 tests.
- `composer test:integration-ms` passed: 251 tests.
- `composer lint` passed.
- CodeRabbit review: 0 findings.
