### PR TITLE
Stop hiding the Authors box on custom post types

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -356,8 +356,18 @@ class CoAuthors_Plus {
 		 */
 		$supported_post_types = (array) apply_filters( 'coauthors_supported_post_types', $post_types );
 
-		// Set class property for back-compat.
-		$this->supported_post_types = $supported_post_types;
+		// Only memoise once every post type has had a chance to register. The first
+		// call can arrive before `init` — a capability check during bootstrap (e.g.
+		// kses_init() on set_current_user calling current_user_can()) reaches this
+		// method via filter_user_has_cap() → get_to_be_filtered_caps(). Caching then
+		// would freeze a list containing only the built-in post types, permanently
+		// excluding every custom post type registered on `init` and hiding the
+		// Authors box on those screens. Compute fresh until `wp_loaded` (which fires
+		// after `init`), by which point the list is stable, then memoise it for the
+		// admin and REST requests where this method is called many times per request.
+		if ( did_action( 'wp_loaded' ) ) {
+			$this->supported_post_types = $supported_post_types;
+		}
 
 		return $supported_post_types;
 	}

--- a/tests/Integration/Bylines/SupportedPostTypesTest.php
+++ b/tests/Integration/Bylines/SupportedPostTypesTest.php
@@ -201,4 +201,58 @@ class SupportedPostTypesTest extends TestCase {
 		$this->assertSame( $first, $second, 'supported_post_types() should return the memoised result on subsequent calls.' );
 		$this->assertNotContains( 'cap_post_type_added_late', $second, 'A filter change after the first call must not leak into the cached result.' );
 	}
+
+	/**
+	 * Regression coverage for the Authors box disappearing on custom post types.
+	 *
+	 * The memoisation from #1049 froze the supported-post-type list on the first
+	 * call. That call can arrive before `init` — a capability check during
+	 * bootstrap (kses_init() on set_current_user) reaches supported_post_types()
+	 * via filter_user_has_cap() → get_to_be_filtered_caps(). Caching there froze a
+	 * list of only the built-in post types, so every custom post type registered
+	 * on `init` was excluded for the rest of the request and its Authors box was
+	 * hidden, leaving only the native single-author selector.
+	 *
+	 * The list must therefore not be memoised until `wp_loaded` has fired, by
+	 * which point all post types are registered.
+	 *
+	 * @covers ::supported_post_types
+	 */
+	public function test_early_call_before_wp_loaded_does_not_freeze_the_list(): void {
+		global $wp_actions;
+
+		$this->_cap->supported_post_types = array();
+
+		// Simulate reaching supported_post_types() before wp_loaded has fired.
+		$wp_loaded_count = $wp_actions['wp_loaded'] ?? 0;
+		unset( $wp_actions['wp_loaded'] );
+
+		try {
+			// An early call must compute a result but must NOT memoise it.
+			$early = $this->_cap->supported_post_types();
+			$this->assertNotEmpty( $early, 'The early call should still return the built-in post types.' );
+			$this->assertEmpty(
+				$this->_cap->supported_post_types,
+				'The list must not be memoised before wp_loaded.'
+			);
+
+			// A custom post type registers later (as it would on init).
+			register_post_type( 'cap_late_cpt', array( 'supports' => array( 'author' ) ) );
+
+			// Once wp_loaded has fired, the late post type must be detected — not
+			// excluded by a stale list frozen during the early call.
+			$wp_actions['wp_loaded'] = max( $wp_loaded_count, 1 );
+			$supported               = $this->_cap->supported_post_types();
+
+			$this->assertContains(
+				'cap_late_cpt',
+				$supported,
+				'A custom post type registered after an early call must still be supported.'
+			);
+		} finally {
+			$wp_actions['wp_loaded']          = $wp_loaded_count;
+			$this->_cap->supported_post_types = array();
+			unregister_post_type( 'cap_late_cpt' );
+		}
+	}
 }


### PR DESCRIPTION
## Summary

After updating to 4.1.0, the **Authors** box stops appearing on custom post types. Posts and Pages keep working, but on a CPT the editor falls back to WordPress's native single-author selector, so multiple authors can no longer be assigned. Downgrading to 4.0.2 restores it. This was reported twice on the support forum, the second reporter pinning it to custom post types specifically.

The cause is the `supported_post_types()` memoisation added in #1307. That change caches the supported-post-type list on first call and never recomputes it, on the assumption the first call lands in `action_init_late()` at `init` priority 100. It does not. A capability check during bootstrap, before `init`, reaches the method first: `kses_init()` runs on `set_current_user` and calls `current_user_can()`, which passes through `filter_user_has_cap()` and `get_to_be_filtered_caps()` into `supported_post_types()`. At that moment only the built-in post types exist, so the list freezes as just `post` and `page`, and every custom post type registered later on `init` is excluded for the rest of the request. `is_post_type_enabled()` then returns false for those types and their Authors box is never added. In 4.0.2 the list was recomputed on every call, so by metabox-render time the CPT was present and the box appeared.

The fix defers the memo until `wp_loaded` has fired, by which point all post types are registered. Early bootstrap calls compute a throwaway list and skip the cache; the admin and REST requests that call this method many times per request all run after `wp_loaded`, so the performance gain from #1307 is preserved. The behaviour was confirmed end to end in wp-env: before the fix a CPT registered at `init:10` resolves to `is_post_type_enabled() === false` with a frozen list of `post,page`; after the fix the same CPT resolves to `true`.

This was reproduced and root-caused in wp-env, and should ship as **4.1.1**.

Refs VIPPLUG-39
Refs #1307, #1049

## Test plan

- [ ] Register a CPT with `author` support on `init` (priority 10) and confirm the Authors box / block-editor panel appears on that CPT in 4.1.1, and multiple authors can be assigned.
- [x] New regression test `test_early_call_before_wp_loaded_does_not_freeze_the_list` simulates the pre-`wp_loaded` early call and asserts a later-registered CPT is still supported. Fails without the fix, passes with it.
- [x] Existing `supported_post_types()` memoisation coverage (#1049) still passes.