### PR TITLE
fix(author-query): optimize multi-author SQL rewrite for author__in queries

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -986,6 +986,36 @@ class CoAuthors_Plus {
 				return $join;
 			}
 
+			// Multi-author path (author__in / comma-separated author).
+			$author_ids      = $this->get_author_ids_from_query( $query );
+			$is_multi_author = ! empty( $author_ids ) && ( ! $query->is_author() || count( $author_ids ) > 1 );
+
+			if ( $is_multi_author ) {
+				$maybe_both = $this->force_guest_authors
+					? false
+					: apply_filters( 'coauthors_plus_should_query_post_author', true );
+
+				if ( $maybe_both ) {
+					// Need post_author fallback -- keep LEFT JOIN.
+					$rel_join = " LEFT JOIN {$wpdb->term_relationships} AS tr1 ON ({$wpdb->posts}.ID = tr1.object_id)";
+					$tax_join = " LEFT JOIN {$wpdb->term_taxonomy} ON ( tr1.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
+				} else {
+					// Only co-author terms -- INNER JOIN is sufficient.
+					$rel_join = " INNER JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
+					$tax_join = " INNER JOIN {$wpdb->term_taxonomy} ON ( {$wpdb->term_relationships}.term_taxonomy_id = {$wpdb->term_taxonomy}.term_taxonomy_id )";
+				}
+
+				if ( false === strpos( $join, trim( $rel_join ) ) ) {
+					$join .= $rel_join;
+				}
+				if ( false === strpos( $join, trim( $tax_join ) ) ) {
+					$join .= $tax_join;
+				}
+
+				return $join;
+			}
+
+			// Single-author path: only add ONCE having_terms is populated.
 			if ( empty( $this->having_terms ) ) {
 				return $join;
 			}
@@ -1240,8 +1270,20 @@ class CoAuthors_Plus {
 			return $where;
 		}
 
-		$terms_implode = $this->build_terms_clauses( $all_terms );
-		$this->having_terms = rtrim( $this->having_terms, ' OR' );
+		// Build a single IN clause instead of a per-term OR-chain.
+		$term_ids = array_unique(
+			array_map(
+				function ( $t ) {
+					return $t->term_id;
+				},
+				$all_terms
+			)
+		);
+		$placeholders = implode( ', ', array_fill( 0, count( $term_ids ), '%d' ) );
+		$terms_implode = $wpdb->prepare(
+			"{$wpdb->term_taxonomy}.taxonomy = %s AND {$wpdb->term_taxonomy}.term_id IN ({$placeholders})",  // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			array_merge( array( $this->coauthor_taxonomy ), $term_ids )
+		);
 
 		$maybe_both = $this->force_guest_authors
 			? false
@@ -1276,7 +1318,15 @@ class CoAuthors_Plus {
 				return $groupby;
 			}
 
-			if ( $this->having_terms ) {
+			// Multi-author path: GROUP BY to deduplicate rows from the JOIN.
+			$author_ids       = $this->get_author_ids_from_query( $query );
+			$is_multi_author  = ! empty( $author_ids ) && ( ! $query->is_author() || count( $author_ids ) > 1 );
+
+			if ( $is_multi_author ) {
+				if ( empty( $groupby ) ) {
+					$groupby = $wpdb->posts . '.ID';
+				}
+			} elseif ( $this->having_terms ) {
 				$having  = 'MAX( IF ( ' . $wpdb->term_taxonomy . '.taxonomy = \'' . $this->coauthor_taxonomy . '\', IF ( ' . $this->having_terms . ',2,1 ),0 ) ) <> 1 ';
 				$groupby = $wpdb->posts . '.ID HAVING ' . $having;
 			}

--- a/tests/Integration/Queries/AuthorQueriesTest.php
+++ b/tests/Integration/Queries/AuthorQueriesTest.php
@@ -264,4 +264,88 @@ class AuthorQueriesTest extends TestCase {
 			'Opting out must leave the query as a post_author query and skip co-authored posts.'
 		);
 	}
