### PR TITLE
Add E2E coverage for managing co-authors

### DIFF
--- a/tests/e2e/block-editor-manage.spec.js
+++ b/tests/e2e/block-editor-manage.spec.js
@@ -1,0 +1,135 @@
+/**
+ * End-to-end coverage for managing multiple co-authors in the block editor.
+ *
+ * The reorder / add / remove array logic is already unit-tested in
+ * src/__tests__/utils.test.js. These specs prove the part units cannot: that
+ * the panel's buttons drive the editor entity store, and that the resulting
+ * byline — membership AND order — survives a publish.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const {
+	coAuthorChip,
+	openAuthorsPanel,
+	addCoAuthor,
+	removeCoAuthor,
+	moveCoAuthor,
+	getCoAuthorNames,
+	getSavedCoAuthors,
+} = require( './helpers/co-authors' );
+const { createCoAuthorUser } = require( './helpers/fixtures' );
+
+test.describe( 'Managing co-authors in the block editor', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// Distinct, non-substring display names keep option/chip matching
+		// unambiguous for the substring-based locators.
+		await createCoAuthorUser( requestUtils, {
+			username: 'e2ebianca',
+			displayName: 'Bianca Byline',
+		} );
+		await createCoAuthorUser( requestUtils, {
+			username: 'e2ecarl',
+			displayName: 'Carl Column',
+		} );
+		await createCoAuthorUser( requestUtils, {
+			username: 'e2edana',
+			displayName: 'Dana Draft',
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllUsers();
+	} );
+
+	test( 'adds several co-authors, reorders them, and persists the new order', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await admin.createNewPost( { title: 'Ordered byline' } );
+		await editor.openDocumentSettingsSidebar();
+		await openAuthorsPanel( page );
+
+		// Wait for the panel to resolve the default author before editing so the
+		// ordering assertions start from a known state.
+		await coAuthorChip( page, 'admin' ).waitFor();
+
+		await addCoAuthor( page, 'Bianca Byline' );
+		await addCoAuthor( page, 'Carl Column' );
+		await addCoAuthor( page, 'Dana Draft' );
+
+		// New authors append after the default author (admin).
+		await expect
+			.poll( () => getCoAuthorNames( page ) )
+			.toEqual( [
+				'admin',
+				'Bianca Byline',
+				'Carl Column',
+				'Dana Draft',
+			] );
+
+		// Move the last author up one place.
+		await moveCoAuthor( page, 'Dana Draft', 'up' );
+		await expect
+			.poll( () => getCoAuthorNames( page ) )
+			.toEqual( [
+				'admin',
+				'Bianca Byline',
+				'Dana Draft',
+				'Carl Column',
+			] );
+
+		// The saved byline reflects the reordered sequence, not just membership.
+		const postId = await editor.publishPost();
+		await expect
+			.poll( () => getSavedCoAuthors( requestUtils, postId ) )
+			.toEqual( [
+				'admin',
+				'Bianca Byline',
+				'Dana Draft',
+				'Carl Column',
+			] );
+	} );
+
+	test( 'removing co-authors down to one disables the row controls', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		await admin.createNewPost( { title: 'Single byline' } );
+		await editor.openDocumentSettingsSidebar();
+		await openAuthorsPanel( page );
+
+		await coAuthorChip( page, 'admin' ).waitFor();
+
+		await addCoAuthor( page, 'Bianca Byline' );
+		await expect
+			.poll( () => getCoAuthorNames( page ) )
+			.toEqual( [ 'admin', 'Bianca Byline' ] );
+
+		await removeCoAuthor( page, 'Bianca Byline' );
+		await expect
+			.poll( () => getCoAuthorNames( page ) )
+			.toEqual( [ 'admin' ] );
+
+		// With a single co-author remaining, its move/remove controls disable.
+		const adminChip = coAuthorChip( page, 'admin' );
+		await expect(
+			adminChip.getByRole( 'button', { name: 'Remove Author' } )
+		).toBeDisabled();
+		await expect(
+			adminChip.getByRole( 'button', { name: 'Move Up', exact: true } )
+		).toBeDisabled();
+		await expect(
+			adminChip.getByRole( 'button', { name: 'Move down', exact: true } )
+		).toBeDisabled();
+
+		const postId = await editor.publishPost();
+		await expect
+			.poll( () => getSavedCoAuthors( requestUtils, postId ) )
+			.toEqual( [ 'admin' ] );
+	} );
+} );

--- a/tests/e2e/helpers/co-authors.js
+++ b/tests/e2e/helpers/co-authors.js
@@ -1,0 +1,119 @@
+/**
+ * Shared helpers for driving the Co-Authors Plus "Authors" panel in the block
+ * editor, and for reading the saved byline back via the public REST endpoint.
+ *
+ * These are deliberately thin, stateless, selector-driven actions — not
+ * Playwright fixtures or page objects, which would be premature at this scale.
+ * They mirror the selectors used by the original tests/e2e/coauthors.spec.js
+ * so every spec drives the same UI an editor uses.
+ */
+
+/**
+ * Locate the panel chip (`.cap-author`) for a given co-author by display name.
+ *
+ * @param {import('@playwright/test').Page} page        Playwright page.
+ * @param {string}                          displayName Author display name shown in the chip.
+ * @return {import('@playwright/test').Locator} The chip locator.
+ */
+function coAuthorChip( page, displayName ) {
+	return page.locator( '.cap-author', { hasText: displayName } );
+}
+
+/**
+ * Open the "Authors" document-settings panel, expanding it if it is collapsed.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page.
+ */
+async function openAuthorsPanel( page ) {
+	const panelToggle = page.getByRole( 'button', { name: 'Authors' } );
+	if ( 'false' === ( await panelToggle.getAttribute( 'aria-expanded' ) ) ) {
+		await panelToggle.click();
+	}
+}
+
+/**
+ * Search for an author in the panel combobox and add them to the byline.
+ *
+ * Relies on Playwright auto-waiting for the matching option and the resulting
+ * chip, which absorbs the 500ms search debounce without a fixed timeout.
+ *
+ * @param {import('@playwright/test').Page} page         Playwright page.
+ * @param {string}                          displayName  Author display name (the option label and resulting chip text).
+ * @param {string}                          [searchTerm] Text to type; defaults to the display name.
+ */
+async function addCoAuthor( page, displayName, searchTerm = displayName ) {
+	const combobox = page.getByRole( 'combobox', { name: 'Select An Author' } );
+	await combobox.click();
+	await combobox.fill( searchTerm );
+
+	// The option label is "Display Name | email"; a substring match on the
+	// display name is enough so long as display names are not substrings of
+	// one another (enforced by the fixtures).
+	await page.getByRole( 'option', { name: displayName } ).click();
+	await coAuthorChip( page, displayName ).waitFor();
+}
+
+/**
+ * Remove a co-author from the byline via its chip's "Remove Author" button.
+ *
+ * @param {import('@playwright/test').Page} page        Playwright page.
+ * @param {string}                          displayName Author display name to remove.
+ */
+async function removeCoAuthor( page, displayName ) {
+	await coAuthorChip( page, displayName )
+		.getByRole( 'button', { name: 'Remove Author' } )
+		.click();
+}
+
+/**
+ * Move a co-author up or down via its chip's chevron button.
+ *
+ * @param {import('@playwright/test').Page} page        Playwright page.
+ * @param {string}                          displayName Author display name to move.
+ * @param {'up'|'down'}                     direction   Direction to move the author.
+ */
+async function moveCoAuthor( page, displayName, direction ) {
+	// Source labels are inconsistently cased ("Move Up" / "Move down").
+	const label = 'up' === direction ? 'Move Up' : 'Move down';
+	await coAuthorChip( page, displayName )
+		.getByRole( 'button', { name: label, exact: true } )
+		.click();
+}
+
+/**
+ * Read the ordered list of co-author display names currently shown in the panel.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page.
+ * @return {Promise<string[]>} Display names in panel order.
+ */
+async function getCoAuthorNames( page ) {
+	const names = await page
+		.locator( '.cap-author .cap-author-flex-item span' )
+		.allInnerTexts();
+	return names.map( ( name ) => name.trim() );
+}
+
+/**
+ * Read the saved co-authors for a post via the public REST endpoint — the
+ * persisted byline, independent of the active theme's markup or the editor UI.
+ *
+ * @param {import('@wordpress/e2e-test-utils-playwright').RequestUtils} requestUtils Request utils fixture.
+ * @param {number}                                                      postId       Post ID.
+ * @return {Promise<string[]>} Display names in saved order.
+ */
+async function getSavedCoAuthors( requestUtils, postId ) {
+	const coauthors = await requestUtils.rest( {
+		path: `/coauthors/v1/coauthors?post_id=${ postId }`,
+	} );
+	return coauthors.map( ( coauthor ) => coauthor.display_name );
+}
+
+module.exports = {
+	coAuthorChip,
+	openAuthorsPanel,
+	addCoAuthor,
+	removeCoAuthor,
+	moveCoAuthor,
+	getCoAuthorNames,
+	getSavedCoAuthors,
+};

