### PR TITLE
Add rest_coauthors_prepare_items filter to Co-Authors REST endpoint

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -46,6 +46,13 @@ The resolved co-authors for a post. Runs after the plugin's lookup but before an
 - **Parameters:** `array $coauthors`, `int $post_id`
 - **File:** `template-tags.php`
 
+### `coauthors_block_authors`
+
+The resolved co-authors for a post, evaluated inside the `coauthors/v1/coauthors` REST endpoint. Use this to limit, reorder, or replace the list of co-authors that the Co-Authors block renders on the front end. The list is also exposed to the block editor via the same endpoint, so editor previews stay in sync. Returning a non-array from the callback yields an empty response.
+
+- **Parameters:** `array $coauthors`, `int $post_id`, `string $context`
+- **File:** `php/api/endpoints/class-coauthors-controller.php`
+
 ### `coauthors_open_graph_tags`
 
 The Open Graph tags the plugin contributes to the document head.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -46,13 +46,6 @@ The resolved co-authors for a post. Runs after the plugin's lookup but before an
 - **Parameters:** `array $coauthors`, `int $post_id`
 - **File:** `template-tags.php`
 
-### `coauthors_block_authors`
-
-The resolved co-authors for a post, evaluated inside the `coauthors/v1/coauthors` REST endpoint. Use this to limit, reorder, or replace the list of co-authors that the Co-Authors block renders on the front end. The list is also exposed to the block editor via the same endpoint, so editor previews stay in sync. Returning a non-array from the callback yields an empty response.
-
-- **Parameters:** `array $coauthors`, `int $post_id`, `string $context`
-- **File:** `php/api/endpoints/class-coauthors-controller.php`
-
 ### `coauthors_open_graph_tags`
 
 The Open Graph tags the plugin contributes to the document head.
@@ -201,6 +194,19 @@ Schema for a single co-author resource returned by the REST controller.
 The `WP_REST_Response` for a single co-author, after the default preparation. Use this to add custom fields.
 
 - **Parameters:** `WP_REST_Response $response`, `object $author`, `WP_REST_Request $request`
+
+### `rest_coauthors_prepare_items`
+
+The resolved co-authors for a post, before the `coauthors/v1/coauthors` collection endpoint formats them for a REST response. Use this to limit, reorder, or replace the list that endpoint returns. The Co-Authors block's server render and the block editor both read from this endpoint, so their output follows the filtered list; headless clients and other plugins that query the same endpoint see it too.
+
+This is presentation filtering only: co-authors removed here still exist on the post and remain visible through `get_coauthors()`, the byline template tags, the post's `coauthors` REST field, and the Authors panel in the editor sidebar. Do not use this filter for access control.
+
+When you need to change the co-authors everywhere the plugin resolves them, filter `get_coauthors` instead — it runs earlier and applies to template tags and archives as well. Reach for `rest_coauthors_prepare_items` only when the change should affect the REST collection response.
+
+Returning a non-array from the callback yields an empty response. Entries that are not valid co-author objects are dropped, and the surviving entries are reindexed so the response is always a well-formed JSON array.
+
+- **Parameters:** `array $coauthors`, `int $post_id`, `WP_REST_Request $request`
+- **File:** `php/api/endpoints/class-coauthors-controller.php`
 
 ## JavaScript filters (`@wordpress/hooks`)
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -56,6 +56,8 @@ Returns rich co-author data (display name, avatar, email, etc.) for a given post
 
 Available to anonymous requesters when the post is publicly viewable (`is_post_publicly_viewable()`). Otherwise the requester must have `read_post` permission for that post ID. Tightened in 4.0 to stop draft/private/scheduled posts from leaking author data.
 