+	// -- Multi-author SQL structure tests, issue #1308 -------------------------
+
+	/**
+	 * The multi-author WHERE clause must use `term_id IN (...)` instead of
+	 * a per-term `(taxonomy = 'author' AND term_id = 'N') OR ...` chain.
+	 */
+	public function test_multi_author_query_uses_in_clause_not_or_chain(): void {
+		$author1 = $this->create_author( 'in_clause_a1' );
+		$author2 = $this->create_author( 'in_clause_a2' );
+		$post    = $this->create_post( $author1 );
+		$this->_cap->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		$sql = '';
+		add_filter(
+			'posts_request',
+			function ( $request ) use ( &$sql ) {
+				$sql = $request;
+				return $request;
+			} 
+		);
+
+		$query = new WP_Query( array( 'author__in' => array( $author2->ID ) ) );
+
+		$this->assertNotEmpty( $sql, 'SQL must be captured via posts_request.' );
+		$this->assertStringContainsString( 'term_id IN (', $sql, 'Must use IN clause for multiple term IDs.' );
+
+		$this->assertQueryReturns( array( $post->ID ), $query );
+	}
+
+	/**
+	 * When `coauthors_plus_should_query_post_author` returns false, the JOIN
+	 * should be an INNER JOIN (only co-author taxonomy matches needed).
+	 */
+	public function test_multi_author_query_uses_inner_join_when_post_author_excluded(): void {
+		$author1 = $this->create_author( 'inner_join_a1' );
+		$author2 = $this->create_author( 'inner_join_a2' );
+		$post    = $this->create_post( $author1 );
+		$this->_cap->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		add_filter( 'coauthors_plus_should_query_post_author', '__return_false' );
+
+		$sql = '';
+		add_filter(
+			'posts_request',
+			function ( $request ) use ( &$sql ) {
+				$sql = $request;
+				return $request;
+			} 
+		);
+
+		$query = new WP_Query( array( 'author__in' => array( $author2->ID ) ) );
+
+		remove_all_filters( 'coauthors_plus_should_query_post_author' );
+
+		$this->assertNotEmpty( $sql, 'SQL must be captured via posts_request.' );
+		$this->assertStringContainsString( 'INNER JOIN', $sql, 'Must use INNER JOIN when post_author is excluded.' );
+		$this->assertQueryReturns( array( $post->ID ), $query );
+	}
+
+	/**
+	 * By default (`coauthors_plus_should_query_post_author` is true), the JOIN
+	 * must be a LEFT JOIN to cover the post_author fallback.
+	 */
+	public function test_multi_author_query_uses_left_join_by_default(): void {
+		$author1 = $this->create_author( 'left_join_a1' );
+		$author2 = $this->create_author( 'left_join_a2' );
+		$post    = $this->create_post( $author1 );
+		$this->_cap->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		$sql = '';
+		add_filter(
+			'posts_request',
+			function ( $request ) use ( &$sql ) {
+				$sql = $request;
+				return $request;
+			} 
+		);
+
+		$query = new WP_Query( array( 'author__in' => array( $author2->ID ) ) );
+
+		$this->assertNotEmpty( $sql, 'SQL must be captured via posts_request.' );
+		$this->assertStringContainsString( 'LEFT JOIN', $sql, 'Must use LEFT JOIN by default (post_author included).' );
+		$this->assertQueryReturns( array( $post->ID ), $query );
+	}
 }

--- a/tests/Integration/Queries/AuthorQueriesTest.php
+++ b/tests/Integration/Queries/AuthorQueriesTest.php
@@ -348,4 +348,53 @@ class AuthorQueriesTest extends TestCase {
 		$this->assertStringContainsString( 'LEFT JOIN', $sql, 'Must use LEFT JOIN by default (post_author included).' );
 		$this->assertQueryReturns( array( $post->ID ), $query );
 	}