--- a/tests/e2e/helpers/fixtures.js
+++ b/tests/e2e/helpers/fixtures.js
@@ -1,0 +1,45 @@
+/**
+ * Shared data fixtures for the Co-Authors Plus E2E specs.
+ */
+
+/**
+ * Create a WordPress user that can be assigned as a co-author.
+ *
+ * createUser() cannot set the display name, so it is set via REST afterwards —
+ * that is what the panel, the list column and the byline show, and what the
+ * specs assert against (the same workaround the original spec uses inline).
+ *
+ * @param {import('@wordpress/e2e-test-utils-playwright').RequestUtils} requestUtils        Request utils fixture.
+ * @param {Object}                                                      options             User options.
+ * @param {string}                                                      options.username    Login / username.
+ * @param {string}                                                      options.displayName Display name to set via REST.
+ * @param {string[]}                                                    [options.roles]     Roles; defaults to [ 'author' ].
+ * @return {Promise<Object>} The created user object (includes `id`).
+ */
+async function createCoAuthorUser(
+	requestUtils,
+	{ username, displayName, roles = [ 'author' ] }
+) {
+	const [ firstName, ...rest ] = displayName.split( ' ' );
+
+	const user = await requestUtils.createUser( {
+		username,
+		email: `${ username }@example.com`,
+		firstName,
+		lastName: rest.join( ' ' ) || 'Example',
+		roles,
+		password: 'cap-e2e-password',
+	} );
+
+	await requestUtils.rest( {
+		method: 'POST',
+		path: `/wp/v2/users/${ user.id }`,
+		data: { name: displayName },
+	} );
+
+	return user;
+}
+
+module.exports = {
+	createCoAuthorUser,
+};

