### PR TITLE
Move hook registration out of class constructors

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -51,7 +51,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 global $coauthors_plus;
 $coauthors_plus     = new CoAuthors_Plus();
+$coauthors_plus->register_hooks();
 $coauthors_endpoint = new CoAuthors\API\Endpoints( $coauthors_plus );
+$coauthors_endpoint->register_hooks();
 CoAuthors\Blocks::run();
 
 // Initialize integrations.

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -44,7 +44,15 @@ class Endpoints {
 	 */
 	public function __construct( $coauthors_instance ) {
 		$this->coauthors = $coauthors_instance;
+	}
 
+	/**
+	 * Register the REST API hooks.
+	 *
+	 * Called from the composition root after construction so that creating an
+	 * instance has no global side effects.
+	 */
+	public function register_hooks(): void {
 		add_action( 'rest_api_init', array( $this, 'add_endpoints' ) );
 		add_action( 'wp_loaded', array( $this, 'modify_responses' ) );
 	}

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -17,9 +17,12 @@ class CoAuthors_Guest_Authors {
 	public static $cache_group = 'coauthors-plus-guest-authors';
 
 	/**
-	 * Initialize our Guest Authors class and establish common hooks
+	 * Register the Guest Authors hooks and the guest author post type.
+	 *
+	 * Called from the composition root after construction so that creating an
+	 * instance has no global side effects.
 	 */
-	public function __construct() {
+	public function register_hooks(): void {
 		global $coauthors_plus;
 
 		// Add the guest author management menu

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -59,9 +59,12 @@ class CoAuthors_Plus {
 	public $guest_authors;
 
 	/**
-	 * __construct()
+	 * Register the plugin's WordPress hooks.
+	 *
+	 * Called from the composition root after construction so that creating an
+	 * instance has no global side effects.
 	 */
-	public function __construct() {
+	public function register_hooks(): void {
 
 		// Register our models
 		add_action( 'init', array( $this, 'action_init' ) );
@@ -162,6 +165,7 @@ class CoAuthors_Plus {
 		if ( $this->is_guest_authors_enabled() ) {
 			require_once dirname( COAUTHORS_PLUS_FILE ) . '/php/class-coauthors-guest-authors.php';
 			$this->guest_authors = new CoAuthors_Guest_Authors();
+			$this->guest_authors->register_hooks();
 			if ( apply_filters( 'coauthors_guest_authors_force', false ) ) {
 				$this->force_guest_authors = true;
 			}
@@ -171,6 +175,7 @@ class CoAuthors_Plus {
 		if ( apply_filters( 'coauthors_auto_apply_template_tags', false ) ) {
 			global $coauthors_plus_template_filters;
 			$coauthors_plus_template_filters = new CoAuthors_Template_Filters();
+			$coauthors_plus_template_filters->register_hooks();
 		}
 
 	}

--- a/php/class-coauthors-template-filters.php
+++ b/php/class-coauthors-template-filters.php
@@ -6,7 +6,13 @@
 
 class CoAuthors_Template_Filters {
 
-	public function __construct() {
+	/**
+	 * Register the template filter hooks.
+	 *
+	 * Called from the composition root after construction so that creating an
+	 * instance has no global side effects.
+	 */
+	public function register_hooks(): void {
 		add_filter( 'the_author', array( $this, 'filter_the_author' ) );
 		add_filter( 'the_author_posts_link', array( $this, 'filter_the_author_posts_link' ) );
 

--- a/tests/Integration/EndpointsTest.php
+++ b/tests/Integration/EndpointsTest.php
@@ -27,9 +27,11 @@ class EndpointsTest extends TestCase {
 	}
 
 	/**
-	 * @covers \CoAuthors\API\Endpoints::__construct
+	 * @covers \CoAuthors\API\Endpoints::register_hooks
 	 */
-	public function test_construct(): void {
+	public function test_register_hooks(): void {
+
+		$this->_api->register_hooks();
 
 		$this->assertEquals(
 			10,

--- a/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
@@ -15,6 +15,7 @@ class CoauthorsPostsLinksTest extends TestCase {
 	public function test_the_author_filter_is_retained(): void {
 		global $coauthors_plus_template_filters;
 		$coauthors_plus_template_filters = new \CoAuthors_Template_Filters();
+		$coauthors_plus_template_filters->register_hooks();
 		$this->assertEquals( 10, has_filter( 'the_author', array( $coauthors_plus_template_filters, 'filter_the_author' ) ) );
 	}
 


### PR DESCRIPTION
## Summary

Constructing `CoAuthors_Plus`, `CoAuthors_Guest_Authors`, `CoAuthors\API\Endpoints`, or `CoAuthors_Template_Filters` used to mutate the global hook registry as a side effect: each constructor called `add_action()`/`add_filter()`, and the guest authors constructor went further by requiring the list-table class and registering the `guest-author` post type. Coupling instantiation to hook registration means these objects cannot be created for inspection or testing without wiring them into WordPress, and it scatters the hook surface across constructors where it is harder to discover and reason about.

This change introduces a side-effect-free `register_hooks()` method on each of the four classes. Constructors now set up state only (`Endpoints` keeps its `$coauthors` assignment); everything that touches WordPress moves into `register_hooks()`. The composition root calls it immediately after construction — in `co-authors-plus.php` for `CoAuthors_Plus` and `Endpoints`, and in `CoAuthors_Plus::action_init()` for the guest authors and template filter instances — so registration happens at exactly the same point in the load as before.

Two integration tests asserted the old constructor side effect (that hooks were registered on construction). They have been updated to call `register_hooks()` first, with `EndpointsTest::test_construct()` renamed to `test_register_hooks()` to reflect what it now covers.

The in-method `remove_filter()`/`remove_action()` calls noted in the issue are intentionally left untouched: those are operational, mid-request behaviour rather than construction side effects, and are tracked separately.

## Is this a breaking change?

Technically yes, under a strict reading of semver: the observable behaviour of public constructors has changed. In practice it is about as benign as such a change can be, because the only thing that breaks is reliance on the exact coupling this PR exists to remove.

There are two ways a consumer could notice:

1. **Direct instantiation no longer wires hooks.** `new CoAuthors_Plus()` used to register hooks; now you must call `->register_hooks()`. The blast radius is near zero: the documented entry point is the `$coauthors_plus` global, which is unchanged, and re-instantiating the class was never sensible anyway — it would have double-registered ~55 hooks on top of the global instance's.

2. **A subclass calling `parent::__construct()` now fatals**, because three of the classes no longer define a constructor. This looks like a separate break but collapses into the first: under the old code the *only* thing `parent::__construct()` did was register those same hooks bound to `$this`, and since the plugin instantiates the concrete class directly (with no filter to swap it), a subclass could never cleanly replace the canonical instance regardless. So any subclass calling it was already depending on the side effect we are deliberately deleting.

We considered re-adding empty constructors to keep `parent::__construct()` working, but decided against it: a no-op constructor would silently swallow the call instead of throwing, turning an accurate fatal ("this changed, go look") into a subclass whose hooks quietly fail to register. The loud failure is the more honest signal.

The supported public surface — template tags, hooks/filters, and the `$coauthors_plus` global — is wholly unchanged. Only code reaching into internal class *construction*, which was never a supported pattern, is affected.

Refs #1315.

## Test plan

- [x] `composer cs` on the changed files shows no new violations (error counts match `develop` exactly; the template filters file dropped by one as the new docblock satisfied a sniff).
- [x] Single-site integration suite passes: 265 tests, 0 failures (the one skip is the pre-existing missing-build-files asset test).
- [x] Multisite integration suite shows only the two failures that already fail on `develop` (an unrelated wp-env blog-factory setup issue); this change adds none.