+
+	// -- GROUP BY dedup, review feedback on #1326 ----------------------------
+
+	/**
+	 * A single post co-authored by two of the queried authors must be returned
+	 * exactly once. The per-term taxonomy JOIN yields one row per matching term,
+	 * so this guards the GROUP BY deduplication in posts_groupby_filter().
+	 */
+	public function test_author_in_returns_a_shared_coauthored_post_only_once(): void {
+		$author1 = $this->create_author( 'dedup_a1' );
+		$author2 = $this->create_author( 'dedup_a2' );
+
+		$post = $this->create_post( $author1 );
+		$this->_cap->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		// Both queried authors co-author the same post, so the JOIN produces one
+		// row per matching term. Without GROUP BY the post would appear twice.
+		$query = new WP_Query( array( 'author__in' => array( $author1->ID, $author2->ID ) ) );
+
+		$this->assertQueryReturns(
+			array( $post->ID ),
+			$query,
+			'A post shared by two queried co-authors must be returned once, not duplicated by the JOIN.'
+		);
+	}
+
+	/**
+	 * The GROUP BY deduplication must also hold on the INNER JOIN path taken when
+	 * `coauthors_plus_should_query_post_author` opts out of the post_author fallback.
+	 */
+	public function test_author_in_returns_a_shared_coauthored_post_only_once_when_post_author_excluded(): void {
+		$author1 = $this->create_author( 'dedup_inner_a1' );
+		$author2 = $this->create_author( 'dedup_inner_a2' );
+
+		$post = $this->create_post( $author1 );
+		$this->_cap->add_coauthors( $post->ID, array( $author1->user_login, $author2->user_login ) );
+
+		add_filter( 'coauthors_plus_should_query_post_author', '__return_false' );
+
+		$query = new WP_Query( array( 'author__in' => array( $author1->ID, $author2->ID ) ) );
+
+		remove_all_filters( 'coauthors_plus_should_query_post_author' );
+
+		$this->assertQueryReturns(
+			array( $post->ID ),
+			$query,
+			'A shared co-authored post must be returned once on the INNER JOIN path too.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Optimizes the author/co-author SQL rewrite for multi-author queries (`author__in` / comma-separated `author`). Replaces the per-term OR-chain with a single indexable `IN (...)` clause, and uses INNER JOIN when `post_author` is excluded from the query.

Fixes #1308

## Changes

### `php/class-coauthors-plus.php`

**`posts_join_filter()`** — Choose JOIN type based on multi-author path:
- When `coauthors_plus_should_query_post_author` returns false: INNER JOIN
- Otherwise: LEFT JOIN (default, preserves post_author fallback)

**`posts_where_filter_multi_author()`** — Replace per-term OR-chain:
- Before: `(taxonomy = 'author' AND term_id = 'N') OR (taxonomy = 'author' AND term_id = 'M')`
- After: `taxonomy = 'author' AND term_id IN ('N', 'M')`

**`posts_groupby_filter()`** — Add GROUP BY for multi-author deduplication when JOIN produces multiple rows per post.

### `tests/Integration/Queries/AuthorQueriesTest.php`

3 new SQL structure tests:
- `test_multi_author_query_uses_in_clause_not_or_chain`
- `test_multi_author_query_uses_inner_join_when_post_author_excluded`
- `test_multi_author_query_uses_left_join_by_default`

2 new GROUP BY dedup tests, added per review feedback (no existing test had a post matching two queried co-authors at once, so the dedup branch was never exercised):
- `test_author_in_returns_a_shared_coauthored_post_only_once`
- `test_author_in_returns_a_shared_coauthored_post_only_once_when_post_author_excluded`

## Deploy Notes

None — no new dependencies. Internal query-building change only (SQL string construction plus a GROUP BY clause), no schema or data changes.

## Steps to Test

1. Check out this PR.
2. Run `composer test:integration` and `composer test:integration-ms` — all tests pass, including the 5 new ones covering the `IN (...)` clause, JOIN type, and GROUP BY dedup.
3. Optional manual check: co-author a post with two users, then query `author__in` with both of their IDs (e.g. via `WP_Query` or an author archive covering both) — the post must come back exactly once, not duplicated.

## Testing

- `composer test:integration` — 274 tests pass (5 new)
- `composer test:integration-ms` — 276 tests pass
- `composer cs` — clean on modified files
- CodeRabbit review: 0 findings

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
