### PR TITLE
fix(tests): replace numberposts => -1 to clear cs-lint regression

### DIFF
--- a/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
+++ b/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
@@ -101,14 +101,10 @@ class CreateGuestAuthorTest extends TestCase {
 		$guest_author_obj = $coauthors_plus->guest_authors;
 
 		// Count posts before attempting to create the guest author.
-		$posts_before = get_posts(
-			array(
-				'post_type'   => $guest_author_obj->post_type,
-				'post_status' => 'any',
-				'numberposts' => -1,
-			)
-		);
-		$count_before = count( $posts_before );
+		// Sum every status key on the wp_count_posts() result so we count
+		// across all statuses without using numberposts => -1, which is
+		// prohibited by the VIP coding standard.
+		$count_before = $this->count_guest_author_posts( $guest_author_obj->post_type );
 
 		// Force wp_insert_term to fail by using a filter.
 		add_filter(
@@ -133,14 +129,7 @@ class CreateGuestAuthorTest extends TestCase {
 		$this->assertInstanceOf( 'WP_Error', $result );
 
 		// Verify no orphaned post was left behind.
-		$posts_after = get_posts(
-			array(
-				'post_type'   => $guest_author_obj->post_type,
-				'post_status' => 'any',
-				'numberposts' => -1,
-			)
-		);
-		$count_after = count( $posts_after );
+		$count_after = $this->count_guest_author_posts( $guest_author_obj->post_type );
 
 		$this->assertEquals( $count_before, $count_after, 'Orphaned guest author post should be cleaned up on term creation failure.' );
 	}
@@ -172,5 +161,25 @@ class CreateGuestAuthorTest extends TestCase {
 		$guest_author = $guest_author_obj->get_guest_author_by( 'ID', $guest_author_id );
 		$this->assertInstanceOf( \stdClass::class, $guest_author );
 		$this->assertEquals( 'Test Empty Content Author', $guest_author->display_name );
+	}
+
+	/**
+	 * Counts all guest-author posts across every status, matching the
+	 * behaviour of get_posts( [ 'post_status' => 'any', 'numberposts' => -1 ] )
+	 * without tripping the VIP no-paging rule.
+	 *
+	 * @param string $post_type The post type to count.
+	 * @return int Total number of posts in any status.
+	 */
+	private function count_guest_author_posts( string $post_type ): int {
+		$counts = wp_count_posts( $post_type );
+		if ( ! $counts instanceof \stdClass ) {
+			return 0;
+		}
+		$total = 0;
+		foreach ( (array) $counts as $value ) {
+			$total += (int) $value;
+		}
+		return $total;
 	}
 }


### PR DESCRIPTION
## Description

The `cs-lint` workflow runs PHPCS on `tests/` and blocks on any failure. Commit `a5d8f506` (Jun 24) introduced `numberposts => -1` in `test_create_guest_author_returns_error_and_cleans_up_on_term_failure`, which trips the VIP rule `WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts`. Because the workflow's `paths:` filter only triggers on `**.php` changes, the failure stayed hidden until any later PR touched PHP — including unrelated PRs like #1346.

This PR replaces both `get_posts([ 'post_status' => 'any', 'numberposts' => -1 ])` count blocks with a private `count_guest_author_posts()` helper that sums every status from `wp_count_posts()`. Semantic behaviour for the test is unchanged; the rule no longer trips.

Refs #1346 (blocked on this).

## Deploy Notes

No new dependencies. Test-only change.

## Steps to Test

1. Check out this PR.
2. Run `./vendor/bin/phpcs --standard=.phpcs.xml.dist tests/Integration/GuestAuthors/CreateGuestAuthorTest.php` — expect 0 errors (was 2).
3. Run `./vendor/bin/phpcs --standard=.phpcs.xml.dist tests/` — expect all files clean.
4. Run `composer test:integration -- --filter CreateGuestAuthor` — expect `test_create_guest_author_returns_error_and_cleans_up_on_term_failure` to pass.
5. Confirm the `Basic CS and QA checks` check on this PR turns green in CI.
6. After merge, re-run CI on #1346 — its `Basic CS and QA checks` failure was this same regression; it should now be green.