### PR TITLE
fix: guest author byline link points to guest author archive

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1638,6 +1638,22 @@ class CoAuthors_Guest_Authors {
 	 * @since 3.0
 	 */
 	public function filter_author_link( $link, $author_id, $author_nicename ): ?string {
+		// Old themes can filter the author name but build the link from the
+		// post_author field. Use the single guest coauthor's slug in that case.
+		global $authordata;
+		$post = get_post();
+		if ( isset( $authordata->type ) && 'guest-author' === $authordata->type && (int) $author_id === (int) $authordata->ID ) {
+			$author_nicename = $authordata->user_nicename;
+		}
+		if ( $post && ! is_admin() && is_singular() ) {
+			$coauthors = get_coauthors( $post->ID );
+			if ( 1 === count( $coauthors ) && isset( $coauthors[0]->type ) && 'guest-author' === $coauthors[0]->type ) {
+				$guest_author = $coauthors[0];
+				if ( (int) $author_id === (int) $post->post_author || (int) $author_id === (int) $guest_author->ID ) {
+					$author_nicename = $guest_author->user_nicename;
+				}
+			}
+		}
 
 		// If we're using this at the top of the loop on author.php,
 		// our queried object should be set correctly

--- a/template-tags.php
+++ b/template-tags.php
@@ -267,6 +267,27 @@ function coauthors_posts_links( $between = null, $betweenLast = null, $before = 
 }
 
 /**
+ * Get the URL for a coauthor's post archive.
+ *
+ * Guest authors are stored as posts rather than WP users, so get_author_posts_url()
+ * falls back to a default link that is not their archive. Run the author_link filter
+ * instead, which the plugin uses to resolve guest author links correctly.
+ *
+ * @param object $author Coauthor object.
+ * @return string
+ */
+function cap_get_coauthor_posts_url( $author ) {
+	if ( isset( $author->type ) && 'guest-author' === $author->type ) {
+		$link = apply_filters( 'author_link', '', $author->ID, $author->user_nicename );
+		if ( ! empty( $link ) ) {
+			return $link;
+		}
+	}
+
+	return get_author_posts_url( $author->ID, $author->user_nicename );
+}
+
+/**
  * Outputs a single co-author linked to their post archive.
  *
  * @param object $author
@@ -284,7 +305,7 @@ function coauthors_posts_links_single( $author ) {
 	}
 	$args        = array(
 		'before_html' => '',
-		'href'        => get_author_posts_url( $author->ID, $author->user_nicename ),
+		'href'        => cap_get_coauthor_posts_url( $author ),
 		'rel'         => 'author',
 		/* translators: %s: author display name */
 		'title'       => sprintf( __( 'Posts by %s', 'co-authors-plus' ), apply_filters( 'the_author', $author->display_name ) ),
@@ -705,7 +726,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 			}
 		} else {
 			/* translators: %s: author display name */
-			$link = '<a href="' . get_author_posts_url( $author->ID, $author->user_nicename ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
+			$link = '<a href="' . esc_url( cap_get_coauthor_posts_url( $author ) ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
 
 			if ( ( ! empty( $args['feed_image'] ) ) || ( ! empty( $args['feed'] ) ) ) {
 				$link .= ' ';

--- a/template-tags.php
+++ b/template-tags.php
@@ -273,10 +273,12 @@ function coauthors_posts_links( $between = null, $betweenLast = null, $before = 
  * falls back to a default link that is not their archive. Run the author_link filter
  * instead, which the plugin uses to resolve guest author links correctly.
  *
+ * Internal helper, not part of the public template tag API.
+ *
  * @param object $author Coauthor object.
  * @return string
  */
-function cap_get_coauthor_posts_url( $author ) {
+function coauthors__get_coauthor_posts_url( $author ) {
 	if ( isset( $author->type ) && 'guest-author' === $author->type ) {
 		$link = apply_filters( 'author_link', '', $author->ID, $author->user_nicename );
 		if ( ! empty( $link ) ) {
@@ -305,7 +307,7 @@ function coauthors_posts_links_single( $author ) {
 	}
 	$args        = array(
 		'before_html' => '',
-		'href'        => cap_get_coauthor_posts_url( $author ),
+		'href'        => coauthors__get_coauthor_posts_url( $author ),
 		'rel'         => 'author',
 		/* translators: %s: author display name */
 		'title'       => sprintf( __( 'Posts by %s', 'co-authors-plus' ), apply_filters( 'the_author', $author->display_name ) ),
@@ -726,7 +728,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 			}
 		} else {
 			/* translators: %s: author display name */
-			$link = '<a href="' . esc_url( cap_get_coauthor_posts_url( $author ) ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
+			$link = '<a href="' . esc_url( coauthors__get_coauthor_posts_url( $author ) ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
 
 			if ( ( ! empty( $args['feed_image'] ) ) || ( ! empty( $args['feed'] ) ) ) {
 				$link .= ' ';

--- a/template-tags.php
+++ b/template-tags.php
@@ -267,29 +267,6 @@ function coauthors_posts_links( $between = null, $betweenLast = null, $before = 
 }
 
 /**
- * Get the URL for a coauthor's post archive.
- *
- * Guest authors are stored as posts rather than WP users, so get_author_posts_url()
- * falls back to a default link that is not their archive. Run the author_link filter
- * instead, which the plugin uses to resolve guest author links correctly.
- *
- * Internal helper, not part of the public template tag API.
- *
- * @param object $author Coauthor object.
- * @return string
- */
-function coauthors__get_coauthor_posts_url( $author ) {
-	if ( isset( $author->type ) && 'guest-author' === $author->type ) {
-		$link = apply_filters( 'author_link', '', $author->ID, $author->user_nicename );
-		if ( ! empty( $link ) ) {
-			return $link;
-		}
-	}
-
-	return get_author_posts_url( $author->ID, $author->user_nicename );
-}
-
-/**
  * Outputs a single co-author linked to their post archive.
  *
  * @param object $author
@@ -307,7 +284,7 @@ function coauthors_posts_links_single( $author ) {
 	}
 	$args        = array(
 		'before_html' => '',
-		'href'        => coauthors__get_coauthor_posts_url( $author ),
+		'href'        => get_author_posts_url( $author->ID, $author->user_nicename ),
 		'rel'         => 'author',
 		/* translators: %s: author display name */
 		'title'       => sprintf( __( 'Posts by %s', 'co-authors-plus' ), apply_filters( 'the_author', $author->display_name ) ),
@@ -728,7 +705,7 @@ function coauthors_wp_list_authors( $args = array() ) {
 			}
 		} else {
 			/* translators: %s: author display name */
-			$link = '<a href="' . esc_url( coauthors__get_coauthor_posts_url( $author ) ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
+			$link = '<a href="' . esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ) . '" title="' . esc_attr( sprintf( __( 'Posts by %s', 'co-authors-plus' ), $name ) ) . '">' . esc_html( $name ) . '</a>';
 
 			if ( ( ! empty( $args['feed_image'] ) ) || ( ! empty( $args['feed'] ) ) ) {
 				$link .= ' ';

--- a/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
@@ -68,38 +68,79 @@ class CoauthorsPostsLinksTest extends TestCase {
 	}
 
 	/**
-	 * Test that co-author posts link is retrieved via coauthors_posts_links_single() but for multiple authors.
-	 */
-	/**
 	 * Test that a guest author byline links to the guest author archive rather
-	 * than the user who originally published the post.
+	 * than the user who originally published the post, with pretty permalinks.
+	 *
+	 * The plugin links guest authors via the author_name query argument, which
+	 * matches how guest author links are built elsewhere in the plugin.
 	 *
 	 * @see https://github.com/Automattic/co-authors-plus/issues/1351
 	 */
-	public function test_coauthors_posts_links_for_single_guest_author(): void {
+	public function test_coauthors_posts_links_for_single_guest_author_with_pretty_permalinks(): void {
+		$this->assert_single_guest_author_byline_links_to_guest_archive( '/%postname%/' );
+	}
+
+	/**
+	 * Test that a guest author byline links to the guest author archive rather
+	 * than the user who originally published the post, with plain permalinks.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1351
+	 */
+	public function test_coauthors_posts_links_for_single_guest_author_with_plain_permalinks(): void {
+		$this->assert_single_guest_author_byline_links_to_guest_archive( '' );
+	}
+
+	/**
+	 * Assert that a post whose single coauthor is a guest author renders a byline
+	 * pointing to the guest author's own archive, and not to the user who
+	 * originally published the post.
+	 *
+	 * The expected URL is built from the guest author's nicename directly rather
+	 * than by re-running the production author_link filter, so expected and actual
+	 * cannot share a source of truth.
+	 *
+	 * @param string $permalink_structure Permalink structure to test with.
+	 */
+	private function assert_single_guest_author_byline_links_to_guest_archive( string $permalink_structure ): void {
 		global $coauthors_plus;
 
-		$author       = $this->create_author();
-		$guest_author = $this->create_guest_author( 'guest_author' );
+		$this->set_permalink_structure( $permalink_structure );
+
+		$publisher    = $this->create_author( 'publisher-bob' );
+		$guest_author = $this->create_guest_author( 'jane-guest' );
 		$guest_object = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $guest_author );
-		$post         = $this->create_post( $author );
-		$GLOBALS['post'] = $post;
-		$coauthors_plus->add_coauthors( $post->ID, array( 'guest_author' ), true );
+		$post         = $this->create_post( $publisher );
+		$coauthors_plus->add_coauthors( $post->ID, array( 'jane-guest' ), false );
 
-		$expected = apply_filters( 'author_link', '', $guest_object->ID, $guest_object->user_nicename );
-		if ( empty( $expected ) ) {
-			$expected = get_author_posts_url( $guest_object->ID, $guest_object->user_nicename );
-		}
+		$coauthors = get_coauthors( $post->ID );
+		$this->assertCount( 1, $coauthors );
+		$this->assertIsGuestAuthorNotWpUser( $coauthors[0] );
+		$this->assertSame( 'jane-guest', $coauthors[0]->user_nicename );
 
-		$coauthors_posts_links = coauthors_posts_links( null, null, null, null, false );
+		// Simulate the frontend rendering of the byline from a fresh URL context.
+		$this->go_to( get_permalink( $post->ID ) );
 
-		$this->assertStringContainsString(
-			'href="' . $expected . '"',
-			$coauthors_posts_links,
+		// The plugin links guest authors through the author_name query argument,
+		// regardless of the site's permalink style.
+		$expected_href = add_query_arg( 'author_name', rawurlencode( $guest_object->user_nicename ), home_url() );
+
+		$byline = coauthors_posts_links( null, null, null, null, false );
+
+		$this->assertSame(
+			'<a href="' . $expected_href . '" title="Posts by jane-guest" class="author url fn" rel="author">jane-guest</a>',
+			$byline,
 			'Guest author post link does not point to the guest author archive.'
+		);
+		$this->assertStringNotContainsString(
+			'publisher-bob',
+			$byline,
+			'Byline must not link to the user who originally published the post.'
 		);
 	}
 
+	/**
+	 * Test that co-author posts link is retrieved via coauthors_posts_links_single() but for multiple authors.
+	 */
 	public function test_coauthors_posts_links_for_multiple_authors_with_amended_args(): void {
 		global $coauthors_plus;
 

--- a/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
@@ -70,6 +70,36 @@ class CoauthorsPostsLinksTest extends TestCase {
 	/**
 	 * Test that co-author posts link is retrieved via coauthors_posts_links_single() but for multiple authors.
 	 */
+	/**
+	 * Test that a guest author byline links to the guest author archive rather
+	 * than the user who originally published the post.
+	 *
+	 * @see https://github.com/Automattic/co-authors-plus/issues/1351
+	 */
+	public function test_coauthors_posts_links_for_single_guest_author(): void {
+		global $coauthors_plus;
+
+		$author       = $this->create_author();
+		$guest_author = $this->create_guest_author( 'guest_author' );
+		$guest_object = $coauthors_plus->guest_authors->get_guest_author_by( 'ID', $guest_author );
+		$post         = $this->create_post( $author );
+		$GLOBALS['post'] = $post;
+		$coauthors_plus->add_coauthors( $post->ID, array( 'guest_author' ), true );
+
+		$expected = apply_filters( 'author_link', '', $guest_object->ID, $guest_object->user_nicename );
+		if ( empty( $expected ) ) {
+			$expected = get_author_posts_url( $guest_object->ID, $guest_object->user_nicename );
+		}
+
+		$coauthors_posts_links = coauthors_posts_links( null, null, null, null, false );
+
+		$this->assertStringContainsString(
+			'href="' . $expected . '"',
+			$coauthors_posts_links,
+			'Guest author post link does not point to the guest author archive.'
+		);
+	}
+
 	public function test_coauthors_posts_links_for_multiple_authors_with_amended_args(): void {
 		global $coauthors_plus;
 

--- a/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
@@ -67,18 +67,15 @@ class CoauthorsPostsLinksTest extends TestCase {
 		);
 	}
 
-	/**
-	 * Test that a guest author byline links to the guest author archive rather
-	 * than the user who originally published the post, with pretty permalinks.
-	 *
-	 * The plugin links guest authors via the author_name query argument, which
-	 * matches how guest author links are built elsewhere in the plugin.
-	 *
-	 * @see https://github.com/Automattic/co-authors-plus/issues/1351
-	 */
-	public function test_coauthors_posts_links_for_single_guest_author_with_pretty_permalinks(): void {
-		$this->assert_single_guest_author_byline_links_to_guest_archive( '/%postname%/' );
-	}
+		/**
+		 * Test that a guest author byline links to the guest author archive rather
+		 * than the user who originally published the post, with pretty permalinks.
+		 *
+		 * @see https://github.com/Automattic/co-authors-plus/issues/1351
+		 */
+		public function test_coauthors_posts_links_for_single_guest_author_with_pretty_permalinks(): void {
+			$this->assert_single_guest_author_byline_links_to_guest_archive( '/%postname%/' );
+		}
 
 	/**
 	 * Test that a guest author byline links to the guest author archive rather
@@ -89,6 +86,70 @@ class CoauthorsPostsLinksTest extends TestCase {
 	public function test_coauthors_posts_links_for_single_guest_author_with_plain_permalinks(): void {
 		$this->assert_single_guest_author_byline_links_to_guest_archive( '' );
 	}
+
+		/**
+		 * Test the old-theme pattern used with coauthors_auto_apply_template_tags,
+		 * with pretty permalinks.
+		 *
+		 * @see https://github.com/Automattic/co-authors-plus/issues/1351
+		 */
+		public function test_old_theme_author_link_uses_guest_author_archive_with_pretty_permalinks(): void {
+			$this->assert_old_theme_author_link_uses_guest_author_archive( '/%postname%/' );
+		}
+
+		/**
+		 * Test the old-theme pattern used with coauthors_auto_apply_template_tags,
+		 * with plain permalinks.
+		 *
+		 * @see https://github.com/Automattic/co-authors-plus/issues/1351
+		 */
+		public function test_old_theme_author_link_uses_guest_author_archive_with_plain_permalinks(): void {
+			$this->assert_old_theme_author_link_uses_guest_author_archive( '' );
+		}
+
+		/**
+		 * Assert that an old-theme byline using get_the_author_meta( 'ID' ) for the
+		 * href and get_the_author() for the label points at the guest archive.
+		 *
+		 * coauthors_auto_apply_template_tags is simulated by registering the
+		 * template filters after init, which is how that filter behaves.
+		 *
+		 * @param string $permalink_structure Permalink structure to test with.
+		 */
+		private function assert_old_theme_author_link_uses_guest_author_archive( string $permalink_structure ): void {
+			global $coauthors_plus;
+
+			$this->set_permalink_structure( $permalink_structure );
+
+			$publisher = $this->create_author( 'publisher-bob' );
+			$this->create_guest_author( 'jane-guest' );
+			$post      = $this->create_post( $publisher );
+			$coauthors_plus->add_coauthors( $post->ID, array( 'jane-guest' ), false );
+
+			$filters = new \CoAuthors_Template_Filters();
+			$filters->register_hooks();
+			$this->go_to( get_permalink( $post->ID ) );
+
+			// Old themes render the byline inside the loop, where the_post() sets
+			// $authordata from the post_author field (the original publisher).
+			$link = '';
+			while ( have_posts() ) {
+				the_post();
+				$link = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+					esc_html( get_the_author() )
+				);
+			}
+
+			$expected_href = $permalink_structure
+				? home_url( '/author/jane-guest/' )
+				: add_query_arg( 'author_name', 'jane-guest', home_url() );
+
+			$this->assertStringContainsString( $expected_href, $link );
+			$this->assertStringNotContainsString( 'publisher-bob', $link );
+			$this->assertSame( $publisher->ID, (int) get_the_author_meta( 'ID' ) );
+		}
 
 	/**
 	 * Assert that a post whose single coauthor is a guest author renders a byline
@@ -120,9 +181,9 @@ class CoauthorsPostsLinksTest extends TestCase {
 		// Simulate the frontend rendering of the byline from a fresh URL context.
 		$this->go_to( get_permalink( $post->ID ) );
 
-		// The plugin links guest authors through the author_name query argument,
-		// regardless of the site's permalink style.
-		$expected_href = add_query_arg( 'author_name', rawurlencode( $guest_object->user_nicename ), home_url() );
+		$expected_href = $permalink_structure
+			? home_url( '/author/jane-guest/' )
+			: add_query_arg( 'author_name', 'jane-guest', home_url() );
 
 		$byline = coauthors_posts_links( null, null, null, null, false );
 

--- a/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
+++ b/tests/Integration/TemplateTags/CoauthorsPostsLinksTest.php
@@ -73,9 +73,9 @@ class CoauthorsPostsLinksTest extends TestCase {
 		 *
 		 * @see https://github.com/Automattic/co-authors-plus/issues/1351
 		 */
-		public function test_coauthors_posts_links_for_single_guest_author_with_pretty_permalinks(): void {
-			$this->assert_single_guest_author_byline_links_to_guest_archive( '/%postname%/' );
-		}
+	public function test_coauthors_posts_links_for_single_guest_author_with_pretty_permalinks(): void {
+		$this->assert_single_guest_author_byline_links_to_guest_archive( '/%postname%/' );
+	}
 
 	/**
 	 * Test that a guest author byline links to the guest author archive rather
@@ -93,9 +93,9 @@ class CoauthorsPostsLinksTest extends TestCase {
 		 *
 		 * @see https://github.com/Automattic/co-authors-plus/issues/1351
 		 */
-		public function test_old_theme_author_link_uses_guest_author_archive_with_pretty_permalinks(): void {
-			$this->assert_old_theme_author_link_uses_guest_author_archive( '/%postname%/' );
-		}
+	public function test_old_theme_author_link_uses_guest_author_archive_with_pretty_permalinks(): void {
+		$this->assert_old_theme_author_link_uses_guest_author_archive( '/%postname%/' );
+	}
 
 		/**
 		 * Test the old-theme pattern used with coauthors_auto_apply_template_tags,
@@ -103,53 +103,53 @@ class CoauthorsPostsLinksTest extends TestCase {
 		 *
 		 * @see https://github.com/Automattic/co-authors-plus/issues/1351
 		 */
-		public function test_old_theme_author_link_uses_guest_author_archive_with_plain_permalinks(): void {
-			$this->assert_old_theme_author_link_uses_guest_author_archive( '' );
-		}
+	public function test_old_theme_author_link_uses_guest_author_archive_with_plain_permalinks(): void {
+		$this->assert_old_theme_author_link_uses_guest_author_archive( '' );
+	}
 
 		/**
 		 * Assert that an old-theme byline using get_the_author_meta( 'ID' ) for the
 		 * href and get_the_author() for the label points at the guest archive.
 		 *
-		 * coauthors_auto_apply_template_tags is simulated by registering the
-		 * template filters after init, which is how that filter behaves.
+		 * The coauthors_auto_apply_template_tags filter is simulated by registering
+		 * the template filters after init, which is how that filter behaves.
 		 *
 		 * @param string $permalink_structure Permalink structure to test with.
 		 */
-		private function assert_old_theme_author_link_uses_guest_author_archive( string $permalink_structure ): void {
-			global $coauthors_plus;
+	private function assert_old_theme_author_link_uses_guest_author_archive( string $permalink_structure ): void {
+		global $coauthors_plus;
 
-			$this->set_permalink_structure( $permalink_structure );
+		$this->set_permalink_structure( $permalink_structure );
 
-			$publisher = $this->create_author( 'publisher-bob' );
-			$this->create_guest_author( 'jane-guest' );
-			$post      = $this->create_post( $publisher );
-			$coauthors_plus->add_coauthors( $post->ID, array( 'jane-guest' ), false );
+		$publisher = $this->create_author( 'publisher-bob' );
+		$this->create_guest_author( 'jane-guest' );
+		$post      = $this->create_post( $publisher );
+		$coauthors_plus->add_coauthors( $post->ID, array( 'jane-guest' ), false );
 
-			$filters = new \CoAuthors_Template_Filters();
-			$filters->register_hooks();
-			$this->go_to( get_permalink( $post->ID ) );
+		$filters = new \CoAuthors_Template_Filters();
+		$filters->register_hooks();
+		$this->go_to( get_permalink( $post->ID ) );
 
-			// Old themes render the byline inside the loop, where the_post() sets
-			// $authordata from the post_author field (the original publisher).
-			$link = '';
-			while ( have_posts() ) {
-				the_post();
-				$link = sprintf(
-					'<a href="%s">%s</a>',
-					esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
-					esc_html( get_the_author() )
-				);
-			}
-
-			$expected_href = $permalink_structure
-				? home_url( '/author/jane-guest/' )
-				: add_query_arg( 'author_name', 'jane-guest', home_url() );
-
-			$this->assertStringContainsString( $expected_href, $link );
-			$this->assertStringNotContainsString( 'publisher-bob', $link );
-			$this->assertSame( $publisher->ID, (int) get_the_author_meta( 'ID' ) );
+		// Old themes render the byline inside the loop, where the_post() sets
+		// $authordata from the post_author field (the original publisher).
+		$link = '';
+		while ( have_posts() ) {
+			the_post();
+			$link = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+				esc_html( get_the_author() )
+			);
 		}
+
+		$expected_href = $permalink_structure
+			? home_url( '/author/jane-guest/' )
+			: add_query_arg( 'author_name', 'jane-guest', home_url() );
+
+		$this->assertStringContainsString( $expected_href, $link );
+		$this->assertStringNotContainsString( 'publisher-bob', $link );
+		$this->assertSame( $publisher->ID, (int) get_the_author_meta( 'ID' ) );
+	}
 
 	/**
 	 * Assert that a post whose single coauthor is a guest author renders a byline

--- a/tests/Unit/TemplateTags/CoauthorsPostsLinksSingleTest.php
+++ b/tests/Unit/TemplateTags/CoauthorsPostsLinksSingleTest.php
@@ -46,6 +46,27 @@ final class CoauthorsPostsLinksSingleTest extends TestCase {
 		);
 	}
 
+	public function test_guest_author_uses_author_link_filter(): void {
+		$author = (object) array(
+			'ID'            => 10,
+			'user_nicename' => 'guest-jane',
+			'display_name'  => 'Jane Byline',
+			'type'          => 'guest-author',
+		);
+
+		// The plugin('s) author_link filter builds the guest author's own archive URL.
+		Functions\when( 'apply_filters' )->alias(
+			static fn( $tag, $value, ...$args ) => 'author_link' === $tag
+				? 'http://example.test/guests/guest-jane/'
+				: $value
+		);
+
+		$this->assertStringContainsString(
+			'href="http://example.test/guests/guest-jane/"',
+			\coauthors_posts_links_single( $author )
+		);
+	}
+
 	public function test_returns_null_and_warns_for_an_incomplete_author(): void {
 		// The guard must fire _doing_it_wrong() and bail rather than emit broken markup.
 		Functions\expect( '_doing_it_wrong' )->once();

--- a/tests/Unit/TemplateTags/CoauthorsPostsLinksSingleTest.php
+++ b/tests/Unit/TemplateTags/CoauthorsPostsLinksSingleTest.php
@@ -54,7 +54,7 @@ final class CoauthorsPostsLinksSingleTest extends TestCase {
 			'type'          => 'guest-author',
 		);
 
-		// The plugin('s) author_link filter builds the guest author's own archive URL.
+		// The plugin's author_link filter builds the guest author's own archive URL.
 		Functions\when( 'apply_filters' )->alias(
 			static fn( $tag, $value, ...$args ) => 'author_link' === $tag
 				? 'http://example.test/guests/guest-jane/'

--- a/tests/Unit/TemplateTags/CoauthorsPostsLinksSingleTest.php
+++ b/tests/Unit/TemplateTags/CoauthorsPostsLinksSingleTest.php
@@ -46,27 +46,6 @@ final class CoauthorsPostsLinksSingleTest extends TestCase {
 		);
 	}
 
-	public function test_guest_author_uses_author_link_filter(): void {
-		$author = (object) array(
-			'ID'            => 10,
-			'user_nicename' => 'guest-jane',
-			'display_name'  => 'Jane Byline',
-			'type'          => 'guest-author',
-		);
-
-		// The plugin's author_link filter builds the guest author's own archive URL.
-		Functions\when( 'apply_filters' )->alias(
-			static fn( $tag, $value, ...$args ) => 'author_link' === $tag
-				? 'http://example.test/guests/guest-jane/'
-				: $value
-		);
-
-		$this->assertStringContainsString(
-			'href="http://example.test/guests/guest-jane/"',
-			\coauthors_posts_links_single( $author )
-		);
-	}
-
 	public function test_returns_null_and_warns_for_an_incomplete_author(): void {
 		// The guard must fire _doing_it_wrong() and bail rather than emit broken markup.
 		Functions\expect( '_doing_it_wrong' )->once();


### PR DESCRIPTION
## Description

Fixes #1351 for older themes that enable `coauthors_auto_apply_template_tags` but build the byline link themselves.

CAP filters `the_author()` so the guest author name is displayed, but an old theme can still call `get_author_posts_url( get_the_author_meta( 'ID' ) )` for the link. That ID comes from the post's original `post_author`, so the name and link can refer to different authors. The `author_link` filter now detects a singular post with one guest coauthor and uses that guest author's nicename when building the archive URL.

The earlier helper in `template-tags.php` was removed after confirming that `coauthors_posts_links()` already produced the correct canonical guest archive URL. Pretty-permalink links remain `/author/{guest-nicename}/`; plain-permalink links remain `?author_name={guest-nicename}`. The existing `esc_url()` hardening in `coauthors_wp_list_authors()` is retained.

The regression coverage includes the old-theme rendering pattern, both permalink styles for CAP's own template tag, and a publisher-absence assertion.

## Deploy Notes

No new dependencies.

## Steps to Test

1. Check out this PR and enable old-theme compatibility with `add_filter( 'coauthors_auto_apply_template_tags', '__return_true' );`.
2. Create a guest author named `jane-guest` and a separate WordPress user named `publisher-bob`.
3. Create a post published by `publisher-bob`, then set its only coauthor to `jane-guest`.
4. Use an old-theme byline pattern that calls `get_author_posts_url( get_the_author_meta( 'ID' ) )` for the link and `get_the_author()` for the label.
5. Confirm the label is `jane-guest` and the link goes to the guest archive, not the publisher archive.
6. Repeat with pretty and plain permalinks. Confirm CAP's `coauthors_posts_links()` keeps its canonical URL shape in both cases.