### PR TITLE
Restore `create-guest-authors` support for arbitrary `WP_User_Query` args

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -37,10 +37,15 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * [--number=<number>]
 	 * : Maximum number of users to process in this run. Defaults to all users.
 	 *
+	 * [--role=<role>]
+	 * : Only display users with a certain role.
+	 *
+	 * [--<field>=<value>]
+	 * : Control output by one or more arguments of WP_User_Query().
+	 *
 	 * @since 3.0
 	 *
 	 * @subcommand create-guest-authors
-	 * @synopsis [--offset=<offset>] [--number=<number>]
 	 */
 	public function create_guest_authors( $args, $assoc_args ): void {
 		global $coauthors_plus;


### PR DESCRIPTION
## Description

The inline documentation for the `create-guest-authors` WP-CLI command is currently too restrictive to support any of the `WP_User_Query` args aside from those specifically added to the Options section.  Such a limitation results in a very narrow use case: creating Guest Authors for all users on a site.

While #378 is a nice improvement, it appears to have introduced this regression.

My current use case is converting all users with the Subscriber role to Guest Authors.  Until I updated from 4.0.2 to 4.1.1, it was possible to specify `--role=subscriber`, but now that is no longer possible:

```sh
$ wp co-authors-plus create-guest-authors --role=subscriber
Error: Parameter errors:
unknown --role parameter
``` 

I referred to the source code for `wp user list` as prior art for how to allow the unbounded field/value options while still highlighting explicit options like `--offset`, `--number`, and additionally `--role`.

https://github.com/wp-cli/entity-command/blob/85c803a93dd8571909bf5c077bf243aada3e5309/src/User_Command.php#L67-L71  

## Steps to Test

1. Check out PR.
1. `wp co-authors-plus create-guest-authors --role=subscriber`
