### PR TITLE
fix: raise author search limit from 10 to 100 (#1050)

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -80,6 +80,19 @@ class Endpoints {
 							'type'        => 'string',
 							'required'    => false,
 						),
+						'per_page'         => array(
+							'description'       => __( 'Maximum number of authors to return.', 'co-authors-plus' ),
+							'required'          => false,
+							'type'              => 'integer',
+							'default'           => 100,
+							'sanitize_callback' => function( $value ): int {
+								return absint( $value );
+							},
+							'validate_callback' => function( $value ): bool {
+								$value = (int) $value;
+								return $value >= 1 && $value <= 200;
+							},
+						),
 					),
 				),
 			)
@@ -160,7 +173,11 @@ class Endpoints {
 		$search  = strtolower( $request->get_param( 'q' ) );
 		$ignorable = $request->get_param( 'existing_authors' ) ?? '';
 		$ignore  = explode( ',', $ignorable );
-		$authors = $this->coauthors->search_authors( $search, $ignore );
+		$per_page = absint( $request->get_param( 'per_page' ) );
+		if ( ! $per_page ) {
+			$per_page = 100;
+		}
+		$authors = $this->coauthors->search_authors( $search, $ignore, $per_page );
 
 		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2072,7 +2072,22 @@ class CoAuthors_Plus {
 	/**
 	 * Get matching co-authors based on a search value
 	 */
-	public function search_authors( $search = '', $ignored_authors = array() ): array {
+	/**
+	 * Search authors by name, login, or email.
+	 *
+	 * The previous default of 10 silently truncated results for sites with
+	 * many guest authors, which broke the Gutenberg sidebar's ability to
+	 * select anyone past the first page. Default is now 100 to cover
+	 * realistic site sizes; pass a different value from the REST handler
+	 * or override the args via the coauthors_search_authors_get_terms_args
+	 * filter.
+	 *
+	 * @param string $search         Text to search for.
+	 * @param array  $ignored_authors List of user_nicenames to exclude.
+	 * @param int    $number          Maximum number of coauthor terms to return.
+	 * @return array
+	 */
+	public function search_authors( $search = '', $ignored_authors = array(), $number = 100 ): array {
 
 		// Since 2.7, we're searching against the term description for the fields
 		// instead of the user details. If the term is missing, we probably need to
@@ -2102,7 +2117,7 @@ class CoAuthors_Plus {
 		$args = array(
 			'search' => $search,
 			'get'    => 'all',
-			'number' => 10,
+			'number' => max( 1, (int) $number ),
 		);
 		$args = apply_filters( 'coauthors_search_authors_get_terms_args', $args );
 		add_filter( 'terms_clauses', array( $this, 'filter_terms_clauses' ) );

--- a/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
+++ b/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
@@ -101,14 +101,10 @@ class CreateGuestAuthorTest extends TestCase {
 		$guest_author_obj = $coauthors_plus->guest_authors;
 
 		// Count posts before attempting to create the guest author.
-		$posts_before = get_posts(
-			array(
-				'post_type'   => $guest_author_obj->post_type,
-				'post_status' => 'any',
-				'numberposts' => -1,
-			)
-		);
-		$count_before = count( $posts_before );
+		// Sum every status key on the wp_count_posts() result so we count
+		// across all statuses without using numberposts => -1, which is
+		// prohibited by the VIP coding standard.
+		$count_before = $this->count_guest_author_posts( $guest_author_obj->post_type );
 
 		// Force wp_insert_term to fail by using a filter.
 		add_filter(
@@ -133,14 +129,7 @@ class CreateGuestAuthorTest extends TestCase {
 		$this->assertInstanceOf( 'WP_Error', $result );
 
 		// Verify no orphaned post was left behind.
-		$posts_after = get_posts(
-			array(
-				'post_type'   => $guest_author_obj->post_type,
-				'post_status' => 'any',
-				'numberposts' => -1,
-			)
-		);
-		$count_after = count( $posts_after );
+		$count_after = $this->count_guest_author_posts( $guest_author_obj->post_type );
 
 		$this->assertEquals( $count_before, $count_after, 'Orphaned guest author post should be cleaned up on term creation failure.' );
 	}
@@ -172,5 +161,25 @@ class CreateGuestAuthorTest extends TestCase {
 		$guest_author = $guest_author_obj->get_guest_author_by( 'ID', $guest_author_id );
 		$this->assertInstanceOf( \stdClass::class, $guest_author );
 		$this->assertEquals( 'Test Empty Content Author', $guest_author->display_name );
+	}
+
+	/**
+	 * Counts all guest-author posts across every status, matching the
+	 * behaviour of get_posts( [ 'post_status' => 'any', 'numberposts' => -1 ] )
+	 * without tripping the VIP no-paging rule.
+	 *
+	 * @param string $post_type The post type to count.
+	 * @return int Total number of posts in any status.
+	 */
+	private function count_guest_author_posts( string $post_type ): int {
+		$counts = wp_count_posts( $post_type );
+		if ( ! $counts instanceof \stdClass ) {
+			return 0;
+		}
+		$total = 0;
+		foreach ( (array) $counts as $value ) {
+			$total += (int) $value;
+		}
+		return $total;
 	}
 }

--- a/tests/Integration/Rest/EndpointsTest.php
+++ b/tests/Integration/Rest/EndpointsTest.php
@@ -171,6 +171,58 @@ class EndpointsTest extends TestCase {
 	}
 
 	/**
+	 * @covers \CoAuthors\API\Endpoints::get_coauthors_search_results
+	 */
+	public function test_get_coauthors_search_results_exceeds_legacy_limit(): void {
+		// Create more guest authors than the old hard-coded limit of 10 so the
+		// result count proves the new default cap (100) is actually applied.
+		$guest_authors = array();
+		for ( $i = 1; $i <= 15; $i++ ) {
+			$guest_authors[] = $this->create_guest_author( 'search_guest_' . $i );
+		}
+
+		$get_request = new \WP_REST_Request( 'GET' );
+		$get_request->set_url_params(
+			array(
+				'q' => 'search_guest_',
+			)
+		);
+
+		$get_response = $this->_api->get_coauthors_search_results( $get_request );
+
+		$this->assertCount(
+			15,
+			$get_response->data,
+			'Failed to assert that coauthors search returns all guest authors when it exceeds the legacy limit.'
+		);
+	}
+
+	/**
+	 * @covers \CoAuthors\API\Endpoints::get_coauthors_search_results
+	 */
+	public function test_get_coauthors_search_results_honors_per_page(): void {
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$this->create_guest_author( 'per_page_guest_' . $i );
+		}
+
+		$get_request = new \WP_REST_Request( 'GET' );
+		$get_request->set_url_params(
+			array(
+				'q'        => 'per_page_guest_',
+				'per_page' => 3,
+			)
+		);
+
+		$get_response = $this->_api->get_coauthors_search_results( $get_request );
+
+		$this->assertCount(
+			3,
+			$get_response->data,
+			'Failed to assert that coauthors search honors the per_page parameter.'
+		);
+	}
+
+	/**
 	 * @covers \CoAuthors\API\Endpoints::get_coauthors
 	 */
 	public function test_authors_get_coauthors(): void {


### PR DESCRIPTION
## Description

The co-author search endpoint and search_authors() used a hard-coded limit of 10 results. Sites with more than ~50 guest authors could not see or select authors past the first page in the Gutenberg sidebar combobox, causing an infinite spinner or failed adds.

Raised the default cap to 100 and wired a per_page parameter through the REST handler. Existing callers and the filter still work.

Fixes #1050

## Deploy Notes

None.

## Steps to Test

1. Install the build zip on a site with 15+ guest authors.
2. Open the block editor and the Co-Authors panel.
3. Confirm the "Select An Author" dropdown shows more results than the old limit of 10.
4. Select a guest author that would have been excluded before.
5. Confirm the selection succeeds and persists after save.