### PR TITLE
perf: replace WP_Query with raw SQL for author post count checks

### DIFF
--- a/php/api/endpoints/class-coauthors-controller.php
+++ b/php/api/endpoints/class-coauthors-controller.php
@@ -203,6 +203,9 @@ class CoAuthors_Controller extends WP_REST_Controller {
 	 * any visitor could read. Guest authors and WP users are handled by the
 	 * same co-author term lookup so the check is consistent across both.
 	 *
+	 * The result is cached in the object cache for five minutes, so it can lag
+	 * behind newly published or unpublished posts by up to that long.
+	 *
 	 * @since 4.0.0
 	 * @param WP_User|stdClass $coauthor
 	 */
@@ -221,6 +224,14 @@ class CoAuthors_Controller extends WP_REST_Controller {
 			return false;
 		}
 
+		$cache_key = 'author-has-public-posts-' . md5( $term->term_taxonomy_id . '|' . implode( ',', $public_post_types ) );
+		$found     = false;
+		$cached    = wp_cache_get( $cache_key, 'co-authors-plus', false, $found );
+
+		if ( $found ) {
+			return (bool) $cached;
+		}
+
 		$post_type_placeholders = implode( ',', array_fill( 0, count( $public_post_types ), '%s' ) );
 
 		$post_id = $wpdb->get_var(
@@ -228,9 +239,13 @@ class CoAuthors_Controller extends WP_REST_Controller {
 				"SELECT p.ID FROM {$wpdb->posts} AS p INNER JOIN {$wpdb->term_relationships} AS tr ON p.ID = tr.object_id WHERE tr.term_taxonomy_id = %d AND p.post_type IN ( {$post_type_placeholders} ) AND p.post_status = 'publish' LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Placeholders are built from array counts; values are passed to prepare().
 				array_merge( array( $term->term_taxonomy_id ), $public_post_types )
 			)
-		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row existence check is cheaper than WP_Query; result changes with post updates.
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Single-row existence check is cheaper than WP_Query.
 
-		return null !== $post_id;
+		$has_public_posts = null !== $post_id;
+
+		wp_cache_set( $cache_key, (int) $has_public_posts, 'co-authors-plus', 5 * MINUTE_IN_SECONDS );
+
+		return $has_public_posts;
 	}
 
 	/**

--- a/php/api/endpoints/class-coauthors-controller.php
+++ b/php/api/endpoints/class-coauthors-controller.php
@@ -207,6 +207,7 @@ class CoAuthors_Controller extends WP_REST_Controller {
 	 * @param WP_User|stdClass $coauthor
 	 */
 	public function has_public_posts( $coauthor ): bool {
+		global $wpdb;
 
 		$term = $this->coauthors_plus->get_author_term( $coauthor );
 
@@ -214,28 +215,22 @@ class CoAuthors_Controller extends WP_REST_Controller {
 			return false;
 		}
 
-		$public_post_types = get_post_types( array( 'public' => true ) );
+		$public_post_types = array_values( get_post_types( array( 'public' => true ) ) );
 
-		$query = new \WP_Query(
-			array(
-				'post_type'              => array_values( $public_post_types ),
-				'post_status'            => 'publish',
-				'posts_per_page'         => 1,
-				'fields'                 => 'ids',
-				'no_found_rows'          => true,
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				'tax_query'              => array(
-					array(
-						'taxonomy' => $this->coauthors_plus->coauthor_taxonomy,
-						'field'    => 'term_id',
-						'terms'    => $term->term_id,
-					),
-				),
+		if ( empty( $public_post_types ) ) {
+			return false;
+		}
+
+		$post_type_placeholders = implode( ',', array_fill( 0, count( $public_post_types ), '%s' ) );
+
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT p.ID FROM {$wpdb->posts} AS p INNER JOIN {$wpdb->term_relationships} AS tr ON p.ID = tr.object_id WHERE tr.term_taxonomy_id = %d AND p.post_type IN ( {$post_type_placeholders} ) AND p.post_status = 'publish' LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Placeholders are built from array counts; values are passed to prepare().
+				array_merge( array( $term->term_taxonomy_id ), $public_post_types )
 			)
-		);
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Single-row existence check is cheaper than WP_Query; result changes with post updates.
 
-		return ! empty( $query->posts );
+		return null !== $post_id;
 	}
 
 	/**

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1870,6 +1870,9 @@ class CoAuthors_Plus {
 	/**
 	 * Get the post count for an author term with specific post types.
 	 *
+	 * The result is cached in the object cache for five minutes, so counts can
+	 * lag behind newly published or deleted posts by up to that long.
+	 *
 	 * @since 3.6.3
 	 *
 	 * @param WP_Term      $term        Author term object.
@@ -1883,6 +1886,14 @@ class CoAuthors_Plus {
 		$post_types    = (array) $post_type;
 		$post_statuses = $public_only ? array( 'publish' ) : array( 'publish', 'private' );
 
+		$cache_key = 'author-post-count-' . md5( $term->term_taxonomy_id . '|' . implode( ',', $post_types ) . '|' . implode( ',', $post_statuses ) );
+		$found     = false;
+		$count     = wp_cache_get( $cache_key, 'co-authors-plus', false, $found );
+
+		if ( $found ) {
+			return (int) $count;
+		}
+
 		$post_type_placeholders   = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
 		$post_status_placeholders = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
 
@@ -1891,7 +1902,9 @@ class CoAuthors_Plus {
 				"SELECT COUNT( DISTINCT p.ID ) FROM {$wpdb->posts} AS p INNER JOIN {$wpdb->term_relationships} AS tr ON p.ID = tr.object_id WHERE tr.term_taxonomy_id = %d AND p.post_type IN ( {$post_type_placeholders} ) AND p.post_status IN ( {$post_status_placeholders} )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Placeholders are built from array counts; values are passed to prepare().
 				array_merge( array( $term->term_taxonomy_id ), $post_types, $post_statuses )
 			)
-		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- COUNT query is cheaper than loading all posts via WP_Query; result changes with post updates.
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- COUNT query is cheaper than loading all posts via WP_Query.
+
+		wp_cache_set( $cache_key, (int) $count, 'co-authors-plus', 5 * MINUTE_IN_SECONDS );
 
 		return (int) $count;
 	}

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1878,32 +1878,22 @@ class CoAuthors_Plus {
 	 * @return int Post count.
 	 */
 	private function get_post_count_for_author_term( $term, $post_type = 'post', $public_only = false ): int {
-		$post_types = (array) $post_type;
+		global $wpdb;
 
-		$args = array(
-			'tax_query'              => array(
-				array(
-					'taxonomy' => $this->coauthor_taxonomy,
-					'field'    => 'term_id',
-					'terms'    => $term->term_id,
-				),
-			),
-			'post_type'              => $post_types,
-			'posts_per_page'         => -1,
-			'fields'                 => 'ids',
-			'update_post_meta_cache' => false,
-			'update_post_term_cache' => false,
-		);
+		$post_types    = (array) $post_type;
+		$post_statuses = $public_only ? array( 'publish' ) : array( 'publish', 'private' );
 
-		if ( $public_only ) {
-			$args['post_status'] = 'publish';
-		} else {
-			$args['post_status'] = array( 'publish', 'private' );
-		}
+		$post_type_placeholders   = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		$post_status_placeholders = implode( ',', array_fill( 0, count( $post_statuses ), '%s' ) );
 
-		$query = new \WP_Query( $args );
+		$count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT( DISTINCT p.ID ) FROM {$wpdb->posts} AS p INNER JOIN {$wpdb->term_relationships} AS tr ON p.ID = tr.object_id WHERE tr.term_taxonomy_id = %d AND p.post_type IN ( {$post_type_placeholders} ) AND p.post_status IN ( {$post_status_placeholders} )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Placeholders are built from array counts; values are passed to prepare().
+				array_merge( array( $term->term_taxonomy_id ), $post_types, $post_statuses )
+			)
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- COUNT query is cheaper than loading all posts via WP_Query; result changes with post updates.
 
-		return $query->found_posts;
+		return (int) $count;
 	}
 
 	/**

--- a/tests/Integration/Queries/CountUserPostsTest.php
+++ b/tests/Integration/Queries/CountUserPostsTest.php
@@ -150,6 +150,42 @@ class CountUserPostsTest extends TestCase {
 	}
 
 	/**
+	 * Test that the post count is served from the object cache until it is cleared.
+	 *
+	 * @covers CoAuthors_Plus::filter_count_user_posts
+	 * @covers CoAuthors_Plus::get_post_count_for_author_term
+	 */
+	public function test_count_user_posts_is_cached(): void {
+		$author = $this->create_author();
+
+		$this->factory()->post->create_many(
+			2,
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$this->assertSame( 2, count_user_posts( $author->ID ) );
+
+		// A new post does not change the count while the cached value is live.
+		$this->factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$this->assertSame( 2, count_user_posts( $author->ID ) );
+
+		wp_cache_flush();
+
+		$this->assertSame( 3, count_user_posts( $author->ID ) );
+	}
+
+	/**
 	 * Test count for guest authors with custom post types.
 	 *
 	 * @covers CoAuthors_Plus::filter_count_user_posts

--- a/tests/Integration/Rest/CoAuthorsControllerTest.php
+++ b/tests/Integration/Rest/CoAuthorsControllerTest.php
@@ -185,6 +185,34 @@ class CoAuthorsControllerTest extends TestCase {
 	}
 
 	/**
+	 * @covers ::has_public_posts
+	 */
+	public function test_has_public_posts_is_cached(): void {
+
+		$author  = $this->create_author( 'cached-author' );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author->ID,
+				'post_status' => 'draft',
+			)
+		);
+		$this->_cap->add_coauthors( $post_id, array( $author->user_nicename ) );
+
+		$coauthor = $this->_cap->get_coauthor_by( 'user_nicename', 'cached-author' );
+
+		$this->assertFalse( $this->controller->has_public_posts( $coauthor ) );
+
+		// Publishing the post does not change the result while the cached value is live.
+		wp_publish_post( $post_id );
+
+		$this->assertFalse( $this->controller->has_public_posts( $coauthor ) );
+
+		wp_cache_flush();
+
+		$this->assertTrue( $this->controller->has_public_posts( $coauthor ) );
+	}
+
+	/**
 	 * @covers ::get_item_permissions_check
 	 */
 	public function test_get_item_allows_editor_for_any_author(): void {


### PR DESCRIPTION
## Description

Two internal checks loaded post data through `WP_Query` when all they need is a number or a yes/no answer. On sites where an author has thousands of posts, `CoAuthors_Plus::get_post_count_for_author_term()` fetched every matching post ID into memory (`posts_per_page => -1`) only to read `found_posts`.

Both now run a single prepared SQL query against `wp_posts` joined to `wp_term_relationships`:

- `get_post_count_for_author_term()` uses `SELECT COUNT( DISTINCT p.ID )`.
- `CoAuthors_Controller::has_public_posts()` uses a `LIMIT 1` existence check, and returns early when no public post types are registered (previously an empty post type list fell through to `WP_Query`).

Both results are also cached in the object cache for five minutes, keyed by term and arguments, so repeated calls (the Users screen counts once per listed user) skip the query entirely. They can lag behind newly published or deleted posts by up to five minutes.

Query behavior is otherwise unchanged: same post types, same status rules (`publish` + `private` for counts unless public-only; `publish` for the REST permission check).

## Deploy Notes

No new dependencies.

## Steps to Test

1. Check out PR and create a co-author with several published posts, at least one of them private.
2. Go to Users → All Users. The post count column shows the published + private total for that author.
3. As a logged-out user, request `/wp-json/coauthors/v1/coauthors/<user_nicename>`. The profile is returned.
4. Unpublish all of that author's posts and repeat step 3. The request returns `rest_forbidden`.
5. Publish another post for the author and reload Users → All Users within five minutes. The count is unchanged; after the cache expires it includes the new post.
6. Run `composer test:integration`. `CountUserPostsTest` (5 tests) and `CoAuthorsControllerTest` (15 tests) pass, including cache-behavior tests for both methods.
