### PR TITLE
Add Playwright end-to-end tests for the co-author flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,78 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+      - '**.js'
+      - '**.jsx'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.js'
+      - 'tests/e2e/**'
+      - '.wp-env.json'
+      - '.github/workflows/e2e.yml'
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - '**.php'
+      - '**.js'
+      - '**.jsx'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.js'
+      - 'tests/e2e/**'
+      - '.wp-env.json'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+
+# Disable all permissions by default; grant minimal permissions per job.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: Playwright E2E (block editor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build block assets
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Install wordpress environment
+        run: npm install -g @wordpress/env
+
+      - name: Start wp-env
+        run: wp-env start
+
+      # E2E runs against the dev environment (a stable WordPress release), not the
+      # tests environment (which tracks trunk and can drift ahead of the editor
+      # utilities). In CI the dev site is served on the default port 8888.
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          WP_BASE_URL: http://localhost:8888

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # Tests
 /.phpunit.cache/
 /phpunit.xml
+/artifacts/
 
 # PHPCS
 /phpcs.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
 				"@wordpress/i18n": "^6.9.0"
 			},
 			"devDependencies": {
+				"@playwright/test": "^1.61.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.48.1",
 				"@wordpress/icons": "^14.0.1",
 				"@wordpress/scripts": "^32.4.1",
 				"classnames": "^2.5.1",
@@ -4471,7 +4473,6 @@
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
 			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.61.0"
 			},
@@ -16932,7 +16933,6 @@
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
 			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.61.0"
 			},
@@ -16951,7 +16951,6 @@
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
 			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -16969,7 +16968,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -21060,7 +21058,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -25393,7 +25391,6 @@
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
 			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"playwright": "1.61.0"
 			}
@@ -34444,7 +34441,6 @@
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
 			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"fsevents": "2.3.2",
 				"playwright-core": "1.61.0"
@@ -34455,8 +34451,7 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 					"dev": true,
-					"optional": true,
-					"peer": true
+					"optional": true
 				}
 			}
 		},
@@ -34464,8 +34459,7 @@
 			"version": "1.61.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
 			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"plur": {
 			"version": "4.0.0",
@@ -37407,7 +37401,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"peer": true
 		},
 		"typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
 		"packages-update": "wp-scripts packages-update",
 		"start": "wp-scripts start",
-		"test:e2e": "wp-scripts test-e2e",
+		"test:e2e": "playwright test --config playwright.config.js",
 		"test:unit": "wp-scripts test-unit-js",
 		"test:unit:watch": "wp-scripts test-unit-js --watch"
 	},
@@ -39,6 +39,8 @@
 		"@wordpress/i18n": "^6.9.0"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.61.0",
+		"@wordpress/e2e-test-utils-playwright": "^1.48.1",
 		"@wordpress/icons": "^14.0.1",
 		"@wordpress/scripts": "^32.4.1",
 		"classnames": "^2.5.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,16 @@
+/**
+ * Playwright configuration for Co-Authors Plus end-to-end tests.
+ *
+ * Extends the @wordpress/scripts default config (which wires up the WordPress
+ * e2e-test-utils-playwright login/global-setup) and points it at tests/e2e.
+ *
+ * wp-env is started externally — locally and in CI — so the default webServer
+ * (which would run `npm run wp-env start`) is disabled.
+ */
+const baseConfig = require( '@wordpress/scripts/config/playwright.config.js' );
+
+module.exports = {
+	...baseConfig,
+	testDir: './tests/e2e',
+	webServer: undefined,
+};

--- a/tests/e2e/coauthors.spec.js
+++ b/tests/e2e/coauthors.spec.js
@@ -1,0 +1,79 @@
+/**
+ * End-to-end coverage for assigning a co-author in the block editor.
+ *
+ * Drives the real "Authors" document-settings panel — the same UI an editor
+ * uses — to add a second author to a post, and confirms the byline reflects it
+ * both in the editor panel and on the published front end.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Assigning a co-author in the block editor', () => {
+	let author;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		author = await requestUtils.createUser( {
+			username: 'e2ecoauthor',
+			email: 'e2ecoauthor@example.com',
+			firstName: 'Ezra',
+			lastName: 'Example',
+			roles: [ 'author' ],
+			password: 'cap-e2e-password',
+		} );
+
+		// createUser() cannot set the display name, so set it via REST — that is
+		// what the panel and the byline show, and what we assert against.
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/wp/v2/users/${ author.id }`,
+			data: { name: 'Ezra Example' },
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllUsers();
+	} );
+
+	test( 'adds the chosen author to the byline', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await admin.createNewPost( { title: 'A co-authored post' } );
+		await editor.openDocumentSettingsSidebar();
+
+		// Expand the "Authors" panel if it is collapsed.
+		const panelToggle = page.getByRole( 'button', { name: 'Authors' } );
+		if (
+			'false' === ( await panelToggle.getAttribute( 'aria-expanded' ) )
+		) {
+			await panelToggle.click();
+		}
+
+		// Search for and select the second author via the combobox.
+		const combobox = page.getByRole( 'combobox', {
+			name: 'Select An Author',
+		} );
+		await combobox.click();
+		await combobox.fill( 'Ezra' );
+		await page.getByRole( 'option', { name: 'Ezra Example' } ).click();
+
+		// The panel now lists the added co-author.
+		await expect(
+			page.locator( '.cap-author', { hasText: 'Ezra Example' } )
+		).toBeVisible();
+
+		// Publish, then confirm both authors persisted via the public co-authors
+		// endpoint — the saved byline, independent of the active theme's markup.
+		const postId = await editor.publishPost();
+		const coauthors = await requestUtils.rest( {
+			path: `/coauthors/v1/coauthors?post_id=${ postId }`,
+		} );
+		const names = coauthors.map( ( coauthor ) => coauthor.display_name );
+
+		expect( names ).toContain( 'Ezra Example' );
+		expect( names ).toContain( 'admin' );
+	} );
+} );


### PR DESCRIPTION
## Summary

The plugin has no end-to-end coverage. The block-editor "Authors" panel — how editors actually assign co-authors — is exercised only indirectly, through unit tests of its React utilities and PHP tests of the REST endpoints behind it; nothing drives the real editor and confirms the round trip. The `test:e2e` script compounded this by pointing at the legacy `wp-scripts test-e2e` (Jest + Puppeteer) runner with no specs behind it, so it looked like coverage while providing none.

This adds a Playwright suite, built on `@wordpress/e2e-test-utils-playwright`, that opens a new post, opens the "Authors" document panel, searches the author combobox, assigns a second co-author, and — after publishing — confirms both authors are stored on the post via the public `coauthors/v1` endpoint. `test:e2e` now invokes Playwright directly, and a new workflow builds the assets, starts wp-env, installs Chromium and runs the suite. No production code is changed.

Two decisions are worth a reviewer's attention. First, the suite runs against the **dev** environment rather than the tests environment: the tests environment tracks WordPress trunk, whose editor markup runs ahead of the e2e-test-utils version and breaks the sidebar helper, so a stable release is the reliable target (CI uses the default dev port, 8888). Second, it asserts the saved co-authors through the REST endpoint rather than the rendered byline: on block themes the core post-author block reads `post_author` directly and bypasses Co-Authors Plus's `the_author` filter, so a multi-author *front-end* byline is produced by the plugin's own co-author blocks — worth covering, but as a separate, more involved spec.

## Test plan

- `wp-env start`, `npm run build`, then `WP_BASE_URL=http://localhost:8888 npm run test:e2e` (the dev port may differ locally) — the spec passes in ~2s.
- The new **E2E Tests** workflow runs the same on pull requests.