--- a/tests/e2e/quick-edit.spec.js
+++ b/tests/e2e/quick-edit.spec.js
@@ -1,0 +1,97 @@
+/**
+ * End-to-end coverage for assigning a co-author via Quick Edit on the posts list.
+ *
+ * Quick Edit works by hijacking inlineEditPost.edit (js/co-authors-plus.js): it
+ * re-parents the hidden #coauthors-edit control into the inline-edit row, seeds
+ * it from the list column's data-* attributes, and re-initialises the jQuery UI
+ * autocomplete. None of that runs without the real list-table DOM, so this glue
+ * is browser-only and untested at any lower level. We assert the client → save
+ * round-trip, not assignment semantics (already covered by integration tests).
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { getSavedCoAuthors } = require( './helpers/co-authors' );
+const { createCoAuthorUser } = require( './helpers/fixtures' );
+
+test.describe( 'Assigning a co-author via Quick Edit', () => {
+	let post;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await createCoAuthorUser( requestUtils, {
+			username: 'e2equincy',
+			displayName: 'Quincy Quill',
+		} );
+	} );
+
+	test.beforeEach( async ( { requestUtils } ) => {
+		post = await requestUtils.createPost( {
+			title: 'Quick edit me',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllUsers();
+	} );
+
+	test( 'adds an author through the inline autocomplete and saves it', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await admin.visitAdminPage( 'edit.php' );
+
+		const row = page.locator( `#post-${ post.id }` );
+
+		// The Authors column is seeded from the post author.
+		await expect( row.locator( '.column-coauthors' ) ).toContainText(
+			'admin'
+		);
+
+		// Open Quick Edit (row actions reveal on hover).
+		await row.hover();
+		await row.locator( '.editinline' ).click();
+
+		const quickEditRow = page.locator( `#edit-${ post.id }` );
+
+		// The co-authors control mounted, pre-populated with the existing author.
+		await expect(
+			quickEditRow.locator( '.inline-edit-coauthors .coauthor-tag', {
+				hasText: 'admin',
+			} )
+		).toBeVisible();
+
+		// Add a second author via the trailing autocomplete input. Type real
+		// keystrokes so the jQuery UI autocomplete search fires.
+		const suggest = quickEditRow
+			.locator( '.inline-edit-coauthors .coauthor-suggest' )
+			.last();
+		await suggest.click();
+		await suggest.pressSequentially( 'Quincy' );
+
+		// The dropdown is appended to <body>; pick the matching suggestion.
+		await page
+			.locator( 'ul.ui-autocomplete:visible li', {
+				hasText: 'Quincy Quill',
+			} )
+			.click();
+
+		await expect(
+			quickEditRow.locator( '.coauthor-tag', { hasText: 'Quincy Quill' } )
+		).toBeVisible();
+
+		// Save the inline edit.
+		await quickEditRow.getByRole( 'button', { name: 'Update' } ).click();
+
+		// Once the AJAX save completes, the row's Authors column reflects it.
+		await expect( row.locator( '.column-coauthors' ) ).toContainText(
+			'Quincy Quill'
+		);
+
+		// Confirm persistence independent of the list markup.
+		const names = await getSavedCoAuthors( requestUtils, post.id );
+		expect( names ).toContain( 'admin' );
+		expect( names ).toContain( 'Quincy Quill' );
+	} );
+} );


### PR DESCRIPTION
## Summary

PR #1324 introduced the Playwright framework alongside a single spec covering the assignment of one co-author. The test pyramid beneath it is already strong: the reorder, add and remove array utilities are unit-tested, assignment semantics are covered by integration tests, and Behat exercises the classic flows. New end-to-end specs should therefore be reserved for the handful of behaviours that only a real browser against a real WordPress can prove.

This branch adds two such specs. The first drives the block editor's Authors panel to add three co-authors, reorder them, and publish, asserting that both membership **and order** survive the round-trip. That is the part the unit-tested array helpers cannot reach, because what is under test is the panel's buttons wiring through to the editor entity store, not the array logic itself. The second covers Quick Edit on the posts list, where `js/co-authors-plus.js` hijacks `inlineEditPost.edit` to re-parent the hidden control into the inline row, seed it from the column's data attributes, and re-initialise the jQuery UI autocomplete. None of that glue runs without the real list-table DOM, so it is untested at any lower tier; the spec proves a full client-to-save round-trip.

To keep all three specs driving the same UI an editor uses, the shared panel actions and the display-name user fixture are extracted into `tests/e2e/helpers/`, replacing the boilerplate the original spec inlined.

## Test plan

The suite could not be run locally in this environment owing to Docker resource contention (wp-env could not bring up the WordPress containers), so these specs are **unverified against a live site**. CI exercises them on a clean runner via `.github/workflows/e2e.yml`. Every selector was grounded in the source (`src/components/author-selection/index.jsx`, `src/components/co-authors/index.jsx`, `js/co-authors-plus.js`), and both new specs pass `npm run lint:js`.

- [ ] The `Playwright E2E (block editor)` CI job passes