### PR TITLE
fix(cli): add list-authors command to read back a post's co-authors

### DIFF
--- a/features/list-authors.feature
+++ b/features/list-authors.feature
@@ -1,0 +1,49 @@
+Feature: Co-authors of a post can be listed
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+
+	Scenario: Error on an invalid post id
+		When I try `wp co-authors-plus list-authors 0`
+		Then STDERR should be:
+      """
+      Error: Please specify a valid post_id.
+      """
+
+	Scenario: No co-authors are found for a post
+		When I run `wp post create --post_author=0 --post_status=publish --post_title="A post" --porcelain`
+		And save STDOUT as {POST_ID}
+		When I run `wp co-authors-plus list-authors {POST_ID}`
+		Then STDOUT should contain:
+      """
+      No co-authors found for post #{POST_ID}
+      """
+
+	Scenario: List the single WP user author of a post
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		When I run `wp post create --post_author={AUTHOR1_ID} --post_status=publish --post_title="A post" --porcelain`
+		And save STDOUT as {POST_ID}
+		When I run `wp co-authors-plus list-authors {POST_ID}`
+		Then STDOUT should contain:
+      """
+      author1
+      """
+
+	Scenario: List multiple co-authors assigned to a post
+		When I run `wp co-authors-plus create-guest-authors`
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp post create --post_status=publish --post_title="A post" --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term add {POST_ID} author admin`
+		And I run `wp post term add {POST_ID} author author1`
+		When I run `wp co-authors-plus list-authors {POST_ID}`
+		Then STDOUT should contain:
+      """
+      admin
+      """
+		And STDOUT should contain:
+      """
+      author1
+      """

--- a/features/list-authors.feature
+++ b/features/list-authors.feature
@@ -30,6 +30,30 @@ Feature: Co-authors of a post can be listed
       author1
       """
 
+	Scenario: Format the co-author output
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		When I run `wp post create --post_author={AUTHOR1_ID} --post_status=publish --post_title="A post" --porcelain`
+		And save STDOUT as {POST_ID}
+
+		When I run `wp co-authors-plus list-authors {POST_ID} --field=ID`
+		Then STDOUT should be:
+      """
+      {AUTHOR1_ID}
+      """
+
+		When I run `wp co-authors-plus list-authors {POST_ID} --format=count`
+		Then STDOUT should be:
+      """
+      1
+      """
+
+		When I run `wp co-authors-plus list-authors {POST_ID} --format=csv`
+		Then STDOUT should contain:
+      """
+      ID,display_name,user_nicename,user_email
+      """
+
 	Scenario: List multiple co-authors assigned to a post
 		When I run `wp co-authors-plus create-guest-authors`
 		When I run `wp user create author1 author1@example.com --role=author --porcelain`

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -839,13 +839,48 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * <post_id>
 	 * : ID of the post to list co-authors for.
 	 *
-	 * @since 3.0
+	 * [--field=<field>]
+	 * : Print the value of a single field for each co-author.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields. Defaults to all fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - count
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields are available for each co-author:
+	 *
+	 * * ID
+	 * * display_name
+	 * * user_nicename
+	 * * user_email
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List the co-authors of a post as a table.
+	 *     $ wp co-authors-plus list-authors 123
+	 *
+	 *     # Print just the co-author IDs, one per line.
+	 *     $ wp co-authors-plus list-authors 123 --field=ID
+	 *
+	 * @since 4.2.0
 	 *
 	 * @param array $args Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 *
 	 * @subcommand list-authors
-	 * @synopsis <post_id>
+	 * @synopsis <post_id> [--field=<field>] [--fields=<fields>] [--format=<format>]
 	 */
 	public function list_authors( $args, $assoc_args ): void {
 		$post_id = absint( $args[0] ?? 0 );
@@ -861,20 +896,23 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			return;
 		}
 
-		foreach ( $coauthors as $coauthor ) {
-			$row = array_map(
-				static function ( $value ) {
-					return '"' . str_replace( '"', '""', (string) $value ) . '"';
-				},
-				array(
-					$coauthor->ID,
-					$coauthor->display_name,
-					$coauthor->user_nicename,
-					$coauthor->user_email,
-				)
-			);
-			WP_CLI::log( implode( ',', $row ) );
-		}
+		$fields = array( 'ID', 'display_name', 'user_nicename', 'user_email' );
+
+		$items = array_map(
+			static function ( $coauthor ) use ( $fields ) {
+				$item = array();
+
+				foreach ( $fields as $field ) {
+					$item[ $field ] = $coauthor->$field ?? '';
+				}
+
+				return $item;
+			},
+			$coauthors
+		);
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( $items );
 	}
 
 	/**

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -832,6 +832,52 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * List the co-authors assigned to a post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : ID of the post to list co-authors for.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 *
+	 * @subcommand list-authors
+	 * @synopsis <post_id>
+	 */
+	public function list_authors( $args, $assoc_args ): void {
+		$post_id = absint( $args[0] ?? 0 );
+
+		if ( ! $post_id || ! get_post( $post_id ) ) {
+			WP_CLI::error( 'Please specify a valid post_id.' );
+		}
+
+		$coauthors = get_coauthors( $post_id );
+
+		if ( empty( $coauthors ) ) {
+			WP_CLI::log( 'No co-authors found for post #' . $post_id );
+			return;
+		}
+
+		foreach ( $coauthors as $coauthor ) {
+			$row = array_map(
+				static function ( $value ) {
+					return '"' . str_replace( '"', '""', (string) $value ) . '"';
+				},
+				array(
+					$coauthor->ID,
+					$coauthor->display_name,
+					$coauthor->user_nicename,
+					$coauthor->user_email,
+				)
+			);
+			WP_CLI::log( implode( ',', $row ) );
+		}
+	}
+
+	/**
 	 * Migrate author terms without prefixes to ones with prefixes
 	 * Pre-3.0, all author terms didn't have a 'cap-' prefix, which means
 	 * they can easily collide with terms in other taxonomies


### PR DESCRIPTION
## Description

Adds `wp co-authors-plus list-authors <post_id>` so users can read back which authors are assigned to a post, complementing the existing create/assign/remove CLI commands. This resolves the request in #1045.

The command reuses `get_coauthors()`, so it handles every case the front end does: a single WP user author (with fallback to the post's `post_author` when no terms are set), guest authors, and multi-author posts. It outputs one CSV row per co-author with the ID, display_name, user_nicename, and user_email. It errors out with a clear message on an invalid post id.

## Deploy Notes

No new dependencies. No user-facing strings that need i18n.

## Steps to Test

1. Check out this branch.
2. `composer install` and bring up wp-env (`npm run wp-env start`, or the repo's usual env setup).
3. Create a post and assign co-authors (`wp co-authors-plus create-guest-authors`, `wp post term add <post_id> author <nicename>`).
4. Run `wp co-authors-plus list-authors <post_id>`.
5. Verify one CSV row per co-author appears with ID, display_name, user_nicename, user_email.
6. Run `wp co-authors-plus list-authors 0` and verify it reports `Error: Please specify a valid post_id.`

Automated coverage lives in `features/list-authors.feature` (4 Behat scenarios). All suites pass: PHPCS clean, parallel-lint clean, Behat 4/4, unit 38, integration 269.