### PR TITLE
Refresh a co-author's search term when their user profile changes

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -83,6 +83,9 @@ class CoAuthors_Plus {
 		// Action to reassign posts when a guest author is deleted
 		add_action( 'delete_user', array( $this, 'delete_user_action' ) );
 
+		// Keep an existing co-author's search term (and its cache) in step when the user's profile changes.
+		add_action( 'profile_update', array( $this, 'update_author_term_on_profile_update' ) );
+
 		add_filter( 'get_usernumposts', array( $this, 'filter_count_user_posts' ), 10, 4 );
 
 		// Action to set up co-author auto-suggest
@@ -2414,6 +2417,32 @@ class CoAuthors_Plus {
 		}
 		wp_cache_delete( 'author-term-' . $coauthor->user_nicename, 'co-authors-plus' );
 		return $this->get_author_term( $coauthor );
+	}
+
+	/**
+	 * Refresh a co-author's author term when their user profile is updated.
+	 *
+	 * The author term description stores the user's searchable fields (display
+	 * name, email, login). Without this, editing a user's profile leaves that
+	 * description, and the cached term in the persistent 'co-authors-plus' object
+	 * cache group, stale until a manual cache flush, so the author search keeps
+	 * matching the old details. Only an existing co-author term is refreshed;
+	 * users who are not co-authors do not get a term created here, to avoid
+	 * unbounded term growth on sites with large, low-privilege user bases.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param int $user_id The ID of the updated user.
+	 * @return void
+	 */
+	public function update_author_term_on_profile_update( $user_id ): void {
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return;
+		}
+		if ( $this->get_author_term( $user ) ) {
+			$this->update_author_term( $user );
+		}
 	}
 
 	/**

--- a/tests/Integration/AuthorTermProfileUpdateTest.php
+++ b/tests/Integration/AuthorTermProfileUpdateTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration;
+
+/**
+ * Regression coverage for issue #849.
+ *
+ * A co-author's searchable author term (its description holds the display name,
+ * email and login) was only rebuilt when CAP itself touched the author, never
+ * when the underlying user's profile changed through normal wp-admin. On a
+ * persistent object cache this left the author search matching stale details
+ * until a manual flush. The profile_update hook now refreshes an existing
+ * co-author term so the search stays in step.
+ *
+ * @covers \CoAuthors_Plus::update_author_term_on_profile_update
+ */
+class AuthorTermProfileUpdateTest extends TestCase {
+
+	public function test_author_term_refreshes_when_user_profile_changes(): void {
+		$user = $this->factory()->user->create_and_get(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'jane_refresh',
+				'display_name' => 'Jane Smith',
+			)
+		);
+
+		// Give the co-author a searchable term, and confirm the original name matches.
+		$this->_cap->update_author_term( $user );
+		$this->assertArrayHasKey(
+			'jane_refresh',
+			$this->_cap->search_authors( 'Smith' ),
+			'Sanity check: the co-author should be searchable by their original name.'
+		);
+
+		// Rename the user through the normal flow, which fires profile_update.
+		wp_update_user(
+			array(
+				'ID'           => $user->ID,
+				'display_name' => 'Jane Jones',
+			)
+		);
+
+		$this->assertArrayHasKey(
+			'jane_refresh',
+			$this->_cap->search_authors( 'Jones' ),
+			'After a profile update the co-author must be searchable by their new name.'
+		);
+	}
+
+	public function test_profile_update_does_not_create_a_term_for_a_non_coauthor(): void {
+		$user = $this->factory()->user->create_and_get(
+			array(
+				'role'         => 'subscriber',
+				'user_login'   => 'sub_refresh',
+				'display_name' => 'Sub Scriber',
+			)
+		);
+
+		// This user has never been a co-author and has no term.
+		$this->assertEmpty( $this->_cap->get_author_term( $user ), 'Sanity check: the user has no author term to begin with.' );
+
+		wp_update_user(
+			array(
+				'ID'           => $user->ID,
+				'display_name' => 'Sub Renamed',
+			)
+		);
+
+		$this->assertEmpty(
+			$this->_cap->get_author_term( $user ),
+			'A profile update must not create an author term for a user who is not a co-author.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

A co-author's author term carries their display name, email and login in its description — that's what the author search matches against — and `get_author_term()` caches the term in the **persistent** `co-authors-plus` object-cache group. Neither was rebuilt when a user's profile changed through normal wp-admin: CAP only refreshed a term when it touched the author itself. So on a site with a persistent object cache, editing a co-author's name or email left the author search matching the old details until a manual cache flush — and the back-fill in `search_authors()` doesn't recover it, because it skips any term whose description is already non-empty.

This hooks `profile_update` to refresh an **existing** co-author's term, which updates the searchable description in the database and busts the cached term. Users who aren't co-authors don't gain a term here, so this can't cause unbounded term growth on sites with large, low-privilege user bases.

## Test plan

- [x] `AuthorTermProfileUpdateTest`: renaming a co-author makes them searchable by the new name (fails without the hook, since the term description stays stale); and a `profile_update` on a non-co-author does **not** create a term.
- [x] phpcs clean on the new test file; full integration suite green locally.

## Note for reviewers

The author term is keyed and slugged on `user_nicename`, so this refreshes the term in place for the common case (a display name or email change). A change to the *nicename* itself is a deeper, pre-existing concern (the term slug is `cap-<nicename>`) and is out of scope here.

Resolves #849.