+The response array passes through the `coauthors_block_authors` filter (added in 4.2.0) before serialization, which is the supported extension point for limiting, reordering, or replacing the list rendered by the Co-Authors block. See [filters.md](./filters.md).
+
 **Defined in** `php/api/endpoints/class-coauthors-controller.php`.
 
 ### `GET /coauthors/v1/coauthors/{user_nicename}`

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -56,7 +56,7 @@ Returns rich co-author data (display name, avatar, email, etc.) for a given post
 
 Available to anonymous requesters when the post is publicly viewable (`is_post_publicly_viewable()`). Otherwise the requester must have `read_post` permission for that post ID. Tightened in 4.0 to stop draft/private/scheduled posts from leaking author data.
 
-The response array passes through the `coauthors_block_authors` filter (added in 4.2.0) before serialization, which is the supported extension point for limiting, reordering, or replacing the list rendered by the Co-Authors block. See [filters.md](./filters.md).
+The response array passes through the `rest_coauthors_prepare_items` filter (added in 4.2.0) before serialization, which is the supported extension point for limiting, reordering, or replacing the returned list. The Co-Authors block is the main consumer of this endpoint, but the filter applies to every response from it. See [filters.md](./filters.md).
 
 **Defined in** `php/api/endpoints/class-coauthors-controller.php`.
 

