### PR TITLE
Allow creating a new guest author from the block-editor Co-Authors sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 			"devDependencies": {
 				"@playwright/test": "^1.62.1",
 				"@testing-library/dom": "^10.4.1",
+				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.3",
 				"@wordpress/e2e-test-utils-playwright": "^1.54.0",
 				"@wordpress/icons": "^15.5.0",
@@ -26,6 +27,13 @@
 				"prettier": "npm:wp-prettier@^2.2.1-beta-1",
 				"version-bump-prompt": "^6.1.0"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+			"integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ariakit/components": {
 			"version": "0.1.11",
@@ -6028,6 +6036,33 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@testing-library/jest-dom": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@adobe/css-tools": "^4.4.0",
+				"aria-query": "^5.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"picocolors": "^1.1.1",
+				"redent": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
+		},
+		"node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@testing-library/react": {
 			"version": "16.3.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
@@ -10870,6 +10905,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
 			}
+		},
+		"node_modules/css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
@@ -23659,6 +23701,12 @@
 		}
 	},
 	"dependencies": {
+		"@adobe/css-tools": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+			"integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+			"dev": true
+		},
 		"@ariakit/components": {
 			"version": "0.1.11",
 			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.11.tgz",
@@ -27533,6 +27581,28 @@
 				}
 			}
 		},
