### PR TITLE
Absorb Prettier drift from the @wordpress/scripts 34 bump

### DIFF
--- a/src/blocks/block-coauthor-avatar/block.json
+++ b/src/blocks/block-coauthor-avatar/block.json
@@ -30,10 +30,7 @@
 			}
 		}
 	},
-	"usesContext": [
-		"co-authors-plus/author",
-		"co-authors-plus/layout"
-	],
+	"usesContext": [ "co-authors-plus/author", "co-authors-plus/layout" ],
 	"attributes": {
 		"size": {
 			"type": "number",

--- a/src/blocks/block-coauthor-image/block.json
+++ b/src/blocks/block-coauthor-image/block.json
@@ -29,10 +29,7 @@
 			}
 		}
 	},
-	"usesContext": [
-		"co-authors-plus/author",
-		"co-authors-plus/layout"
-	],
+	"usesContext": [ "co-authors-plus/author", "co-authors-plus/layout" ],
 	"attributes": {
 		"isLink": {
 			"type": "boolean",

--- a/src/components/author-selection/index.jsx
+++ b/src/components/author-selection/index.jsx
@@ -65,7 +65,10 @@ const AuthorsSelection = ( { selectedAuthors, updateAuthors } ) => {
 					<FlexItem className="cap-author-flex-item">
 						<span>{ display }</span>
 					</FlexItem>
-					<FlexItem justify="flex-end" className="cap-author-flex-item">
+					<FlexItem
+						justify="flex-end"
+						className="cap-author-flex-item"
+					>
 						<Flex>
 							<div className="cap-icon-button-stack">
 								<Button


### PR DESCRIPTION
## Summary

The dev-dependencies group update in #1331 moved `@wordpress/scripts` from 32 to 34, which bundles a newer Prettier. That newer Prettier formats three files in `src/` slightly differently from how they are currently committed: the `usesContext` arrays in two `block.json` files collapse onto a single line, and one `<FlexItem>` in `author-selection/index.jsx` wraps its props.

None of this is caught by CI. The `lint-js` job skips `.jsx` and `.json`, so the drift stays invisible to the pipeline and would instead ambush the next contributor who runs `npm run format`, mixing unrelated reformatting into their diff. This change brings the three files into conformance with the formatter now, so future `format` runs stay clean.

The change is whitespace only. The JSON is semantically identical and the JSX renders the same; there is no behavioural or runtime impact, and nothing ships differently.

I scoped this deliberately to `src/`. Running the whole-project `format:js` also rewrites CI workflow YAML, `.wp-env.json`, blueprint JSON and the legacy `js/` scripts that were never Prettier-formatted, which is a much larger and riskier change unrelated to the toolchain bump. That clean-up, if wanted, belongs in its own PR.