### PR TITLE
Apply the default byline delimiter when 'between' is an empty string

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -140,7 +140,11 @@ function coauthors__echo( $tag, $type = 'tag', $separators = array(), $tag_args 
 	if ( ! isset( $separators['before'] ) ) {
 		$separators['before'] = apply_filters( 'coauthors_default_before', $default_before );
 	}
-	if ( ! isset( $separators['between'] ) ) {
+	// Treat a caller-supplied empty string the same as unset, so the default
+	// delimiter is applied. Otherwise `coauthors( '' )` drops the separator
+	// between the middle authors (e.g. "AnnaBenCara and Dan"). An intentional
+	// empty separator can still be set via the coauthors_default_between filter.
+	if ( ! isset( $separators['between'] ) || '' === $separators['between'] ) {
 		$separators['between'] = apply_filters( 'coauthors_default_between', $default_between );
 	}
 	if ( ! isset( $separators['betweenLast'] ) ) {

--- a/tests/Integration/BylineSeparatorTest.php
+++ b/tests/Integration/BylineSeparatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression coverage for issue #1310.
+ *
+ * Previously, coauthors__echo() applied the default "between" delimiter only
+ * when the separator was unset. A caller passing an empty string — coauthors( '' ) —
+ * left the middle authors run together ("AnnaBenCara and Dan"), because
+ * isset( '' ) is true. A caller-supplied empty string should fall back to the
+ * default, while an empty separator set deliberately through the
+ * coauthors_default_between filter must still be honoured.
+ *
+ * @covers \coauthors__echo
+ */
+class BylineSeparatorTest extends TestCase {
+
+	/**
+	 * Create four named authors and assign them, in order, to a published post.
+	 */
+	private function post_with_four_authors() {
+		$authors = array(
+			'sep_a' => 'Anna',
+			'sep_b' => 'Ben',
+			'sep_c' => 'Cara',
+			'sep_d' => 'Dan',
+		);
+		foreach ( $authors as $login => $display ) {
+			$this->factory()->user->create_and_get(
+				array(
+					'role'         => 'author',
+					'user_login'   => $login,
+					'display_name' => $display,
+				)
+			);
+		}
+		$post = $this->factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+		$this->_cap->add_coauthors( $post->ID, array( 'sep_a', 'sep_b', 'sep_c', 'sep_d' ) );
+
+		return $post;
+	}
+
+	public function test_empty_between_string_falls_back_to_default_delimiter(): void {
+		$post            = $this->post_with_four_authors();
+		$GLOBALS['post'] = $post;
+		setup_postdata( $post );
+
+		$byline = coauthors( '', null, null, null, false );
+
+		wp_reset_postdata();
+
+		$this->assertStringContainsString(
+			'Anna, Ben, Cara and Dan',
+			$byline,
+			'An empty-string between delimiter must fall back to the default ", " rather than dropping the middle separators.'
+		);
+	}
+
+	public function test_filter_supplied_empty_between_is_still_honoured(): void {
+		$post = $this->post_with_four_authors();
+
+		add_filter( 'coauthors_default_between', '__return_empty_string' );
+		$GLOBALS['post'] = $post;
+		setup_postdata( $post );
+
+		$byline = coauthors( null, null, null, null, false );
+
+		remove_filter( 'coauthors_default_between', '__return_empty_string' );
+		wp_reset_postdata();
+
+		$this->assertStringNotContainsString(
+			'Anna, Ben',
+			$byline,
+			'An empty separator set deliberately via the coauthors_default_between filter must still be honoured.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

A forum report ([missing delimiters with 3 authors](https://wordpress.org/support/topic/missing-delimiters-with-3-authors/), Soledad theme) described bylines losing the separators between the middle authors — `AnnaBenCara and Dan` instead of `Anna, Ben, Cara and Dan`.

The byline join in `coauthors__echo()` is correct and unchanged since 3.7.0, and renders properly with the default separators for any number of authors, so this isn't a regression in the join itself. The symptom reproduces only when the `between` delimiter is an **empty string**: `coauthors( '' )`. The default is applied with `! isset( $separators['between'] )`, and `isset( '' )` is `true`, so a caller-supplied empty string skips the default and leaves the middle authors run together. A theme or site snippet passing `coauthors( '' )` (or filtering `coauthors_default_between` to `''`) is the source of the empty value.

This treats a caller-supplied empty string the same as unset, so the default `, ` is applied. An empty separator set deliberately through the `coauthors_default_between` filter is still honoured, because the filter result is what gets applied — only a loosely-passed empty value from a caller is corrected.

## Test plan

- [x] New `BylineSeparatorTest`: `coauthors( '' )` over four authors now yields `Anna, Ben, Cara and Dan` (fails without the fix with `AnnaBenCara and Dan`), and an empty separator set via the filter is still respected.
- [x] Existing byline output for default (`null`) separators is unchanged.

Fixes #1310.