--- a/php/api/endpoints/class-coauthors-controller.php
+++ b/php/api/endpoints/class-coauthors-controller.php
@@ -314,17 +314,18 @@ class CoAuthors_Controller extends WP_REST_Controller {
 		 * Filters the resolved co-authors before they are formatted for the REST response.
 		 *
 		 * Allows consumers to limit, reorder, or replace the list returned by the
-		 * coauthors/v1/coauthors endpoint, which is the data source for the Co-Authors
-		 * block's server render. Returning a non-array short-circuits to an empty list.
-		 * Invalid (non-object) entries and sparse keys are dropped/reindexed so the
-		 * response stays a well-formed JSON array.
+		 * coauthors/v1/coauthors collection endpoint. This endpoint is the data source
+		 * for the Co-Authors block's server render and its editor preview, but it is a
+		 * public endpoint also consumed by headless clients and other plugins. Returning
+		 * a non-array short-circuits to an empty list. Invalid entries are dropped and
+		 * sparse keys are reindexed so the response stays a well-formed JSON array.
 		 *
 		 * @since 4.2.0
-		 * @param array  $coauthors Resolved co-author objects (WP_User|stdClass).
-		 * @param int    $post_id  Post ID from the request.
-		 * @param string $context  Always 'block' for now; reserved for future endpoints.
+		 * @param array           $coauthors Resolved co-author objects (WP_User|stdClass).
+		 * @param int             $post_id   Post ID from the request.
+		 * @param WP_REST_Request $request   The current REST request.
 		 */
-		$coauthors = apply_filters( 'coauthors_block_authors', $coauthors, (int) $request->get_param( 'post_id' ), 'block' );
+		$coauthors = apply_filters( 'rest_coauthors_prepare_items', $coauthors, (int) $request->get_param( 'post_id' ), $request );
 
 		if ( ! is_array( $coauthors ) ) {
 			$coauthors = array();
@@ -334,7 +335,7 @@ class CoAuthors_Controller extends WP_REST_Controller {
 			array_filter(
 				$coauthors,
 				static function ( $author ) {
-					return is_object( $author );
+					return is_object( $author ) && self::is_coauthor( $author );
 				}
 			)
 		);

--- a/php/api/endpoints/class-coauthors-controller.php
+++ b/php/api/endpoints/class-coauthors-controller.php
@@ -310,6 +310,35 @@ class CoAuthors_Controller extends WP_REST_Controller {
 			);
 		}
 
+		/**
+		 * Filters the resolved co-authors before they are formatted for the REST response.
+		 *
+		 * Allows consumers to limit, reorder, or replace the list returned by the
+		 * coauthors/v1/coauthors endpoint, which is the data source for the Co-Authors
+		 * block's server render. Returning a non-array short-circuits to an empty list.
+		 * Invalid (non-object) entries and sparse keys are dropped/reindexed so the
+		 * response stays a well-formed JSON array.
+		 *
+		 * @since 4.2.0
+		 * @param array  $coauthors Resolved co-author objects (WP_User|stdClass).
+		 * @param int    $post_id  Post ID from the request.
+		 * @param string $context  Always 'block' for now; reserved for future endpoints.
+		 */
+		$coauthors = apply_filters( 'coauthors_block_authors', $coauthors, (int) $request->get_param( 'post_id' ), 'block' );
+
+		if ( ! is_array( $coauthors ) ) {
+			$coauthors = array();
+		}
+
+		$coauthors = array_values(
+			array_filter(
+				$coauthors,
+				static function ( $author ) {
+					return is_object( $author );
+				}
+			)
+		);
+
 		return rest_ensure_response(
 			array_map(
 				function( $author ) use ( $request ) : array {

--- a/tests/Integration/Rest/BlockAuthorsFilterTest.php
+++ b/tests/Integration/Rest/BlockAuthorsFilterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the coauthors_block_authors filter on the Co-Authors block REST endpoint.
+ * Tests for the rest_coauthors_prepare_items filter on the coauthors/v1/coauthors collection endpoint.
  *
  * @package Automattic\CoAuthorsPlus
  */
@@ -10,11 +10,11 @@ declare( strict_types=1 );
 namespace Automattic\CoAuthorsPlus\Tests\Integration\Rest;
 
 use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+use CoAuthors\Blocks;
 use WP_REST_Request;
 
-
 /**
- * @coversNothing
+ * @coversDefaultClass \CoAuthors\API\Endpoints\CoAuthors_Controller
  */
 class BlockAuthorsFilterTest extends TestCase {
 
@@ -53,17 +53,17 @@ class BlockAuthorsFilterTest extends TestCase {
 
 		wp_set_current_user( 0 );
 
-		$callback = function ( $coauthors ) {
+		$callback = static function ( $coauthors ) {
 			return array_slice( $coauthors, 0, 1 );
 		};
-		add_filter( 'coauthors_block_authors', $callback );
+		add_filter( 'rest_coauthors_prepare_items', $callback );
 
 		$data = $this->fetch_authors( $post->ID );
 
 		$this->assertCount( 1, $data );
 		$this->assertSame( $a1->user_nicename, $data[0]['user_nicename'] );
 
-		remove_filter( 'coauthors_block_authors', $callback );
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
 	}
 
 	/**
@@ -77,41 +77,42 @@ class BlockAuthorsFilterTest extends TestCase {
 		wp_set_current_user( 0 );
 
 		$captured = null;
-		$callback = function ( $coauthors, $post_id ) use ( &$captured ) {
+		$callback = static function ( $coauthors, $post_id ) use ( &$captured ) {
 			$captured = (int) $post_id;
 			return $coauthors;
 		};
-		add_filter( 'coauthors_block_authors', $callback, 10, 2 );
+		add_filter( 'rest_coauthors_prepare_items', $callback, 10, 2 );
 
 		$this->fetch_authors( $post->ID );
 
 		$this->assertSame( $post->ID, $captured );
 
-		remove_filter( 'coauthors_block_authors', $callback, 10, 2 );
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
 	}
 
 	/**
 	 * @covers ::get_items
 	 */
-	public function test_filter_receives_block_context(): void {
-		$a1   = $this->create_author( 'cap-1051-context' );
+	public function test_filter_receives_request_object(): void {
+		$a1   = $this->create_author( 'cap-1051-request' );
 		$post = $this->create_post( $a1 );
 		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename ) );
 
 		wp_set_current_user( 0 );
 
 		$captured = null;
-		$callback = function ( $coauthors, $post_id, $context ) use ( &$captured ) {
-			$captured = $context;
+		$callback = static function ( $coauthors, $post_id, $request ) use ( &$captured ) {
+			$captured = $request;
 			return $coauthors;
 		};
-		add_filter( 'coauthors_block_authors', $callback, 10, 3 );
+		add_filter( 'rest_coauthors_prepare_items', $callback, 10, 3 );
 
 		$this->fetch_authors( $post->ID );
 
-		$this->assertSame( 'block', $captured );
+		$this->assertInstanceOf( WP_REST_Request::class, $captured );
+		$this->assertSame( $post->ID, (int) $captured->get_param( 'post_id' ) );
 
-		remove_filter( 'coauthors_block_authors', $callback, 10, 3 );
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
 	}
 
 	/**
@@ -124,10 +125,10 @@ class BlockAuthorsFilterTest extends TestCase {
 
 		wp_set_current_user( 0 );
 
-		$callback = function ( $coauthors ) {
+		$callback = static function ( $coauthors ) {
 			return 'not-an-array';
 		};
-		add_filter( 'coauthors_block_authors', $callback );
+		add_filter( 'rest_coauthors_prepare_items', $callback );
 
 		$request  = new WP_REST_Request( 'GET', '/coauthors/v1/coauthors' );
 		$request->set_param( 'post_id', $post->ID );
@@ -136,7 +137,7 @@ class BlockAuthorsFilterTest extends TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array(), $response->get_data() );
 
-		remove_filter( 'coauthors_block_authors', $callback );
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
 	}
 
 	/**
@@ -150,10 +151,10 @@ class BlockAuthorsFilterTest extends TestCase {
 
 		wp_set_current_user( 0 );
 
-		$callback = function ( $coauthors ) {
+		$callback = static function ( $coauthors ) {
 			return array( 'not-an-object', 42, null, $coauthors[0] );
 		};
-		add_filter( 'coauthors_block_authors', $callback );
+		add_filter( 'rest_coauthors_prepare_items', $callback );
 
 		$data = $this->fetch_authors( $post->ID );
 
@@ -162,22 +163,48 @@ class BlockAuthorsFilterTest extends TestCase {
 		// Reindexed so the response is a JSON array, not an object.
 		$this->assertSame( array( 0 ), array_keys( $data ) );
 
-		remove_filter( 'coauthors_block_authors', $callback );
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
 	}
 
 	/**
-	 * The Co-Authors block server-render path goes through
-	 * Blocks::get_authors_with_api_schema(), which dispatches the REST endpoint
-	 * internally. The filtered list must reach that consumer unchanged.
+	 * A bare object that is not a valid co-author (missing ID, description,
+	 * display_name and user_nicename) must be dropped by the guard rather than
+	 * reaching prepare_item_for_response(), which reads those properties.
 	 *
-	 * The spy REST server used in the test suite rejects the full-URL
-	 * dispatch that Blocks::get_authors_with_api_schema() performs, so
-	 * exercise the consumer by calling its internal REST dispatch in the same
-	 * shape the block does, then asserting the filter result reaches it.
+	 * @covers ::get_items
+	 */
+	public function test_non_coauthor_object_is_dropped(): void {
+		$a1   = $this->create_author( 'cap-1051-stdclass' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$callback = static function ( $coauthors ) {
+			return array( new \stdClass(), $coauthors[0] );
+		};
+		add_filter( 'rest_coauthors_prepare_items', $callback );
+
+		$data = $this->fetch_authors( $post->ID );
+
+		$this->assertCount( 1, $data );
+		$this->assertSame( $a1->user_nicename, $data[0]['user_nicename'] );
+
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
+	}
+
+	/**
+	 * The Co-Authors block server render goes through
+	 * Blocks::get_authors_with_api_schema(), which dispatches the REST endpoint
+	 * from a full URL. Under plain permalinks `rest_url()` produces a
+	 * `?rest_route=` query string that `WP_REST_Request::from_url()` cannot
+	 * resolve to a route, so pretty permalinks are required here.
 	 *
 	 * @covers ::get_items
 	 */
 	public function test_block_render_path_sees_filtered_list(): void {
+		$this->set_permalink_structure( '/%postname%/' );
+
 		$a1   = $this->create_author( 'cap-1051-render-a' );
 		$a2   = $this->create_author( 'cap-1051-render-b' );
 		$post = $this->create_post( $a1 );
@@ -185,22 +212,41 @@ class BlockAuthorsFilterTest extends TestCase {
 
 		wp_set_current_user( 0 );
 
-		$callback = function ( $coauthors ) {
+		$callback = static function ( $coauthors ) {
 			return array_slice( $coauthors, 0, 1 );
 		};
-		add_filter( 'coauthors_block_authors', $callback );
+		add_filter( 'rest_coauthors_prepare_items', $callback );
 
-		// Mirror the block's data path: the block ultimately reads the same REST
-		// collection this dispatches, so the filter result observed here is what
-		// the block's server render would render.
-		$request = new WP_REST_Request( 'GET', '/coauthors/v1/coauthors' );
-		$request->set_param( 'post_id', $post->ID );
-		$response = rest_do_request( $request );
-		$authors  = (array) $response->get_data();
+		$authors = Blocks::get_authors_with_api_schema( $post->ID );
 
 		$this->assertCount( 1, $authors );
 		$this->assertSame( $a1->user_nicename, $authors[0]['user_nicename'] );
 
-		remove_filter( 'coauthors_block_authors', $callback );
+		remove_filter( 'rest_coauthors_prepare_items', $callback );
+	}
+
+	/**
+	 * The duplicate objects produced by get_coauthors() on posts with repeated
+	 * co-author terms used to serialise as a JSON object because array_map()
+	 * preserves non-sequential keys. The reindex must fix that at the source.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_duplicate_coauthors_response_is_reindexed(): void {
+		$a1   = $this->create_author( 'cap-1051-duplicate-a' );
+		$a2   = $this->create_author( 'cap-1051-duplicate-b' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename, $a2->user_nicename, $a1->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$data = $this->fetch_authors( $post->ID );
+
+		$this->assertCount( 2, $data );
+		$this->assertSame( array( 0, 1 ), array_keys( $data ) );
+		$this->assertSame(
+			array( $a1->user_nicename, $a2->user_nicename ),
+			array_column( $data, 'user_nicename' )
+		);
 	}
 }

--- a/tests/Integration/Rest/BlockAuthorsFilterTest.php
+++ b/tests/Integration/Rest/BlockAuthorsFilterTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Tests for the coauthors_block_authors filter on the Co-Authors block REST endpoint.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\Rest;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+use WP_REST_Request;
+
+
+/**
+ * @coversNothing
+ */
+class BlockAuthorsFilterTest extends TestCase {
+
+	private function fetch_authors( int $post_id ): array {
+		$request = new WP_REST_Request( 'GET', '/coauthors/v1/coauthors' );
+		$request->set_param( 'post_id', $post_id );
+		$response = rest_do_request( $request );
+		$this->assertSame( 200, $response->get_status() );
+		return (array) $response->get_data();
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_default_behavior_returns_all_coauthors(): void {
+		$a1   = $this->create_author( 'cap-1051-default-one' );
+		$a2   = $this->create_author( 'cap-1051-default-two' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename, $a2->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$data = $this->fetch_authors( $post->ID );
+
+		$this->assertCount( 2, $data );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_filter_can_limit_to_primary_author(): void {
+		$a1   = $this->create_author( 'cap-1051-primary' );
+		$a2   = $this->create_author( 'cap-1051-secondary' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename, $a2->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$callback = function ( $coauthors ) {
+			return array_slice( $coauthors, 0, 1 );
+		};
+		add_filter( 'coauthors_block_authors', $callback );
+
+		$data = $this->fetch_authors( $post->ID );
+
+		$this->assertCount( 1, $data );
+		$this->assertSame( $a1->user_nicename, $data[0]['user_nicename'] );
+
+		remove_filter( 'coauthors_block_authors', $callback );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_filter_receives_post_id(): void {
+		$a1   = $this->create_author( 'cap-1051-post-id' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$captured = null;
+		$callback = function ( $coauthors, $post_id ) use ( &$captured ) {
+			$captured = (int) $post_id;
+			return $coauthors;
+		};
+		add_filter( 'coauthors_block_authors', $callback, 10, 2 );
+
+		$this->fetch_authors( $post->ID );
+
+		$this->assertSame( $post->ID, $captured );
+
+		remove_filter( 'coauthors_block_authors', $callback, 10, 2 );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_filter_receives_block_context(): void {
+		$a1   = $this->create_author( 'cap-1051-context' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$captured = null;
+		$callback = function ( $coauthors, $post_id, $context ) use ( &$captured ) {
+			$captured = $context;
+			return $coauthors;
+		};
+		add_filter( 'coauthors_block_authors', $callback, 10, 3 );
+
+		$this->fetch_authors( $post->ID );
+
+		$this->assertSame( 'block', $captured );
+
+		remove_filter( 'coauthors_block_authors', $callback, 10, 3 );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_non_array_filter_response_is_coerced_to_empty(): void {
+		$a1   = $this->create_author( 'cap-1051-bad-return' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$callback = function ( $coauthors ) {
+			return 'not-an-array';
+		};
+		add_filter( 'coauthors_block_authors', $callback );
+
+		$request  = new WP_REST_Request( 'GET', '/coauthors/v1/coauthors' );
+		$request->set_param( 'post_id', $post->ID );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data() );
+
+		remove_filter( 'coauthors_block_authors', $callback );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_invalid_entries_and_sparse_keys_are_dropped(): void {
+		$a1   = $this->create_author( 'cap-1051-sparse-a' );
+		$a2   = $this->create_author( 'cap-1051-sparse-b' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename, $a2->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$callback = function ( $coauthors ) {
+			return array( 'not-an-object', 42, null, $coauthors[0] );
+		};
+		add_filter( 'coauthors_block_authors', $callback );
+
+		$data = $this->fetch_authors( $post->ID );
+
+		$this->assertCount( 1, $data );
+		$this->assertSame( $a1->user_nicename, $data[0]['user_nicename'] );
+		// Reindexed so the response is a JSON array, not an object.
+		$this->assertSame( array( 0 ), array_keys( $data ) );
+
+		remove_filter( 'coauthors_block_authors', $callback );
+	}
+
+	/**
+	 * The Co-Authors block server-render path goes through
+	 * Blocks::get_authors_with_api_schema(), which dispatches the REST endpoint
+	 * internally. The filtered list must reach that consumer unchanged.
+	 *
+	 * The spy REST server used in the test suite rejects the full-URL
+	 * dispatch that Blocks::get_authors_with_api_schema() performs, so
+	 * exercise the consumer by calling its internal REST dispatch in the same
+	 * shape the block does, then asserting the filter result reaches it.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_block_render_path_sees_filtered_list(): void {
+		$a1   = $this->create_author( 'cap-1051-render-a' );
+		$a2   = $this->create_author( 'cap-1051-render-b' );
+		$post = $this->create_post( $a1 );
+		$this->_cap->add_coauthors( $post->ID, array( $a1->user_nicename, $a2->user_nicename ) );
+
+		wp_set_current_user( 0 );
+
+		$callback = function ( $coauthors ) {
+			return array_slice( $coauthors, 0, 1 );
+		};
+		add_filter( 'coauthors_block_authors', $callback );
+
+		// Mirror the block's data path: the block ultimately reads the same REST
+		// collection this dispatches, so the filter result observed here is what
+		// the block's server render would render.
+		$request = new WP_REST_Request( 'GET', '/coauthors/v1/coauthors' );
+		$request->set_param( 'post_id', $post->ID );
+		$response = rest_do_request( $request );
+		$authors  = (array) $response->get_data();
+
+		$this->assertCount( 1, $authors );
+		$this->assertSame( $a1->user_nicename, $authors[0]['user_nicename'] );
+
+		remove_filter( 'coauthors_block_authors', $callback );
+	}
+}

--- a/tests/Integration/Rest/RestCoauthorsPrepareItemsFilterTest.php
+++ b/tests/Integration/Rest/RestCoauthorsPrepareItemsFilterTest.php
@@ -16,7 +16,7 @@ use WP_REST_Request;
 /**
  * @coversDefaultClass \CoAuthors\API\Endpoints\CoAuthors_Controller
  */
-class BlockAuthorsFilterTest extends TestCase {
+class RestCoauthorsPrepareItemsFilterTest extends TestCase {
 
 	private function fetch_authors( int $post_id ): array {
 		$request = new WP_REST_Request( 'GET', '/coauthors/v1/coauthors' );


### PR DESCRIPTION
## Description

The Co-Authors block reads co-authors through the `coauthors/v1/coauthors` REST endpoint. There was no filter on the resolved list at that layer, so a site that wanted to render only the primary author had to edit plugin code, which does not survive updates.

This PR adds a new filter, `rest_coauthors_prepare_items`, between `get_coauthors()` and the REST response formatting. Consumers can use it to limit, reorder, or replace the list of co-authors returned by the endpoint. The Co-Authors block's server render and its editor preview both read from the same endpoint, so both follow whatever the filter produces; headless clients and other plugins that query the endpoint see the same list.

Default behavior is unchanged when no callback is registered. The filter also receives `$post_id` and the full `WP_REST_Request`, so callbacks can branch on request context (params, headers, route) the same way core's `rest_prepare_*` filters do.

This is presentation filtering, not access control: co-authors removed here still exist on the post and remain visible through `get_coauthors()`, the byline template tags, the post's `coauthors` REST field, and the Authors panel in the editor sidebar. Use the existing `get_coauthors` filter if the change should apply everywhere the plugin resolves co-authors, not just this REST endpoint.

Closes #1051

### Incidental fix

The new guard at the filter call site reindexes the array with `array_values()` before serialization. `get_coauthors()` returns `array_unique( $coauthors, SORT_REGULAR )`, which can leave non-sequential keys when the same co-author appears under more than one term, and `array_map()` preserves keys, so a post with duplicate co-author objects previously serialised as a JSON object rather than a JSON array. A new test (`test_duplicate_coauthors_response_is_reindexed`) covers the fix.

## Deploy Notes

No new dependencies. No changes to existing REST schema, permission checks, or block attributes. Existing consumers of the endpoint see identical responses unless they register the new filter.

## Steps to Test

1. Check out this branch on a WordPress site with Co-Authors Plus active and a post that has at least two co-authors.
2. Confirm the Co-Authors block still renders every co-author in the existing order (no filter registered, default path).
3. Add a small mu-plugin that registers the filter:
   ```php
   add_filter( 'rest_coauthors_prepare_items', static function ( $coauthors ) {
       return array_slice( $coauthors, 0, 1 );
   } );
   ```
4. Reload the post on the front end. Only the first co-author renders.
5. Open the same post in the block editor and confirm the block preview also shows only the first co-author.
6. Deactivate the mu-plugin, reload, and confirm every co-author renders again.
7. Run `composer test:integration` against this branch. The new file `tests/Integration/Rest/RestCoauthorsPrepareItemsFilterTest.php` adds 9 tests covering the default path, the limit-to-primary case, the `$post_id` and `WP_REST_Request` arguments, non-array return coercion, the `is_coauthor()` guard dropping invalid objects, the real `Blocks::get_authors_with_api_schema()` block render path (with pretty permalinks), and the duplicate-key reindexing behaviour.

Expected result: steps 1-2 unchanged, steps 3-5 limited to primary author, step 6 reverted, step 7 green.