### PR TITLE
fix(author-dropdown): pre-populate and repopulate the Select An Author combobox

### DIFF
--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -47,8 +47,8 @@ const CoAuthors = () => {
 
 	/**
 	 * Tracks whether the initial empty-query author list has been loaded
-	 * for this mount. Gates the dropdown so subsequent empty/short queries
-	 * (e.g. user clearing the input) do not clobber the initial results.
+	 * for this mount. The mount effect uses this to avoid duplicate initial
+	 * fetches; clearing the input now intentionally re-fetches the list.
 	 */
 	const hasInitialLoaded = useRef( false );
 
@@ -168,8 +168,10 @@ const CoAuthors = () => {
 	 * @param {string} query The text to search.
 	 */
 	const onFilterValueChange = useDebounce( ( query ) => {
-		// Leave the initially populated list alone when the input is cleared.
-		if ( query.length === 0 && hasInitialLoaded.current ) {
+		// Empty input: repopulate the full alphabetical list so clearing the
+		// search restores the initial dropdown instead of leaving stale results.
+		if ( query.length === 0 ) {
+			fetchAuthors( '' );
 			return;
 		}
 

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -168,16 +168,11 @@ const CoAuthors = () => {
 	 * @param {string} query The text to search.
 	 */
 	const onFilterValueChange = useDebounce( ( query ) => {
-		// Empty input: repopulate the full alphabetical list so clearing the
-		// search restores the initial dropdown instead of leaving stale results.
-		if ( query.length === 0 ) {
-			fetchAuthors( '' );
-			return;
-		}
-
-		// Don't kick off search without having at least the threshold characters.
+		// Short or empty query: show the full alphabetical list. This keeps the
+		// dropdown useful while the user is still typing, and avoids the confusing
+		// "No items found" state for single-character input.
 		if ( query.length < threshold ) {
-			setDropdownOptions( [] );
+			fetchAuthors( '' );
 			return;
 		}
 

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -6,7 +6,7 @@ import { ComboboxControl, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 
 /**
@@ -38,12 +38,19 @@ import './style.css';
  * the select and methods from dispatch as composed below.
  *
  * @return {JSX.Element} Document sidebar panel component.
-*/
+ */
 const CoAuthors = () => {
 	/**
 	 * Local state for dropdown options (search results).
 	 */
 	const [ dropdownOptions, setDropdownOptions ] = useState( [] );
+
+	/**
+	 * Tracks whether the initial empty-query author list has been loaded
+	 * for this mount. Gates the dropdown so subsequent empty/short queries
+	 * (e.g. user clearing the input) do not clobber the initial results.
+	 */
+	const hasInitialLoaded = useRef( false );
 
 	/**
 	 * Read co-author term IDs from the core entity store.
@@ -61,7 +68,8 @@ const CoAuthors = () => {
 	/**
 	 * Resolve term IDs to rich author data.
 	 */
-	const { authors: selectedAuthors, isLoading } = useCoauthorDetails( coauthorTermIds );
+	const { authors: selectedAuthors, isLoading } =
+		useCoauthorDetails( coauthorTermIds );
 
 	/**
 	 * Get editPost dispatcher to write changes back to the core entity.
@@ -74,6 +82,48 @@ const CoAuthors = () => {
 	 * @param {integer} threshold length threshold. default 2.
 	 */
 	const threshold = applyFilters( 'coAuthors.search.threshold', 2 );
+
+	/**
+	 * Fetch authors matching the supplied query and update the dropdown.
+	 *
+	 * @param {string} query Search text to send to the REST endpoint.
+	 */
+	const fetchAuthors = async ( query ) => {
+		const existingAuthors = selectedAuthors
+			.map( ( item ) => item.value )
+			.join( ',' );
+
+		try {
+			const response = await apiFetch( {
+				path: `/coauthors/v1/search/?q=${ query }&existing_authors=${ existingAuthors }`,
+				method: 'GET',
+			} );
+			const formattedAuthors = ( ( items ) => {
+				if ( items.length > 0 ) {
+					return items.map( ( item ) => formatAuthorData( item ) );
+				}
+				return [];
+			} )( response );
+
+			setDropdownOptions( formattedAuthors );
+		} catch ( error ) {
+			console.log( error ); // eslint-disable-line no-console
+		}
+	};
+
+	/**
+	 * Load the initial alphabetical author list once the post and its
+	 * resolved co-authors are available, so the dropdown is already
+	 * populated when the user first focuses it.
+	 */
+	useEffect( () => {
+		if ( ! hasResolvedPost || isLoading || hasInitialLoaded.current ) {
+			return;
+		}
+
+		hasInitialLoaded.current = true;
+		fetchAuthors( '' );
+	}, [ hasResolvedPost, isLoading ] );
 
 	/**
 	 * Setter for updating authors via the core entity store.
@@ -117,36 +167,19 @@ const CoAuthors = () => {
 	 *
 	 * @param {string} query The text to search.
 	 */
-	const onFilterValueChange = useDebounce( async ( query ) => {
-		let response = 0;
+	const onFilterValueChange = useDebounce( ( query ) => {
+		// Leave the initially populated list alone when the input is cleared.
+		if ( query.length === 0 && hasInitialLoaded.current ) {
+			return;
+		}
 
-		// Don't kick off search without having at least two characters.
+		// Don't kick off search without having at least the threshold characters.
 		if ( query.length < threshold ) {
 			setDropdownOptions( [] );
 			return;
 		}
 
-		const existingAuthors = selectedAuthors
-			.map( ( item ) => item.value )
-			.join( ',' );
-
-		try {
-			response = await apiFetch( {
-				path: `/coauthors/v1/search/?q=${ query }&existing_authors=${ existingAuthors }`,
-				method: 'GET',
-			} );
-			const formattedAuthors = ( ( items ) => {
-				if ( items.length > 0 ) {
-					return items.map( ( item ) => formatAuthorData( item ) );
-				}
-				return [];
-			} )( response );
-
-			setDropdownOptions( formattedAuthors );
-		} catch ( error ) {
-			response = 0;
-			console.log( error ); // eslint-disable-line no-console
-		}
+		fetchAuthors( query );
 	}, 500 );
 
 	// Show spinner while the post entity or author details are still loading.


### PR DESCRIPTION
## Summary

Fixes #1300.

The block editor's "Select An Author" combobox showed "No items found" as soon as it was focused, before the user typed anything. After focusing, typing and then clearing or reducing the query to a single character could also leave the dropdown empty or stale. This fix keeps the dropdown populated with the alphabetical author list whenever the user has not yet typed enough characters for a search.

## Changes

### src/components/co-authors/index.jsx

**Before:**

```js
const onFilterValueChange = useDebounce( async ( query ) => {
    let response = 0;

    // Don't kick off search without having at least two characters.
    if ( query.length < threshold ) {
        setDropdownOptions( [] );
        return;
    }

    // ... fetch authors
}, 500 );
```

**After:**

```js
const onFilterValueChange = useDebounce( ( query ) => {
    // Short or empty query: show the full alphabetical list. This keeps the
    // dropdown useful while the user is still typing, and avoids the confusing
    // "No items found" state for single-character input.
    if ( query.length < threshold ) {
        fetchAuthors( '' );
        return;
    }

    fetchAuthors( query );
}, 500 );
```

**Why:** the backend endpoint already returns the first 10 alphabetical co-authors for an empty query. The frontend was blocking that request and clearing the dropdown for short input. Now the dropdown is populated before the user can focus it, and it stays populated while the query is below the threshold.

### src/components/co-authors/index.jsx

**After:**

```js
useEffect( () => {
    if ( ! hasResolvedPost || isLoading || hasInitialLoaded.current ) {
        return;
    }

    hasInitialLoaded.current = true;
    fetchAuthors( '' );
}, [ hasResolvedPost, isLoading ] );
```

**Why:** fetching the initial list via the mount effect avoids the race condition of setting a load flag inside a debounced callback. The list is ready before the user focuses the combobox.

## Testing

**Test 1: Focus shows authors immediately**

1. Open a post in the block editor.
2. Wait for the Authors panel to load.
3. Click into the "Select An Author" combobox.

Result: up to 10 alphabetical co-authors appear immediately, excluding authors already assigned to the post.

**Test 2: Single character does not show "No items found"**

1. Type one character, e.g. "d".

Result: the full alphabetical list remains visible.

**Test 3: Full search still works**

1. Type two or more characters, e.g. "david".
2. Wait for the debounce.

Result: the list updates to matching authors.

**Test 4: Backspacing restores the list**

1. Backspace from "david" to "d" one character at a time.

Result: the full alphabetical list reappears; "No items found" does not appear.

**Test 5: Clearing the input restores the list**

1. Select all text in the combobox and delete it.

Result: the full alphabetical list remains visible.

## Screen recording

https://github.com/user-attachments/assets/4f1b5b4a-9061-4a78-800d-38175a2ccda3