+		"@testing-library/jest-dom": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+			"dev": true,
+			"requires": {
+				"@adobe/css-tools": "^4.4.0",
+				"aria-query": "^5.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"picocolors": "^1.1.1",
+				"redent": "^3.0.0"
+			},
+			"dependencies": {
+				"dom-accessibility-api": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+					"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+					"dev": true
+				}
+			}
+		},
 		"@testing-library/react": {
 			"version": "16.3.3",
 			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
@@ -30790,6 +30860,12 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
 			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"dev": true
+		},
+		"css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
 			"dev": true
 		},
 		"cssesc": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	"devDependencies": {
 		"@playwright/test": "^1.62.1",
 		"@testing-library/dom": "^10.4.1",
+		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.3",
 		"@wordpress/e2e-test-utils-playwright": "^1.54.0",
 		"@wordpress/icons": "^15.5.0",

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -22,6 +22,7 @@ class Endpoints {
 	const SEARCH_ROUTE          = 'search';
 	const AUTHORS_ROUTE         = 'authors';
 	const AUTHORS_BY_TERMS_ROUTE = 'authors-by-term-ids';
+	const GUEST_AUTHORS_ROUTE   = 'guest-authors';
 
 	/**
 	 * Link to remove from REST response to manage core author visibility in
@@ -146,6 +147,42 @@ class Endpoints {
 				),
 			)
 		);
+
+		register_rest_route(
+			static::NS,
+			static::GUEST_AUTHORS_ROUTE,
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'create_guest_author' ),
+					'permission_callback' => array( $this, 'can_edit_coauthors' ),
+					'args'                => array(
+						'display_name' => array(
+							'description' => __( 'Display name for the new guest author.', 'co-authors-plus' ),
+							'type'        => 'string',
+							'required'    => true,
+						),
+						'user_email'   => array(
+							'description'       => __( 'Optional email address for the new guest author.', 'co-authors-plus' ),
+							'type'              => 'string',
+							'required'          => false,
+							'validate_callback' => static function ( $value ) {
+								$email = trim( (string) $value );
+								if ( '' === $email ) {
+									return true;
+								}
+								return is_email( $email );
+							},
+						),
+						'user_login'   => array(
+							'description' => __( 'Optional login/slug. Derived from display_name when empty.', 'co-authors-plus' ),
+							'type'        => 'string',
+							'required'    => false,
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -210,6 +247,95 @@ class Endpoints {
 		}
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Create a new guest author.
+	 *
+	 * Thin REST wrapper around CoAuthors_Guest_Authors::create(). Derives
+	 * user_login from display_name when not supplied. Returns the formatted
+	 * author data on success, or the underlying WP_Error on failure so the
+	 * block-editor modal can surface the message.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_guest_author( $request ) {
+		$display_name = trim( (string) $request->get_param( 'display_name' ) );
+		$user_email   = trim( (string) $request->get_param( 'user_email' ) );
+		$user_login   = trim( (string) $request->get_param( 'user_login' ) );
+
+		if ( '' === $user_login ) {
+			$user_login = sanitize_user( sanitize_title( remove_accents( $display_name ) ) );
+			if ( '' === $user_login ) {
+				$user_login = 'guest-author';
+			}
+		}
+
+		$args = array(
+			'display_name' => $display_name,
+			'user_login'   => $user_login,
+		);
+
+		if ( '' !== $user_email ) {
+			$args['user_email'] = $user_email;
+		}
+
+		$post_id = $this->coauthors->guest_authors->create( $args );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $this->map_create_error_status( $post_id );
+		}
+
+		$author = $this->coauthors->get_coauthor_by( 'ID', $post_id );
+
+		if ( ! $author ) {
+			return new WP_Error(
+				'guest-author-not-loaded',
+				__( 'Guest author was created but could not be loaded.', 'co-authors-plus' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$formatted = $this->_format_author_data( $author );
+
+		if ( null === $formatted ) {
+			return new WP_Error(
+				'guest-author-format-failed',
+				__( 'Guest author was created but could not be formatted.', 'co-authors-plus' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response( $formatted );
+	}
+
+	/**
+	 * Map error codes from CoAuthors_Guest_Authors::create() to REST HTTP statuses.
+	 *
+	 * Without this, raw WP_Error returns would be served as HTTP 500 by the REST
+	 * server, even for client errors like blank names or duplicate logins.
+	 *
+	 * @param WP_Error $error Error returned from create().
+	 * @return WP_Error Error with 'status' data set where appropriate.
+	 */
+	private function map_create_error_status( \WP_Error $error ): \WP_Error {
+		$code = $error->get_error_code();
+		$status = 500;
+
+		if ( 'field-required' === $code ) {
+			$status = 400;
+		} elseif ( 'duplicate-field' === $code ) {
+			$status = 409;
+		} elseif ( 'invalid-email' === $code || 'invalid-field' === $code ) {
+			$status = 400;
+		}
+
+		if ( 500 !== $status ) {
+			$error->add_data( array( 'status' => $status ), $code );
+		}
+
+		return $error;
 	}
 
 	/**

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -158,14 +158,16 @@ class Endpoints {
 					'permission_callback' => array( $this, 'can_edit_coauthors' ),
 					'args'                => array(
 						'display_name' => array(
-							'description' => __( 'Display name for the new guest author.', 'co-authors-plus' ),
-							'type'        => 'string',
-							'required'    => true,
+							'description'       => __( 'Display name for the new guest author.', 'co-authors-plus' ),
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 						'user_email'   => array(
 							'description'       => __( 'Optional email address for the new guest author.', 'co-authors-plus' ),
 							'type'              => 'string',
 							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => static function ( $value ) {
 								$email = trim( (string) $value );
 								if ( '' === $email ) {
@@ -175,9 +177,10 @@ class Endpoints {
 							},
 						),
 						'user_login'   => array(
-							'description' => __( 'Optional login/slug. Derived from display_name when empty.', 'co-authors-plus' ),
-							'type'        => 'string',
-							'required'    => false,
+							'description'       => __( 'Optional login/slug. Derived from display_name when empty.', 'co-authors-plus' ),
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
 						),
 					),
 				),
@@ -261,6 +264,14 @@ class Endpoints {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function create_guest_author( $request ) {
+		if ( ! $this->coauthors->is_guest_authors_enabled() || ! isset( $this->coauthors->guest_authors ) ) {
+			return new WP_Error(
+				'guest-authors-disabled',
+				__( 'Guest authors are disabled.', 'co-authors-plus' ),
+				array( 'status' => 404 )
+			);
+		}
+
 		$display_name = trim( (string) $request->get_param( 'display_name' ) );
 		$user_email   = trim( (string) $request->get_param( 'user_email' ) );
 		$user_login   = trim( (string) $request->get_param( 'user_login' ) );
@@ -327,8 +338,6 @@ class Endpoints {
 			$status = 400;
 		} elseif ( 'duplicate-field' === $code ) {
 			$status = 409;
-		} elseif ( 'invalid-email' === $code || 'invalid-field' === $code ) {
-			$status = 400;
 		}
 
 		if ( 500 !== $status ) {

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -161,7 +161,11 @@ class Endpoints {
 							'description'       => __( 'Display name for the new guest author.', 'co-authors-plus' ),
 							'type'              => 'string',
 							'required'          => true,
-							'sanitize_callback' => 'sanitize_text_field',
+							'sanitize_callback' => static function ( $value ) {
+								$value = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', (string) $value );
+
+								return sanitize_text_field( $value );
+							},
 						),
 						'user_email'   => array(
 							'description'       => __( 'Optional email address for the new guest author.', 'co-authors-plus' ),

--- a/src/__tests__/co-authors.test.js
+++ b/src/__tests__/co-authors.test.js
@@ -26,6 +26,7 @@ import {
 	screen,
 	waitFor,
 } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 /**
  * Internal dependencies

--- a/src/__tests__/co-authors.test.js
+++ b/src/__tests__/co-authors.test.js
@@ -19,7 +19,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * External dependencies
  */
-import { render, act } from '@testing-library/react';
+import {
+	fireEvent,
+	render,
+	act,
+	screen,
+	waitFor,
+} from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -64,19 +70,49 @@ jest.mock( '../hooks/use-coauthor-details', () => ( {
  * Capture the props handed to ComboboxControl so a test can drive the search
  * the way a user typing into the field would, without a real DOM widget.
  */
-let comboboxProps;
+let mockComboboxProps;
+let mockButtonProps = [];
+let mockModalProps;
+let mockTextControlProps = [];
 jest.mock( '@wordpress/components', () => ( {
 	ComboboxControl: ( props ) => {
-		comboboxProps = props;
+		mockComboboxProps = props;
 		return null;
 	},
 	Spinner: () => null,
+	Button: ( props ) => {
+		mockButtonProps.push( props );
+		return <button { ...props }>{ props.children }</button>;
+	},
+	Modal: ( props ) => {
+		mockModalProps = props;
+		return <div role="dialog">{ props.children }</div>;
+	},
+	TextControl: ( props ) => {
+		mockTextControlProps.push( props );
+		return (
+			<div>
+				<label htmlFor={ props.label }>{ props.label }</label>
+				<input
+					id={ props.label }
+					aria-label={ props.label }
+					value={ props.value }
+					onChange={ ( event ) =>
+						props.onChange( event.target.value )
+					}
+				/>
+			</div>
+		);
+	},
 } ) );
 
 describe( 'CoAuthors author search', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
-		comboboxProps = undefined;
+		mockComboboxProps = undefined;
+		mockButtonProps = [];
+		mockModalProps = undefined;
+		mockTextControlProps = [];
 		selectionProps = undefined;
 
 		apiFetch.mockResolvedValue( [] );
@@ -113,7 +149,7 @@ describe( 'CoAuthors author search', () => {
 		await renderPanel();
 
 		act( () => {
-			comboboxProps.onFilterValueChange( 'ada' );
+			mockComboboxProps.onFilterValueChange( 'ada' );
 		} );
 
 		await act( async () => {
@@ -132,7 +168,7 @@ describe( 'CoAuthors author search', () => {
 
 		// The user types a query, queuing the debounced search.
 		act( () => {
-			comboboxProps.onFilterValueChange( 'ada' );
+			mockComboboxProps.onFilterValueChange( 'ada' );
 		} );
 
 		// A store dispatch re-renders the panel before the timer elapses. This
@@ -165,14 +201,14 @@ describe( 'CoAuthors author search', () => {
 		] );
 
 		act( () => {
-			comboboxProps.onFilterValueChange( 'ada' );
+			mockComboboxProps.onFilterValueChange( 'ada' );
 		} );
 
 		await act( async () => {
 			jest.advanceTimersByTime( 500 );
 		} );
 
-		expect( comboboxProps.options ).toStrictEqual( [
+		expect( mockComboboxProps.options ).toStrictEqual( [
 			{
 				id: 5,
 				termId: 42,
@@ -201,26 +237,118 @@ describe( 'CoAuthors author search', () => {
 		] );
 
 		act( () => {
-			comboboxProps.onFilterValueChange( 'ada' );
+			mockComboboxProps.onFilterValueChange( 'ada' );
 		} );
 
 		await act( async () => {
 			jest.advanceTimersByTime( 500 );
 		} );
 
-		expect( comboboxProps.options ).not.toHaveLength( 0 );
+		expect( mockComboboxProps.options ).not.toHaveLength( 0 );
 
 		apiFetch.mockResolvedValue( [] );
 
 		act( () => {
-			comboboxProps.onFilterValueChange( 'nobody' );
+			mockComboboxProps.onFilterValueChange( 'nobody' );
 		} );
 
 		await act( async () => {
 			jest.advanceTimersByTime( 500 );
 		} );
 
-		expect( comboboxProps.options ).toStrictEqual( [] );
+		expect( mockComboboxProps.options ).toStrictEqual( [] );
+	} );
+
+	it( 'opens the create modal with the last search query', async () => {
+		await renderPanel();
+
+		act( () => {
+			mockComboboxProps.onFilterValueChange( 'new guest' );
+		} );
+
+		await act( async () => {
+			jest.advanceTimersByTime( 500 );
+		} );
+
+		fireEvent.click(
+			screen.getByRole( 'button', { name: '+ Create new guest author' } )
+		);
+
+		expect( mockModalProps ).toBeDefined();
+		expect( screen.getByLabelText( 'Display name' ) ).toHaveValue(
+			'new guest'
+		);
+	} );
+
+	it( 'disables Create until a name is entered', async () => {
+		await renderPanel();
+		fireEvent.click(
+			screen.getByRole( 'button', { name: '+ Create new guest author' } )
+		);
+
+		expect(
+			screen.getByRole( 'button', { name: 'Create' } )
+		).toBeDisabled();
+
+		fireEvent.change( screen.getByLabelText( 'Display name' ), {
+			target: { value: 'New Guest' },
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Create' } )
+		).not.toBeDisabled();
+	} );
+
+	it( 'creates a guest author and closes the modal', async () => {
+		await renderPanel();
+		fireEvent.click(
+			screen.getByRole( 'button', { name: '+ Create new guest author' } )
+		);
+
+		apiFetch.mockResolvedValueOnce( {
+			id: 42,
+			termId: 42,
+			displayName: 'New Guest',
+			userNicename: 'new-guest',
+			email: '',
+			userType: 'guest-author',
+		} );
+
+		fireEvent.change( screen.getByLabelText( 'Display name' ), {
+			target: { value: 'New Guest' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Create' } ) );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/coauthors/v1/guest-authors',
+				method: 'POST',
+				data: { display_name: 'New Guest', user_email: '' },
+			} );
+		} );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows a create error and keeps the modal open', async () => {
+		await renderPanel();
+		fireEvent.click(
+			screen.getByRole( 'button', { name: '+ Create new guest author' } )
+		);
+		fireEvent.change( screen.getByLabelText( 'Display name' ), {
+			target: { value: 'Existing Guest' },
+		} );
+		apiFetch.mockRejectedValueOnce( {
+			message: 'That login already exists.',
+		} );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Create' } ) );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'alert' ) ).toHaveTextContent(
+				'That login already exists.'
+			);
+		} );
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { ComboboxControl, Spinner } from '@wordpress/components';
+import {
+	Button,
+	ComboboxControl,
+	Modal,
+	Spinner,
+	TextControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -59,6 +65,23 @@ const CoAuthors = () => {
 	 * fetches; clearing the input now intentionally re-fetches the list.
 	 */
 	const hasInitialLoaded = useRef( false );
+
+	/**
+	 * Last non-empty query the user typed into the combobox. Prefills the
+	 * create-guest-author modal so the user does not have to retype. The
+	 * short-query branch in onFilterValueChange does not overwrite this, so
+	 * the prefill stays accurate even when the user backspaces.
+	 */
+	const lastQuery = useRef( '' );
+
+	/**
+	 * Create-guest-author modal state.
+	 */
+	const [ createModalOpen, setCreateModalOpen ] = useState( false );
+	const [ createDraftName, setCreateDraftName ] = useState( '' );
+	const [ createEmail, setCreateEmail ] = useState( '' );
+	const [ createError, setCreateError ] = useState( null );
+	const [ createSubmitting, setCreateSubmitting ] = useState( false );
 
 	/**
 	 * Read co-author term IDs from the core entity store.
@@ -215,10 +238,14 @@ const CoAuthors = () => {
 	 *
 	 * @param {string} query The text to search.
 	 */
-	const onFilterValueChange = useDebounce(
+		const onFilterValueChange = useDebounce(
 		useCallback( ( query ) => {
 			const { fetchAuthors: search, threshold: minLength } =
 				latest.current;
+
+			if ( query.length >= minLength ) {
+				lastQuery.current = query;
+			}
 
 			// Short or empty query: show the full alphabetical list. This keeps the
 			// dropdown useful while the user is still typing, and avoids the confusing
@@ -232,6 +259,57 @@ const CoAuthors = () => {
 		}, [] ),
 		500
 	);
+
+	/**
+	 * Open the create-guest-author modal, prefilled with the user's last
+	 * query when available.
+	 */
+	const openCreateModal = () => {
+		setCreateDraftName( lastQuery.current );
+		setCreateEmail( '' );
+		setCreateError( null );
+		setCreateModalOpen( true );
+	};
+
+	/**
+	 * Close the create-guest-author modal and reset its state.
+	 */
+	const closeCreateModal = () => {
+		setCreateModalOpen( false );
+		setCreateError( null );
+		setCreateSubmitting( false );
+	};
+
+	/**
+	 * Submit handler for the create-guest-author modal. POSTs to the REST
+	 * endpoint, then inserts the new author into the byline using the same
+	 * path as combobox selection so unresolved term IDs are preserved.
+	 */
+	const onSubmitCreate = async () => {
+		setCreateError( null );
+		setCreateSubmitting( true );
+
+		try {
+			const response = await apiFetch( {
+				path: '/coauthors/v1/guest-authors',
+				method: 'POST',
+				data: {
+					display_name: createDraftName,
+					user_email: createEmail,
+				},
+			} );
+
+			const formatted = formatAuthorData( response );
+			updateAuthors( [ ...selectedAuthors, formatted ] );
+			closeCreateModal();
+		} catch ( error ) {
+			const message =
+				( error && error.message ) ||
+				__( 'Could not create guest author.', 'co-authors-plus' );
+			setCreateError( message );
+			setCreateSubmitting( false );
+		}
+	};
 
 	// Show spinner while the post entity or author details are still loading.
 	// Once loading completes, render the resolved authors (which may be an
@@ -260,6 +338,71 @@ const CoAuthors = () => {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			/>
+
+			<Button
+				variant="link"
+				className="cap-create-guest-author-trigger"
+				onClick={ openCreateModal }
+			>
+				{ __( '+ Create new guest author', 'co-authors-plus' ) }
+			</Button>
+
+			{ createModalOpen && (
+				<Modal
+					title={ __( 'Create new guest author', 'co-authors-plus' ) }
+					onRequestClose={ closeCreateModal }
+					className="cap-create-guest-author-modal"
+				>
+					<TextControl
+						label={ __( 'Display name', 'co-authors-plus' ) }
+						value={ createDraftName }
+						onChange={ setCreateDraftName }
+						required
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<TextControl
+						label={ __( 'Email (optional)', 'co-authors-plus' ) }
+						value={ createEmail }
+						onChange={ setCreateEmail }
+						type="email"
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<p className="cap-create-guest-author-help">
+						{ __(
+							'Creates a guest byline for someone who is not a registered WordPress user on this site. You can complete the rest of their profile later.',
+							'co-authors-plus'
+						) }
+					</p>
+					{ createError && (
+						<p className="cap-create-guest-author-error" role="alert">
+							{ createError }
+						</p>
+					) }
+					<div className="cap-create-guest-author-actions">
+						<Button
+							variant="tertiary"
+							onClick={ closeCreateModal }
+							disabled={ createSubmitting }
+						>
+							{ __( 'Cancel', 'co-authors-plus' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ onSubmitCreate }
+							disabled={
+								createSubmitting ||
+								createDraftName.trim().length === 0
+							}
+						>
+							{ createSubmitting
+								? __( 'Creating…', 'co-authors-plus' )
+								: __( 'Create', 'co-authors-plus' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
 		</>
 	);
 };

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -238,7 +238,7 @@ const CoAuthors = () => {
 	 *
 	 * @param {string} query The text to search.
 	 */
-		const onFilterValueChange = useDebounce(
+	const onFilterValueChange = useDebounce(
 		useCallback( ( query ) => {
 			const { fetchAuthors: search, threshold: minLength } =
 				latest.current;

--- a/src/components/co-authors/style.css
+++ b/src/components/co-authors/style.css
@@ -2,6 +2,35 @@
 	margin-top: 16px;
 }
 
+.cap-create-guest-author-trigger {
+	margin-top: 4px;
+	padding: 0;
+}
+
+.cap-create-guest-author-modal .components-modal__content {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.cap-create-guest-author-help {
+	color: #757575;
+	font-size: 12px;
+	margin: 0;
+}
+
+.cap-create-guest-author-error {
+	color: #cc1818;
+	margin: 0;
+}
+
+.cap-create-guest-author-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+
 .cap-icon-button-stack {
 	display: flex;
 	flex-wrap: wrap;

--- a/tests/Integration/Rest/EndpointsTest.php
+++ b/tests/Integration/Rest/EndpointsTest.php
@@ -91,6 +91,12 @@ class EndpointsTest extends TestCase {
 			Endpoints::SEARCH_ROUTE
 		);
 
+		$guest_authors_route = sprintf(
+			'/%1$s/%2$s',
+			Endpoints::NS,
+			Endpoints::GUEST_AUTHORS_ROUTE
+		);
+
 		$this->assertArrayHasKey(
 			$authors_route,
 			$routes,
@@ -101,6 +107,12 @@ class EndpointsTest extends TestCase {
 			$search_route,
 			$routes,
 			'Failed to assert that search endpoint is registered'
+		);
+
+		$this->assertArrayHasKey(
+			$guest_authors_route,
+			$routes,
+			'Failed to assert that guest-authors endpoint is registered'
 		);
 
 		$this->assertArrayHasKey(
@@ -119,6 +131,12 @@ class EndpointsTest extends TestCase {
 			'POST',
 			$routes[ $authors_route ][1]['methods'],
 			'Failed to assert that authors endpoint has POST method.'
+		);
+
+		$this->assertArrayHasKey(
+			'POST',
+			$routes[ $guest_authors_route ][0]['methods'],
+			'Failed to assert that guest-authors endpoint has POST method.'
 		);
 	}
 
@@ -238,6 +256,99 @@ class EndpointsTest extends TestCase {
 		$update_response = $this->_api->update_coauthors( $post_request );
 
 		$this->assertCount( 2, $update_response->data );
+	}
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::create_guest_author
+	 */
+	public function test_create_guest_author_rest_route_succeeds(): void {
+		$editor = $this->create_editor();
+		wp_set_current_user( $editor->ID );
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_url_params(
+			array(
+				'display_name' => 'New Byline Person',
+				'user_email'   => 'newbyline@example.com',
+			)
+		);
+
+		$response = $this->_api->create_guest_author( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertSame( 'New Byline Person', $data['displayName'] );
+		$this->assertSame( 'new-byline-person', $data['userNicename'] );
+		$this->assertSame( 'newbyline@example.com', $data['email'] );
+		$this->assertSame( 'guest-author', $data['userType'] );
+		$this->assertIsInt( $data['termId'] );
+		$this->assertGreaterThan( 0, $data['termId'] );
+	}
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::create_guest_author
+	 */
+	public function test_create_guest_author_rest_route_returns_error_on_blank_display_name(): void {
+		$editor = $this->create_editor();
+		wp_set_current_user( $editor->ID );
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_url_params(
+			array(
+				'display_name' => '   ',
+			)
+		);
+
+		$response = $this->_api->create_guest_author( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'field-required', $response->get_error_code() );
+	}
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::create_guest_author
+	 */
+	public function test_create_guest_author_rest_route_returns_duplicate_error_on_existing_login(): void {
+		$editor = $this->create_editor();
+		wp_set_current_user( $editor->ID );
+
+		$this->create_guest_author( 'existing_guest' );
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_url_params(
+			array(
+				'display_name' => 'Existing Guest',
+				'user_login'   => 'existing_guest',
+			)
+		);
+
+		$response = $this->_api->create_guest_author( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'duplicate-field', $response->get_error_code() );
+		$this->assertSame( 409, $response->get_error_data( 'duplicate-field' )['status'] );
+	}
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::create_guest_author
+	 */
+	public function test_create_guest_author_rest_route_returns_400_status_on_blank_display_name(): void {
+		$editor = $this->create_editor();
+		wp_set_current_user( $editor->ID );
+
+		$request = new \WP_REST_Request( 'POST' );
+		$request->set_url_params(
+			array(
+				'display_name' => '   ',
+			)
+		);
+
+		$response = $this->_api->create_guest_author( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'field-required', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data( 'field-required' )['status'] );
 	}
 
 	public function data_only_editor_role_can_edit_coauthors(): array {

--- a/tests/Integration/Rest/EndpointsTest.php
+++ b/tests/Integration/Rest/EndpointsTest.php
@@ -265,21 +265,21 @@ class EndpointsTest extends TestCase {
 		$editor = $this->create_editor();
 		wp_set_current_user( $editor->ID );
 
-		$request = new \WP_REST_Request( 'POST' );
-		$request->set_url_params(
+		$request = new \WP_REST_Request( 'POST', '/coauthors/v1/guest-authors' );
+		$request->set_body_params(
 			array(
-				'display_name' => 'New Byline Person',
+				'display_name' => "Evil \nName\tWith\0Control",
 				'user_email'   => 'newbyline@example.com',
 			)
 		);
 
-		$response = $this->_api->create_guest_author( $request );
+		$response = rest_do_request( $request );
 
-		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 
-		$this->assertSame( 'New Byline Person', $data['displayName'] );
-		$this->assertSame( 'new-byline-person', $data['userNicename'] );
+		$this->assertSame( 'Evil Name WithControl', $data['displayName'] );
+		$this->assertSame( 'evil-name-withcontrol', $data['userNicename'] );
 		$this->assertSame( 'newbyline@example.com', $data['email'] );
 		$this->assertSame( 'guest-author', $data['userType'] );
 		$this->assertIsInt( $data['termId'] );
@@ -289,21 +289,38 @@ class EndpointsTest extends TestCase {
 	/**
 	 * @covers \CoAuthors\API\Endpoints::create_guest_author
 	 */
+	public function test_create_guest_author_rest_route_rejects_invalid_email(): void {
+		$editor = $this->create_editor();
+		wp_set_current_user( $editor->ID );
+
+		$request = new \WP_REST_Request( 'POST', '/coauthors/v1/guest-authors' );
+		$request->set_body_params(
+			array(
+				'display_name' => 'Invalid Email Author',
+				'user_email'   => 'not-an-email',
+			)
+		);
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::create_guest_author
+	 */
 	public function test_create_guest_author_rest_route_returns_error_on_blank_display_name(): void {
 		$editor = $this->create_editor();
 		wp_set_current_user( $editor->ID );
 
-		$request = new \WP_REST_Request( 'POST' );
-		$request->set_url_params(
-			array(
-				'display_name' => '   ',
-			)
-		);
+		$request = new \WP_REST_Request( 'POST', '/coauthors/v1/guest-authors' );
+		$request->set_body_params( array( 'display_name' => '   ' ) );
 
-		$response = $this->_api->create_guest_author( $request );
+		$response = rest_do_request( $request );
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertSame( 'field-required', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'field-required', $response->get_data()['code'] );
 	}
 
 	/**
@@ -315,40 +332,18 @@ class EndpointsTest extends TestCase {
 
 		$this->create_guest_author( 'existing_guest' );
 
-		$request = new \WP_REST_Request( 'POST' );
-		$request->set_url_params(
+		$request = new \WP_REST_Request( 'POST', '/coauthors/v1/guest-authors' );
+		$request->set_body_params(
 			array(
 				'display_name' => 'Existing Guest',
 				'user_login'   => 'existing_guest',
 			)
 		);
 
-		$response = $this->_api->create_guest_author( $request );
+		$response = rest_do_request( $request );
 
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertSame( 'duplicate-field', $response->get_error_code() );
-		$this->assertSame( 409, $response->get_error_data( 'duplicate-field' )['status'] );
-	}
-
-	/**
-	 * @covers \CoAuthors\API\Endpoints::create_guest_author
-	 */
-	public function test_create_guest_author_rest_route_returns_400_status_on_blank_display_name(): void {
-		$editor = $this->create_editor();
-		wp_set_current_user( $editor->ID );
-
-		$request = new \WP_REST_Request( 'POST' );
-		$request->set_url_params(
-			array(
-				'display_name' => '   ',
-			)
-		);
-
-		$response = $this->_api->create_guest_author( $request );
-
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertSame( 'field-required', $response->get_error_code() );
-		$this->assertSame( 400, $response->get_error_data( 'field-required' )['status'] );
+		$this->assertSame( 409, $response->get_status() );
+		$this->assertSame( 'duplicate-field', $response->get_data()['code'] );
 	}
 
 	public function data_only_editor_role_can_edit_coauthors(): array {


### PR DESCRIPTION
## Description

Adds a `Create new guest author` action to the Co-Authors panel in the block editor. Editors can create a new byline for someone not yet on the site without leaving the post screen, addressing the friction that has been tracked in #53 since 2012.

The change ships a new REST endpoint `POST /coauthors/v1/guest-authors` and a small inline modal in the existing sidebar component. The new endpoint reuses `CoAuthors_Guest_Authors::create()` so field validation, term creation, and failure cleanup stay in one place. The handler maps the create() error codes (`field-required`, `invalid-field`, `invalid-email`, `duplicate-field`) to REST HTTP statuses (400 / 409) so the modal can show meaningful messages instead of a generic 500.

Scope is block editor only. The classic editor sidebar is left untouched. Creating a full WordPress user account (login, role, password, email notification) is intentionally out of scope for this PR.

Fixes #53

## Deploy Notes

No new dependencies. No build, schema, or deployment changes required. The endpoint is namespaced under the existing `coauthors/v1` namespace and is gated by `current_user_can_set_authors()` via the same permission callback as the search and save routes.

## Steps to Test

### Automated

```sh
npx @wordpress/env start
docker exec wp-env-co-authors-plus-<id>-tests-cli-1 \
  /bin/bash -c 'cd wp-content/plugins/co-authors-plus && \
    ./vendor/bin/phpunit --testsuite integration --exclude=ms-required \
      --no-coverage --filter EndpointsTest'
```

(Replace `<id>` with your local wp-env hash. `npx @wordpress-env status` prints it.)

The new tests cover the happy path, blank display name, duplicate login, and HTTP status mapping.

Linters:

```sh
composer lint
composer lint-ci
npm run lint:js
npm run lint:css
npm run test:unit
```

### Manual

1. Open any post in the block editor.
2. In the Co-Authors sidebar, type a name that does not exist (e.g. `zzz_nonexistent_author`) in the `Select An Author` combobox.
3. Click `+ Create new guest author` directly below the combobox.
4. The modal opens with `Display name` prefilled to `zzz_nonexistent_author`. Leave email blank, click `Create`.
5. The modal closes. The new guest author appears as a chip in the Co-Authors panel.
6. Save the post and reload. The byline persists.
7. Open Users -> Guests. The new author is listed with slug `cap-zzz_nonexistent_author`.
8. Open another post, click `+ Create new guest author` again with a name that already exists. The modal stays open and shows an error like `That login already exists.` (HTTP 409).