### PR TITLE
Release 4.1.1

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,7 +9,7 @@
     "SCRIPT_DEBUG": true
   },
   "lifecycleScripts": {
-    "afterStart": "wp-env run cli wp plugin install query-monitor --activate"
+    "afterStart": "wp-env run cli wp plugin install query-monitor --activate && wp-env run cli wp eval 'require dirname( COAUTHORS_PLUS_FILE ) . \"/bin/seed-demo-data.php\";'"
   },
   "env": {
     "tests": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Multiple byline management for WordPress, supporting both WordPress users and gu
 | **Class prefix** | `CoAuthors_` (legacy), `CoAuthors\` / `Automattic\CoAuthorsPlus\` (namespaced) |
 | **Function prefix** | `cap_` (helpers), `coauthors*` (template tags) |
 | **Source directory** | `php/` (PHP classes), `src/` (JS/blocks) |
-| **Version** | 4.1.0 |
+| **Version** | 4.1.1 |
 | **Requires PHP** | 7.4+ |
 | **Requires WP** | 6.4+ |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-06-26
+
+### Fixed
+
+* Restore the Authors box on custom post types, which 4.1.0 hid by caching the supported-post-type list too early — before custom post types had registered — so multiple authors can be assigned on custom post types again by @GaryJones in https://github.com/Automattic/Co-Authors-Plus/pull/1322
+
+### Maintenance
+
+* Seed demo data on local wp-env start to ease plugin development by @GaryJones in https://github.com/Automattic/Co-Authors-Plus/pull/1320
+
 ## [4.1.0] - 2026-06-24
 
 ### Added
@@ -723,6 +733,7 @@ Props to the many people who helped make this release possible: [catchmyfame](ht
 **1.1.0 (Apr. 14, 2009)**
 * Initial beta release.
 
+[4.1.1]: https://github.com/automattic/co-authors-plus/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/automattic/co-authors-plus/compare/4.0.2...4.1.0
 [4.0.2]: https://github.com/automattic/co-authors-plus/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/automattic/co-authors-plus/compare/4.0.0...4.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,20 @@ Please make pull requests against the `develop` branch.
 
 Ideally include tests.
 
+## Local development
+
+Run `wp-env start` to spin up a local WordPress environment. On start it
+activates Query Monitor and seeds demo data (`bin/seed-demo-data.php`): a spread
+of users, standalone and linked guest authors, and posts covering single,
+multiple, mixed, fallback, and orphaned-author bylines. All demo users share the
+password `password`.
+
+Re-seed at any time (the script is idempotent) with:
+
+```sh
+composer dev:seed
+```
+
 ## Terminology: co-author vs coauthor
 
 If talking about co-authors in a documentation, DocBlock, comment, or user-facing string, please include the hyphen.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Co-Authors Plus
 
-Stable tag: 4.1.0  
+Stable tag: 4.1.1  
 Requires at least: 6.4  
 Tested up to: 7.0  
 Requires PHP: 7.4  

--- a/bin/seed-demo-data.php
+++ b/bin/seed-demo-data.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * Seed demo data for manual testing of Co-Authors Plus.
+ *
+ * Creates a spread of WordPress users, guest authors (standalone and linked),
+ * and posts with varied co-author assignments — including the fallback and
+ * orphaned-author edge cases — then, on a block theme, swaps the single-post
+ * byline for a Co-Authors Plus block so multi-author bylines render on the
+ * front end.
+ *
+ * This file lives in /bin/ and is excluded from the distributed plugin ZIP
+ * via .distignore. It is wired into `.wp-env.json`'s `afterStart` lifecycle,
+ * and can be re-run at any time with `composer dev:seed`.
+ *
+ * Idempotent: re-running reuses existing users / guest authors / posts /
+ * template (matched by login or slug) rather than duplicating them.
+ *
+ * @package CoAuthors
+ */
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+global $coauthors_plus;
+
+if ( ! isset( $coauthors_plus ) || ! isset( $coauthors_plus->guest_authors ) ) {
+	WP_CLI::error( 'Co-Authors Plus is not active; cannot seed demo data.' );
+	return;
+}
+
+$report = array();
+
+/* -------------------------------------------------------------------------
+ * 1. WordPress users (one of each relevant role)
+ * ---------------------------------------------------------------------- */
+$seed_user = static function ( $login, $email, $display, $role, $first, $last ) {
+	$existing = get_user_by( 'login', $login );
+	if ( $existing ) {
+		return (int) $existing->ID;
+	}
+	$id = wp_insert_user(
+		array(
+			'user_login'   => $login,
+			'user_email'   => $email,
+			'user_pass'    => 'password',
+			'display_name' => $display,
+			'first_name'   => $first,
+			'last_name'    => $last,
+			'role'         => $role,
+		)
+	);
+	return is_wp_error( $id ) ? 0 : (int) $id;
+};
+
+$users = array(
+	'ellie_editor'     => $seed_user( 'ellie_editor', 'ellie@example.test', 'Ellie Editor', 'editor', 'Ellie', 'Editor' ),
+	'ana_author'       => $seed_user( 'ana_author', 'ana@example.test', 'Ana Author', 'author', 'Ana', 'Author' ),
+	'ben_author'       => $seed_user( 'ben_author', 'ben@example.test', 'Ben Author', 'author', 'Ben', 'Author' ),
+	'cara_contributor' => $seed_user( 'cara_contributor', 'cara@example.test', 'Cara Contributor', 'contributor', 'Cara', 'Contributor' ),
+	'sam_subscriber'   => $seed_user( 'sam_subscriber', 'sam@example.test', 'Sam Subscriber', 'subscriber', 'Sam', 'Subscriber' ),
+);
+foreach ( $users as $login => $id ) {
+	$report[] = sprintf( 'user      %-18s #%d', $login, $id );
+}
+
+/* -------------------------------------------------------------------------
+ * 2. Guest authors (two standalone, one linked to a WP account)
+ * ---------------------------------------------------------------------- */
+$seed_guest = static function ( $args ) use ( $coauthors_plus ) {
+	$existing = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', $args['user_login'] );
+	if ( $existing ) {
+		return (int) $existing->ID;
+	}
+	return $coauthors_plus->guest_authors->create( $args );
+};
+
+$greta = $seed_guest(
+	array(
+		'display_name' => 'Greta Guest',
+		'user_login'   => 'greta_guest',
+		'first_name'   => 'Greta',
+		'last_name'    => 'Guest',
+		'user_email'   => 'greta@example.test',
+		'website'      => 'https://greta.example.test',
+		'description'  => 'A standalone guest author with no linked WordPress account.',
+	)
+);
+$hank = $seed_guest(
+	array(
+		'display_name' => 'Hank Helper',
+		'user_login'   => 'hank_helper',
+		'first_name'   => 'Hank',
+		'last_name'    => 'Helper',
+		'user_email'   => 'hank@example.test',
+		'website'      => 'https://hank.example.test',
+		'description'  => 'A second standalone guest author, byline-only.',
+	)
+);
+$linked = $seed_guest(
+	array(
+		'display_name' => 'Cara (Guest Profile)',
+		'user_login'   => 'cara_guest_profile',
+		'first_name'   => 'Cara',
+		'last_name'    => 'Contributor',
+		'user_email'   => 'cara.guest@example.test',
+		'description'  => 'A guest author linked to the cara_contributor user account.',
+	)
+);
+if ( $linked && ! is_wp_error( $linked ) ) {
+	update_post_meta( $linked, 'cap-linked_account', 'cara_contributor' );
+	$coauthors_plus->guest_authors->delete_guest_author_cache( $linked );
+}
+
+$report[] = sprintf( 'guest     %-18s #%s', 'greta_guest', is_wp_error( $greta ) ? 'ERR' : $greta );
+$report[] = sprintf( 'guest     %-18s #%s', 'hank_helper', is_wp_error( $hank ) ? 'ERR' : $hank );
+$report[] = sprintf( 'guest     %-18s #%s (linked -> cara_contributor)', 'cara_guest_profile', is_wp_error( $linked ) ? 'ERR' : $linked );
+
+/* -------------------------------------------------------------------------
+ * 3. Posts with varied co-author assignments
+ * ---------------------------------------------------------------------- */
+$seed_post = static function ( $slug, $title, $author_login, $coauthor_logins ) use ( $coauthors_plus ) {
+	$found = get_posts(
+		array(
+			'name'        => $slug,
+			'post_type'   => 'post',
+			'post_status' => 'any',
+			'numberposts' => 1,
+		)
+	);
+	if ( $found ) {
+		$post_id = (int) $found[0]->ID;
+	} else {
+		$author_user = $author_login ? get_user_by( 'login', $author_login ) : null;
+		$post_id     = wp_insert_post(
+			array(
+				'post_title'   => $title,
+				'post_name'    => $slug,
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+				'post_author'  => $author_user ? $author_user->ID : 1,
+				'post_content' => 'Sample content for smoke testing Co-Authors Plus bylines and assignments.',
+			)
+		);
+	}
+
+	if ( is_wp_error( $post_id ) || ! $post_id ) {
+		return 'ERR';
+	}
+
+	// Assign co-authors by login (covers both WP users and guest authors).
+	if ( ! empty( $coauthor_logins ) ) {
+		$coauthors_plus->add_coauthors( $post_id, $coauthor_logins, false, 'user_login' );
+	}
+	return $post_id;
+};
+
+$posts = array(
+	array( 'cap-single-author', 'The Quarterly Roadmap', 'ellie_editor', array( 'ellie_editor' ) ),
+	array( 'cap-two-authors', 'Two Heads Are Better Than One', 'ana_author', array( 'ana_author', 'ben_author' ) ),
+	array( 'cap-guest-only', 'A Guest Perspective', 'ellie_editor', array( 'greta_guest' ) ),
+	array( 'cap-mixed-byline', 'Collaboration Across Teams', 'ellie_editor', array( 'ellie_editor', 'greta_guest' ) ),
+	array( 'cap-three-mixed', 'The Big Announcement', 'ana_author', array( 'ana_author', 'ben_author', 'hank_helper' ) ),
+	array( 'cap-linked-guest', 'Notes From a Linked Profile', 'cara_contributor', array( 'cara_guest_profile' ) ),
+	// No co-author terms: falls back to post_author (legacy post).
+	array( 'cap-fallback-no-terms', 'Legacy Import (No Co-Author Terms)', 'ben_author', array() ),
+);
+
+foreach ( $posts as $p ) {
+	list( $slug, $title, $author, $coauthors ) = $p;
+	$pid      = $seed_post( $slug, $title, $author, $coauthors );
+	$report[] = sprintf( 'post      %-22s #%s  [%s]', $slug, $pid, implode( ', ', $coauthors ) );
+}
+
+// Orphaned-author post: post_author points at a non-existent user. Useful for
+// testing `wp co-authors-plus assign-user-to-coauthor --user_id`.
+$orphan_found = get_posts(
+	array(
+		'name'        => 'cap-orphaned-author',
+		'post_type'   => 'post',
+		'post_status' => 'any',
+		'numberposts' => 1,
+	)
+);
+if ( $orphan_found ) {
+	$orphan_id = (int) $orphan_found[0]->ID;
+} else {
+	$orphan_id = wp_insert_post(
+		array(
+			'post_title'   => 'Orphaned Author Post',
+			'post_name'    => 'cap-orphaned-author',
+			'post_status'  => 'publish',
+			'post_type'    => 'post',
+			'post_author'  => 99999, // Deliberately non-existent user ID.
+			'post_content' => 'post_author references a user that no longer exists.',
+		)
+	);
+}
+$report[] = sprintf( 'post      %-22s #%s  [post_author=99999, no terms]', 'cap-orphaned-author', is_wp_error( $orphan_id ) ? 'ERR' : $orphan_id );
+
+/* -------------------------------------------------------------------------
+ * 4. On a block theme, render the single-post byline with a CAP block so
+ *    multi-author bylines are visible on the front end.
+ * ---------------------------------------------------------------------- */
+if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+	$theme = get_stylesheet();
+	$tpl   = get_block_template( $theme . '//single', 'wp_template' );
+
+	if ( $tpl ) {
+		$cap_byline = '<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"layout":{"type":"constrained"}} -->'
+			. "\n" . '<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20)">'
+			. "\n" . '<!-- wp:co-authors-plus/coauthors -->'
+			. "\n" . '<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name /--></div>'
+			. "\n" . '<!-- /wp:co-authors-plus/coauthors -->'
+			. "\n" . '</div>'
+			. "\n" . '<!-- /wp:group -->';
+
+		// Twenty Twenty-Five renders the byline through this pattern; swap it.
+		$needle  = '<!-- wp:pattern {"slug":"twentytwentyfive/hidden-written-by"} /-->';
+		$content = $tpl->content;
+		if ( strpos( $content, $needle ) !== false ) {
+			$content = str_replace( $needle, $cap_byline, $content );
+		} else {
+			// Fallback for other block themes: inject after the post title.
+			$title   = '<!-- wp:post-title {"level":1} /-->';
+			$content = str_replace( $title, $title . "\n" . $cap_byline, $content );
+		}
+
+		$existing = get_posts(
+			array(
+				'post_type'   => 'wp_template',
+				'post_status' => 'any',
+				'name'        => 'single',
+				'numberposts' => 1,
+				'tax_query'   => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- One-off dev seed.
+					array(
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => $theme,
+					),
+				),
+			)
+		);
+
+		$postarr = array(
+			'post_type'    => 'wp_template',
+			'post_status'  => 'publish',
+			'post_name'    => 'single',
+			'post_title'   => 'Single Posts',
+			'post_excerpt' => 'Displays a single post with a Co-Authors Plus byline.',
+			'post_content' => $content,
+		);
+		if ( $existing ) {
+			$postarr['ID'] = $existing[0]->ID;
+			$tpl_id        = wp_update_post( $postarr, true );
+		} else {
+			$tpl_id = wp_insert_post( $postarr, true );
+		}
+
+		if ( ! is_wp_error( $tpl_id ) ) {
+			wp_set_object_terms( $tpl_id, $theme, 'wp_theme' );
+			$report[] = sprintf( 'template  %-22s #%s  (CAP byline on %s)', 'single', $tpl_id, $theme );
+		}
+	}
+}
+
+/* -------------------------------------------------------------------------
+ * Summary
+ * ---------------------------------------------------------------------- */
+WP_CLI::log( "\n=== Co-Authors Plus demo data ===" );
+WP_CLI::log( implode( "\n", $report ) );
+WP_CLI::log( "\nAll users share the password: password" );
+WP_CLI::success( 'Demo data seeded.' );

--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Co-Authors Plus
  * Plugin URI:        https://wordpress.org/plugins/co-authors-plus/
  * Description:       Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter.
- * Version:           4.1.0
+ * Version:           4.1.1
  * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            Mohammad Jangda, Daniel Bachhuber, Automattic
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-const COAUTHORS_PLUS_VERSION = '4.1.0';
+const COAUTHORS_PLUS_VERSION = '4.1.1';
 const COAUTHORS_PLUS_FILE = __FILE__;
 
 require_once __DIR__ . '/template-tags.php';

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
 		"cs-fix": [
 			"@php ./vendor/bin/phpcbf -q"
 		],
+		"dev:seed": "wp-env run cli wp eval 'require dirname( COAUTHORS_PLUS_FILE ) . \"/bin/seed-demo-data.php\";'",
 		"i18n": [
 			"@php wp i18n make-pot . languages/co-authors-plus.pot --slug=co-authors-plus"
 		],

--- a/languages/co-authors-plus.pot
+++ b/languages/co-authors-plus.pot
@@ -2,40 +2,40 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Co-Authors Plus 4.1.0\n"
+"Project-Id-Version: Co-Authors Plus 4.1.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/co-authors-plus\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-24T18:13:46+00:00\n"
+"POT-Creation-Date: 2026-06-26T12:20:47+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: co-authors-plus\n"
 
 #. Plugin Name of the plugin
-#: co-authors-plus.php
+#: co-authors-plus.php:15
 msgid "Co-Authors Plus"
 msgstr ""
 
 #. Plugin URI of the plugin
-#: co-authors-plus.php
+#: co-authors-plus.php:16
 msgid "https://wordpress.org/plugins/co-authors-plus/"
 msgstr ""
 
 #. Description of the plugin
-#: co-authors-plus.php
+#: co-authors-plus.php:17
 msgid "Allows multiple authors to be assigned to a post. This plugin is an extended version of the Co-Authors plugin developed by Weston Ruter."
 msgstr ""
 
 #. Author of the plugin
-#: co-authors-plus.php
+#: co-authors-plus.php:21
 msgid "Mohammad Jangda, Daniel Bachhuber, Automattic"
 msgstr ""
 
 #. Author URI of the plugin
-#: co-authors-plus.php
+#: co-authors-plus.php:22
 msgid "https://automattic.com"
 msgstr ""
 
@@ -287,7 +287,7 @@ msgid "Add New Guest Author"
 msgstr ""
 
 #: php/class-coauthors-guest-authors.php:99
-#: php/class-coauthors-plus.php:777
+#: php/class-coauthors-plus.php:787
 msgid "Edit Guest Author"
 msgstr ""
 
@@ -712,11 +712,11 @@ msgid "Jabber / Google Talk"
 msgstr ""
 
 #: php/class-coauthors-plus.php:264
-#: php/class-coauthors-plus.php:515
-#: php/class-coauthors-plus.php:645
-#: php/class-coauthors-plus.php:791
-#: php/class-coauthors-plus.php:2471
-#: php/class-coauthors-plus.php:2782
+#: php/class-coauthors-plus.php:525
+#: php/class-coauthors-plus.php:655
+#: php/class-coauthors-plus.php:801
+#: php/class-coauthors-plus.php:2481
+#: php/class-coauthors-plus.php:2792
 #: build/index.js:1
 #: src/index.js:24
 msgid "Authors"
@@ -726,65 +726,65 @@ msgstr ""
 msgid "All Authors"
 msgstr ""
 
-#: php/class-coauthors-plus.php:585
+#: php/class-coauthors-plus.php:595
 msgid "<strong>Note:</strong> To edit post authors, please enable JavaScript or use a JavaScript-capable browser"
 msgstr ""
 
-#: php/class-coauthors-plus.php:592
-#: php/class-coauthors-plus.php:793
-#: php/class-coauthors-plus.php:2166
+#: php/class-coauthors-plus.php:602
+#: php/class-coauthors-plus.php:803
+#: php/class-coauthors-plus.php:2176
 msgid "Click on an author to change them. Drag to change their order. Click on <strong>Remove</strong> to remove them."
 msgstr ""
 
-#: php/class-coauthors-plus.php:707
+#: php/class-coauthors-plus.php:717
 msgid "Linked Guest Author"
 msgstr ""
 
-#: php/class-coauthors-plus.php:708
+#: php/class-coauthors-plus.php:718
 #: php/class-coauthors-wp-list-table.php:181
 msgid "Posts"
 msgstr ""
 
-#: php/class-coauthors-plus.php:758
+#: php/class-coauthors-plus.php:768
 msgid "View posts by this author"
 msgstr ""
 
-#: php/class-coauthors-plus.php:836
-#: php/class-coauthors-plus.php:854
+#: php/class-coauthors-plus.php:846
+#: php/class-coauthors-plus.php:864
 msgid "No co-author exists for that term"
 msgstr ""
 
-#: php/class-coauthors-plus.php:1633
-#: php/class-coauthors-plus.php:1661
+#: php/class-coauthors-plus.php:1643
+#: php/class-coauthors-plus.php:1671
 msgid "This filter is deprecated when saving via the REST API and will be removed in a future version. Use the set_object_terms action for the author taxonomy instead."
 msgstr ""
 
-#: php/class-coauthors-plus.php:2161
+#: php/class-coauthors-plus.php:2171
 #: php/class-coauthors-wp-list-table.php:243
 msgid "Edit"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2162
+#: php/class-coauthors-plus.php:2172
 msgid "Remove"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2163
+#: php/class-coauthors-plus.php:2173
 msgid "Are you sure you want to remove this author?"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2164
+#: php/class-coauthors-plus.php:2174
 msgid "Click to change this author, or drag to change their position"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2165
+#: php/class-coauthors-plus.php:2175
 msgid "Search for an author"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2207
+#: php/class-coauthors-plus.php:2217
 msgid "Mine"
 msgstr ""
 
-#: php/class-coauthors-plus.php:2785
+#: php/class-coauthors-plus.php:2795
 msgid "Leave the field below blank to keep the Authors unchanged. Any change here will overwrite all previously assigned Authors."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "co-authors-plus",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "co-authors-plus",
-			"version": "4.1.0",
+			"version": "4.1.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.48.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "co-authors-plus",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "Allows multiple authors to be assigned to a post.",
 	"license": "GPL-2.0-or-later",
 	"private": true,

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -356,8 +356,18 @@ class CoAuthors_Plus {
 		 */
 		$supported_post_types = (array) apply_filters( 'coauthors_supported_post_types', $post_types );
 
-		// Set class property for back-compat.
-		$this->supported_post_types = $supported_post_types;
+		// Only memoise once every post type has had a chance to register. The first
+		// call can arrive before `init` — a capability check during bootstrap (e.g.
+		// kses_init() on set_current_user calling current_user_can()) reaches this
+		// method via filter_user_has_cap() → get_to_be_filtered_caps(). Caching then
+		// would freeze a list containing only the built-in post types, permanently
+		// excluding every custom post type registered on `init` and hiding the
+		// Authors box on those screens. Compute fresh until `wp_loaded` (which fires
+		// after `init`), by which point the list is stable, then memoise it for the
+		// admin and REST requests where this method is called many times per request.
+		if ( did_action( 'wp_loaded' ) ) {
+			$this->supported_post_types = $supported_post_types;
+		}
 
 		return $supported_post_types;
 	}

--- a/tests/Integration/Bylines/SupportedPostTypesTest.php
+++ b/tests/Integration/Bylines/SupportedPostTypesTest.php
@@ -201,4 +201,58 @@ class SupportedPostTypesTest extends TestCase {
 		$this->assertSame( $first, $second, 'supported_post_types() should return the memoised result on subsequent calls.' );
 		$this->assertNotContains( 'cap_post_type_added_late', $second, 'A filter change after the first call must not leak into the cached result.' );
 	}
+
+	/**
+	 * Regression coverage for the Authors box disappearing on custom post types.
+	 *
+	 * The memoisation from #1049 froze the supported-post-type list on the first
+	 * call. That call can arrive before `init` — a capability check during
+	 * bootstrap (kses_init() on set_current_user) reaches supported_post_types()
+	 * via filter_user_has_cap() → get_to_be_filtered_caps(). Caching there froze a
+	 * list of only the built-in post types, so every custom post type registered
+	 * on `init` was excluded for the rest of the request and its Authors box was
+	 * hidden, leaving only the native single-author selector.
+	 *
+	 * The list must therefore not be memoised until `wp_loaded` has fired, by
+	 * which point all post types are registered.
+	 *
+	 * @covers ::supported_post_types
+	 */
+	public function test_early_call_before_wp_loaded_does_not_freeze_the_list(): void {
+		global $wp_actions;
+
+		$this->_cap->supported_post_types = array();
+
+		// Simulate reaching supported_post_types() before wp_loaded has fired.
+		$wp_loaded_count = $wp_actions['wp_loaded'] ?? 0;
+		unset( $wp_actions['wp_loaded'] );
+
+		try {
+			// An early call must compute a result but must NOT memoise it.
+			$early = $this->_cap->supported_post_types();
+			$this->assertNotEmpty( $early, 'The early call should still return the built-in post types.' );
+			$this->assertEmpty(
+				$this->_cap->supported_post_types,
+				'The list must not be memoised before wp_loaded.'
+			);
+
+			// A custom post type registers later (as it would on init).
+			register_post_type( 'cap_late_cpt', array( 'supports' => array( 'author' ) ) );
+
+			// Once wp_loaded has fired, the late post type must be detected — not
+			// excluded by a stale list frozen during the early call.
+			$wp_actions['wp_loaded'] = max( $wp_loaded_count, 1 );
+			$supported               = $this->_cap->supported_post_types();
+
+			$this->assertContains(
+				'cap_late_cpt',
+				$supported,
+				'A custom post type registered after an early call must still be supported.'
+			);
+		} finally {
+			$wp_actions['wp_loaded']          = $wp_loaded_count;
+			$this->_cap->supported_post_types = array();
+			unregister_post_type( 'cap_late_cpt' );
+		}
+	}
 }


### PR DESCRIPTION
## Summary

This is the 4.1.1 patch release. Its headline is a regression fix for custom post types.

4.1.0 introduced a performance optimisation that memoised the supported-post-type list (#1307), but that list is first computed before `init` — a capability check during bootstrap reaches it via `kses_init()` — when only the built-in post types exist. The list froze as just `post` and `page`, so the Authors box silently disappeared on every custom post type and editors fell back to WordPress's single-author selector. This was reported on the support forum by two people and is tracked as VIPPLUG-39. The fix in #1322 defers the memo until `wp_loaded`, by which point all post types are registered, so custom post types regain their Authors box while the per-request caching is preserved on the hot paths. A regression test pins the behaviour.

Also rolling up from develop is the local wp-env demo-data seeding from #1320, which is development tooling only.

The release itself follows the usual three-commit shape: the changelog entry, the regenerated translation template (refreshed source references plus the `4.1.1` version stamp), and the version bumps across the plugin header, constant, `package.json`, `package-lock.json`, `README.md`, and `AGENTS.md`.

Once merged, `main` will be tagged `4.1.1`, which triggers the GitHub release and the WordPress.org SVN deploy.

## Test plan

- [x] Full PHPUnit integration suite green on #1322, including the new regression test.
- [ ] Confirm CI is green on this release branch.
- [ ] After tagging, verify the GitHub release ZIP and the WordPress.org deploy publish 4.1.1.