### PR TITLE
fix(coauthors): preserve input order in add_coauthors()

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1662,6 +1662,7 @@ class CoAuthors_Plus {
 		// Set the co-authors
 		$coauthors        = array_unique( array_merge( $existing_coauthors, $coauthors ) );
 		$coauthor_objects = array();
+		$coauthor_terms   = array();
 		foreach ( $coauthors as &$author_name ) {
 			if ( $this->is_rest_save && has_filter( 'coauthors_post_get_coauthor_by_field' ) ) {
 				_deprecated_hook(
@@ -1676,11 +1677,39 @@ class CoAuthors_Plus {
 			$author             = $this->get_coauthor_by( $field, $author_name );
 			$coauthor_objects[] = $author;
 			$term               = $this->update_author_term( $author );
-			if ( is_object( $term ) ) {
+			$has_term           = is_object( $term ) && ! is_wp_error( $term );
+			$coauthor_terms[]   = $has_term ? $term : null;
+			if ( $has_term ) {
 				$author_name = $term->slug;
 			}
 		}
+		unset( $author_name );
 		wp_set_post_terms( $post_id, $coauthors, $this->coauthor_taxonomy );
+
+		// Persist the requested order in wp_term_relationships.term_order so that
+		// get_coauthor_terms_for_post() (which orders by term_order ASC) returns
+		// the authors in the same order they were passed in. Without this, every
+		// row gets term_order = 0 and the read path falls back to an arbitrary
+		// order based on term_taxonomy_id. See issue #1052.
+		foreach ( $coauthors as $order => $slug ) {
+			$term_taxonomy_id = isset( $coauthor_terms[ $order ] ) && $coauthor_terms[ $order ]
+				? (int) $coauthor_terms[ $order ]->term_taxonomy_id
+				: 0;
+			if ( ! $term_taxonomy_id ) {
+				continue;
+			}
+			$wpdb->update(
+				$wpdb->term_relationships,
+				array( 'term_order' => (int) $order ),
+				array(
+					'object_id'        => $post_id,
+					'term_taxonomy_id' => $term_taxonomy_id,
+				),
+				array( '%d' ),
+				array( '%d', '%d' )
+			);
+		}
+		$this->clear_cache( $post_id );
 
 		// If the original post_author is no longer assigned,
 		// update to the first WP_User $coauthor

--- a/tests/Integration/Bylines/AddCoauthorsTest.php
+++ b/tests/Integration/Bylines/AddCoauthorsTest.php
@@ -873,6 +873,61 @@ class AddCoauthorsTest extends TestCase {
 	}
 
 	/**
+	 * Confirms that add_coauthors() persists the order of the input array via
+	 * wp_term_relationships.term_order, and that get_coauthors() (which orders
+	 * by term_order ASC) returns the authors in that same order. See issue #1052.
+	 *
+	 * Also covers a re-call with a different order to prove the term_order
+	 * write actually overwrites the previously persisted value, rather than
+	 * only writing on the first call.
+	 *
+	 * @covers ::add_coauthors
+	 */
+	public function test_add_coauthors_preserves_input_order(): void {
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_author' => $this->editor1->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// First assignment: alphabetic input order so it could plausibly match
+		// the read path's accidental ordering.
+		$first_order = array( $this->author1->user_login, $this->author2->user_login, $this->author3->user_login );
+		$this->assertTrue( $this->_cap->add_coauthors( $post_id, $first_order ) );
+
+		$coauthors = get_coauthors( $post_id );
+		$this->assertCount( 3, $coauthors );
+		$this->assertSame(
+			$first_order,
+			array_map(
+				function ( $c ) {
+					return $c->user_login;
+				},
+				$coauthors
+			)
+		);
+
+		// Reorder: a non-alphabetic, non-term-id order to prove the term_order
+		// write overrides the previous value rather than just touching new rows.
+		$second_order = array( $this->author3->user_login, $this->author1->user_login, $this->author2->user_login );
+		$this->assertTrue( $this->_cap->add_coauthors( $post_id, $second_order ) );
+
+		$reordered = get_coauthors( $post_id );
+		$this->assertCount( 3, $reordered );
+		$this->assertSame(
+			$second_order,
+			array_map(
+				function ( $c ) {
+					return $c->user_login;
+				},
+				$reordered
+			)
+		);
+	}
+
+	/**
 	 * Tests that deleting a user without a co-author term doesn't cause PHP warnings.
 	 *
 	 * @covers ::delete_user_action


### PR DESCRIPTION
## Description

Co-Authors Plus reads the co-authors for a post ordered by `wp_term_relationships.term_order ASC`, but `add_coauthors()` never wrote that column. After `wp_set_post_terms()` every relationship row was left at the default `term_order = 0`, so the read path fell back to an arbitrary order based on `term_taxonomy_id`. Programmatic callers (e.g. `$coauthors_plus->add_coauthors( $post_id, $authors )`) saw a random author order, and reordering in the editor drifted too, because the editor also funnels through `add_coauthors()` via `sync_coauthors_on_rest_save`.

This fix writes `term_order` for each author inside `add_coauthors()` so the stored order matches the input array, then clears the `coauthors_post_{ID}` cache so the next read sees the new order. It reuses the `term_taxonomy_id` already returned by `update_author_term()` instead of making an extra `get_term_by()` query per author.

Fixes #1052

## Deploy Notes

No new dependencies. Database schema unchanged; this only writes the existing `term_order` column on `wp_term_relationships`.

## Steps to Test

1. Check out PR.
2. Create a post with three existing users and assign them in a specific order via `$coauthors_plus->add_coauthors()`.
3. Confirm `get_coauthors()` returns them in the exact order passed in.
4. Call `add_coauthors()` again with a different order and confirm the order updates.
5. Reorder authors in the block editor, save, and confirm the order persists on reload.
6. Run the integration test suite with `composer test:integration` (all 270 tests should pass, including the new `AddCoauthorsTest::test_add_coauthors_preserves_input_order`).