### PR TITLE
Render the posts Authors column without relying on global $post

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -296,8 +296,8 @@ class CoAuthors_Plus {
 		// Hooks to add additional co-authors to 'authors' column to edit page
 		add_filter( 'manage_posts_columns', array( $this, '_filter_manage_posts_columns' ) );
 		add_filter( 'manage_pages_columns', array( $this, '_filter_manage_posts_columns' ) );
-		add_action( 'manage_posts_custom_column', array( $this, '_filter_manage_posts_custom_column' ) );
-		add_action( 'manage_pages_custom_column', array( $this, '_filter_manage_posts_custom_column' ) );
+		add_action( 'manage_posts_custom_column', array( $this, '_filter_manage_posts_custom_column' ), 10, 2 );
+		add_action( 'manage_pages_custom_column', array( $this, '_filter_manage_posts_custom_column' ), 10, 2 );
 
 		// Add quick-edit co-author select field
 		add_action( 'quick_edit_custom_box', array( $this, '_action_quick_edit_custom_box' ), 10, 2 );
@@ -647,20 +647,21 @@ class CoAuthors_Plus {
 	/**
 	 * Insert co-authors into post rows on Edit Page
 	 *
-	 * @param string $column_name
+	 * @param string $column_name The name of the column in the list table.
+	 * @param int    $post_id     The ID of the current post in the list table.
 	 */
-	public function _filter_manage_posts_custom_column( $column_name ): void {
+	public function _filter_manage_posts_custom_column( $column_name, $post_id ): void {
 		if ( 'coauthors' === $column_name ) {
-			global $post;
-			$authors = get_coauthors( $post->ID );
+			$authors = get_coauthors( $post_id );
 
 			$count = 1;
 			foreach ( $authors as $author ) :
 				$args = array(
 					'author_name' => $author->user_nicename,
 				);
-				if ( 'post' !== $post->post_type ) {
-					$args['post_type'] = $post->post_type;
+				$post_type = get_post_type( $post_id );
+				if ( 'post' !== $post_type ) {
+					$args['post_type'] = $post_type;
 				}
 				$author_filter_url = add_query_arg( array_map( 'rawurlencode', $args ), admin_url( 'edit.php' ) );
 				$user_type         = $author instanceof WP_User ? 'wp-user' : 'guest-user';

--- a/tests/Integration/PostsListTableColumnTest.php
+++ b/tests/Integration/PostsListTableColumnTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression coverage for issue #1068.
+ *
+ * The "Authors" column on the posts list table read `global $post`, which is
+ * only set while the list table renders inside The Loop. When a list table is
+ * rendered from a programmatic WP_Query (for example Admin Columns exports),
+ * `$post` is null and the column threw "Attempt to read property ID on null"
+ * and rendered nothing. The column must instead use the `$post_id` the
+ * `manage_posts_custom_column` hook passes.
+ *
+ * @covers \CoAuthors_Plus::_filter_manage_posts_custom_column
+ */
+class PostsListTableColumnTest extends TestCase {
+
+	public function test_posts_custom_column_renders_from_post_id_without_global_post(): void {
+		$author = $this->create_author( 'col_author_1068' );
+		$post   = $this->create_post( $author );
+		$this->_cap->add_coauthors( $post->ID, array( $author->user_login ) );
+
+		// Simulate list-table rendering outside The Loop: no global $post.
+		unset( $GLOBALS['post'] );
+
+		ob_start();
+		$this->_cap->_filter_manage_posts_custom_column( 'coauthors', $post->ID );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			$author->display_name,
+			$output,
+			'The column must render the co-author using only the post ID, with no global $post available.'
+		);
+		$this->assertStringContainsString(
+			'author_name=' . $author->user_nicename,
+			$output,
+			'The co-author link must point at the author filter.'
+		);
+	}
+
+	public function test_posts_custom_column_ignores_other_columns(): void {
+		$post = $this->create_post();
+		unset( $GLOBALS['post'] );
+
+		ob_start();
+		$this->_cap->_filter_manage_posts_custom_column( 'some_other_column', $post->ID );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output, 'The method must output nothing for columns other than coauthors.' );
+	}
+}


### PR DESCRIPTION
## Summary

The "Authors" column on the posts list table read `global $post` to find the post it was rendering. That global is only set while the list table runs inside the main loop, so when a list table is built from a programmatic `WP_Query` — Admin Columns exports being the common case — `$post` is null, and the column raised *"Attempt to read property ID on null"* and rendered nothing (#1068).

The fix is to use the `$post_id` that the `manage_posts_custom_column` hook already passes: register the hook with `10, 2`, take `$post_id` as the second argument, and derive everything (`get_coauthors()`, `get_post_type()`) from it rather than from `global $post`.

This takes over #1069 by @justinmaurerdotdev — his commit is preserved here with authorship intact, rebased onto current `develop` so it keeps the newer `data-*` byline markup that had since been added to the same method, with the indentation tidied to match the file.

## Test plan

- [x] New `PostsListTableColumnTest` renders the column from a post ID with **no** `global $post` set, asserting the co-author and its filter link appear. It fails without the fix ("read property ID on null") and passes with it.
- [x] Full integration suite green locally against wp-env.

Closes #1068. Supersedes #1069.