### PR TITLE
Memoise supported_post_types() to stop per-request recomputation

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -321,6 +321,10 @@ class CoAuthors_Plus {
 	 * @return array Supported post types.
 	 */
 	public function supported_post_types(): array {
+		if ( ! empty( $this->supported_post_types ) ) {
+			return $this->supported_post_types;
+		}
+
 		$post_types = array_values( get_post_types() );
 
 		$excluded_built_in = array(

--- a/tests/Integration/SupportedPostTypesCacheTest.php
+++ b/tests/Integration/SupportedPostTypesCacheTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression coverage for issue #1049.
+ *
+ * Previously supported_post_types() was recomputed on every call —
+ * get_post_types() plus the coauthors_supported_post_types filter — hundreds of
+ * times per request.
+ * It now returns the value stored on $this->supported_post_types after the
+ * first call. This test pins that memoisation: once computed, a later change to
+ * the filter does not alter the result within the same request.
+ *
+ * @covers \CoAuthors_Plus::supported_post_types
+ */
+class SupportedPostTypesCacheTest extends TestCase {
+
+	public function test_supported_post_types_is_memoised_after_first_call(): void {
+		// Clear any value cached during bootstrap so the first call below computes fresh.
+		$this->_cap->supported_post_types = array();
+
+		$first = $this->_cap->supported_post_types();
+		$this->assertNotEmpty( $first, 'The first computation should return the supported post types.' );
+
+		// A filter added after the first call must be ignored while the result is cached.
+		$add_type = static function ( $types ) {
+			$types[] = 'cap_post_type_added_late';
+			return $types;
+		};
+		add_filter( 'coauthors_supported_post_types', $add_type );
+
+		try {
+			$second = $this->_cap->supported_post_types();
+		} finally {
+			remove_filter( 'coauthors_supported_post_types', $add_type );
+			$this->_cap->supported_post_types = array();
+		}
+
+		$this->assertSame( $first, $second, 'supported_post_types() should return the memoised result on subsequent calls.' );
+		$this->assertNotContains( 'cap_post_type_added_late', $second, 'A filter change after the first call must not leak into the cached result.' );
+	}
+}


### PR DESCRIPTION
## Summary

`supported_post_types()` is one of the most frequently called methods in the plugin: it backs `is_post_type_enabled()`, the caps filter, and several admin paths, so it runs many times — by the report on #1049, hundreds of times per request. Each call rebuilt the list from scratch with `get_post_types()` and an `apply_filters( 'coauthors_supported_post_types', … )` pass, even though the result does not change within a request.

The method already stored its result on `$this->supported_post_types` "for back-compat", but nothing ever read it. This change has the method return that stored value on subsequent calls, turning an existing dead write into an actual per-request memo.

This takes over #1058 by @douglas-johnson — his original commit is preserved here with authorship intact — and adds integration coverage so the behaviour can't silently regress.

### A note for reviewers on timing

The memo freezes the list at the first call, which happens in `action_init_late()` on `init` priority 100. That is the same point at which the plugin already registers the author taxonomy's `object_types`, so a post type registered later than that is not attached to Co-Authors Plus today either. The memo is therefore consistent with an assumption the plugin already makes, rather than introducing a new limitation. Post types registered at the usual `init` priority (10) are well in place before the first call.

Closes #1049. Supersedes #1058.

## Test plan

- [x] `SupportedPostTypesCacheTest` asserts the result is memoised: a `coauthors_supported_post_types` filter added after the first call does not alter the cached value. Fails without the early return, passes with it.
- [x] phpcs clean; full integration suite green locally against wp-env.