### PR TITLE
Populate Authors panel when the coauthors REST field is overridden

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,6 +2,9 @@
   "plugins": [
     "."
   ],
+  "mappings": {
+    "wp-content/plugins/cap-e2e-plugins": "./tests/e2e/plugins"
+  },
   "phpVersion": "8.2",
   "config": {
     "WP_DEBUG": true,

--- a/src/__tests__/use-coauthor-details.test.js
+++ b/src/__tests__/use-coauthor-details.test.js
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for the co-author details hook — in particular the post-ID
+ * fallback that keeps the Authors panel populated when a third-party
+ * `register_rest_field` override replaces the `coauthors` REST field's
+ * term-ID array with author objects carrying no `term_id`.
+ *
+ * See issue #1277.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useCoauthorDetails from '../hooks/use-coauthor-details';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+/**
+ * Author rows as returned by both coauthors/v1 endpoints
+ * (see CoAuthors_API_Endpoints::_format_author_data()).
+ */
+const RAW_AUTHORS = [
+	{
+		id: '1',
+		termId: 101,
+		userNicename: 'admin',
+		email: 'admin@example.com',
+		displayName: 'admin',
+		userType: 'wp-user',
+	},
+	{
+		id: '2',
+		termId: 102,
+		userNicename: 'jane-doe',
+		email: 'jane@example.com',
+		displayName: 'Jane Doe',
+		userType: 'guest-user',
+	},
+];
+
+describe( 'useCoauthorDetails', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'resolves term IDs through the authors-by-term-ids endpoint', async () => {
+		apiFetch.mockResolvedValue( RAW_AUTHORS );
+
+		const { result } = renderHook( () =>
+			useCoauthorDetails( [ 101, 102 ] )
+		);
+
+		await act( async () => {} );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/coauthors/v1/authors-by-term-ids?ids=101,102',
+			method: 'GET',
+		} );
+		expect( result.current.authors.map( ( a ) => a.display ) ).toEqual( [
+			'admin',
+			'Jane Doe',
+		] );
+	} );
+
+	it( 'falls back to resolving by post ID when no term IDs are available', async () => {
+		apiFetch.mockResolvedValue( RAW_AUTHORS );
+
+		const { result } = renderHook( () => useCoauthorDetails( [], 123 ) );
+
+		await act( async () => {} );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/coauthors/v1/authors/123',
+			method: 'GET',
+		} );
+		expect( result.current.authors.map( ( a ) => a.display ) ).toEqual( [
+			'admin',
+			'Jane Doe',
+		] );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'fetches nothing when the post has no co-authors and no fallback', async () => {
+		const { result } = renderHook( () => useCoauthorDetails( [] ) );
+
+		await act( async () => {} );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( result.current.authors ).toEqual( [] );
+	} );
+
+	it( 'primes the term-ID cache from the fallback response', async () => {
+		apiFetch.mockResolvedValue( RAW_AUTHORS );
+
+		const { rerender, result } = renderHook(
+			( { termIds, postId } ) => useCoauthorDetails( termIds, postId ),
+			{ initialProps: { termIds: [], postId: 123 } }
+		);
+
+		await act( async () => {} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		// Once an edit writes real term IDs back to the entity store, the hook
+		// serves them from the cache the fallback built — no second request.
+		rerender( { termIds: [ 101, 102 ], postId: null } );
+		await act( async () => {} );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.authors.map( ( a ) => a.termId ) ).toEqual( [
+			101, 102,
+		] );
+	} );
+} );

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -5,6 +5,7 @@ import {
 	buildCoauthorTermIds,
 	extractTermIds,
 	formatAuthorData,
+	needsPostIdFallback,
 } from '../utils';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import {
@@ -169,6 +170,42 @@ describe( 'Utility - extractTermIds', () => {
 		[ 'returns empty array for non-array input', 'not an array', [] ],
 	] )( '%s', ( _label, input, expected ) => {
 		expect( extractTermIds( input ) ).toStrictEqual( expected );
+	} );
+} );
+
+describe( 'Utility - needsPostIdFallback', () => {
+	it.each( [
+		[ 'term-ID array needs no fallback', [ 42, 43 ], false ],
+		[
+			'objects carrying term_id need no fallback',
+			[ { term_id: 5 } ],
+			false,
+		],
+		[
+			'objects with only user_id need the fallback',
+			[ { user_id: 8703 }, { user_id: 16 } ],
+			true,
+		],
+		[
+			'objects with only id or ID need the fallback',
+			[ { id: 5 }, { ID: 99 } ],
+			true,
+		],
+		[
+			'objects with no recognisable ID need the fallback',
+			[ { display_name: 'John Doe', user_nicename: 'john-doe' } ],
+			true,
+		],
+		[
+			'a partially resolvable list needs no fallback',
+			[ 42, { user_id: 1 } ],
+			false,
+		],
+		[ 'an empty array needs no fallback', [], false ],
+		[ 'undefined needs no fallback', undefined, false ],
+		[ 'a non-array needs no fallback', 'not an array', false ],
+	] )( '%s', ( _label, input, expected ) => {
+		expect( needsPostIdFallback( input ) ).toBe( expected );
 	} );
 } );
 

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -28,6 +28,7 @@ import {
 	buildCoauthorTermIds,
 	extractTermIds,
 	formatAuthorData,
+	needsPostIdFallback,
 } from '../../utils';
 
 /**
@@ -70,14 +71,24 @@ const CoAuthors = () => {
 	 * re-renders this component continuously and cancels the debounced search
 	 * below before it can fire.
 	 */
-	const { coauthorTermIdsKey, hasResolvedPost } = useSelect( ( select ) => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const coauthors = getEditedPostAttribute( 'coauthors' );
-		return {
-			coauthorTermIdsKey: extractTermIds( coauthors ).join( ',' ),
-			hasResolvedPost: coauthors !== undefined,
-		};
-	}, [] );
+	const { coauthorTermIdsKey, hasResolvedPost, postIdFallback } = useSelect(
+		( select ) => {
+			const { getEditedPostAttribute, getCurrentPostId } =
+				select( 'core/editor' );
+			const coauthors = getEditedPostAttribute( 'coauthors' );
+			return {
+				coauthorTermIdsKey: extractTermIds( coauthors ).join( ',' ),
+				hasResolvedPost: coauthors !== undefined,
+				// When the post has co-authors but their stored shape yields no
+				// term IDs (e.g. a third-party REST override), resolve them by
+				// post ID instead so the panel still populates.
+				postIdFallback: needsPostIdFallback( coauthors )
+					? getCurrentPostId()
+					: null,
+			};
+		},
+		[]
+	);
 
 	/**
 	 * Rebuild the term ID array from the stable key, so consumers below keep a
@@ -92,10 +103,13 @@ const CoAuthors = () => {
 	);
 
 	/**
-	 * Resolve term IDs to rich author data.
+	 * Resolve term IDs to rich author data, falling back to the post ID when the
+	 * stored co-author shape can't be read as term IDs.
 	 */
-	const { authors: selectedAuthors, isLoading } =
-		useCoauthorDetails( coauthorTermIds );
+	const { authors: selectedAuthors, isLoading } = useCoauthorDetails(
+		coauthorTermIds,
+		postIdFallback
+	);
 
 	/**
 	 * Get editPost dispatcher to write changes back to the core entity.

--- a/src/hooks/use-coauthor-details.js
+++ b/src/hooks/use-coauthor-details.js
@@ -12,74 +12,128 @@ import { formatAuthorData } from '../utils';
 /**
  * Hook to resolve co-author taxonomy term IDs to rich author data.
  *
- * @param {Array} termIds Array of taxonomy term IDs from the core entity store.
+ * @param {Array}       termIds        Array of taxonomy term IDs from the core entity store.
+ * @param {number|null} postIdFallback Post ID to resolve co-authors from when no term
+ *                                     IDs are available (see `needsPostIdFallback`). Pass
+ *                                     `null` to disable the fallback.
  * @return {Object} Object with `authors` (array of rich author objects) and `isLoading` (boolean).
  */
-export default function useCoauthorDetails( termIds ) {
+export default function useCoauthorDetails( termIds, postIdFallback = null ) {
 	const [ authors, setAuthors ] = useState( [] );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const cache = useRef( new Map() );
 
 	useEffect( () => {
-		if ( ! termIds || ! termIds.length ) {
-			setAuthors( [] );
-			return;
-		}
-
-		const uncachedIds = termIds.filter(
-			( id ) => ! cache.current.has( id )
-		);
-
-		// If everything is cached, build the result immediately.
-		if ( 0 === uncachedIds.length ) {
-			setAuthors(
-				termIds
-					.map( ( id ) => cache.current.get( id ) )
-					.filter( Boolean )
-			);
-			return;
-		}
-
 		let cancelled = false;
-		setIsLoading( true );
 
-		apiFetch( {
-			path: `/coauthors/v1/authors-by-term-ids?ids=${ uncachedIds.join(
-				','
-			) }`,
-			method: 'GET',
-		} )
-			.then( ( results ) => {
-				if ( cancelled ) {
-					return;
-				}
+		// Format the endpoint results and cache each by term ID, so a later
+		// render that does have the term IDs resolves them from cache.
+		const formatAndCache = ( results ) => {
+			const formatted = results.map( ( author ) =>
+				formatAuthorData( author )
+			);
+			formatted.forEach( ( author ) => {
+				cache.current.set( author.termId, author );
+			} );
+			return formatted;
+		};
 
-				results.forEach( ( author ) => {
-					const formatted = formatAuthorData( author );
-					cache.current.set( formatted.termId, formatted );
-				} );
+		// Path 1: resolve known term IDs — the default for a stock install where
+		// the `coauthors` entity value is the author taxonomy's term-ID array.
+		if ( termIds && termIds.length ) {
+			const uncachedIds = termIds.filter(
+				( id ) => ! cache.current.has( id )
+			);
 
+			// If everything is cached, build the result immediately.
+			if ( 0 === uncachedIds.length ) {
 				setAuthors(
 					termIds
 						.map( ( id ) => cache.current.get( id ) )
 						.filter( Boolean )
 				);
+				return;
+			}
+
+			setIsLoading( true );
+
+			apiFetch( {
+				path: `/coauthors/v1/authors-by-term-ids?ids=${ uncachedIds.join(
+					','
+				) }`,
+				method: 'GET',
 			} )
-			.catch( ( error ) => {
-				if ( ! cancelled ) {
-					console.error( error ); // eslint-disable-line no-console
-				}
+				.then( ( results ) => {
+					if ( cancelled ) {
+						return;
+					}
+
+					formatAndCache( results );
+
+					setAuthors(
+						termIds
+							.map( ( id ) => cache.current.get( id ) )
+							.filter( Boolean )
+					);
+				} )
+				.catch( ( error ) => {
+					if ( ! cancelled ) {
+						console.error( error ); // eslint-disable-line no-console
+					}
+				} )
+				.finally( () => {
+					if ( ! cancelled ) {
+						setIsLoading( false );
+					}
+				} );
+
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		// Path 2: no usable term IDs, but the post still has co-authors whose
+		// stored shape we couldn't read (e.g. a third-party REST override returns
+		// author objects instead of the taxonomy's term-ID array). Resolve them
+		// by post ID so the panel still populates. `postIdFallback` is only set in
+		// that case — see `needsPostIdFallback`.
+		if ( postIdFallback ) {
+			setIsLoading( true );
+
+			apiFetch( {
+				path: `/coauthors/v1/authors/${ postIdFallback }`,
+				method: 'GET',
 			} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-				}
-			} );
+				.then( ( results ) => {
+					if ( cancelled ) {
+						return;
+					}
+
+					setAuthors( formatAndCache( results ) );
+				} )
+				.catch( ( error ) => {
+					if ( ! cancelled ) {
+						console.error( error ); // eslint-disable-line no-console
+					}
+				} )
+				.finally( () => {
+					if ( ! cancelled ) {
+						setIsLoading( false );
+					}
+				} );
+
+			return () => {
+				cancelled = true;
+			};
+		}
+
+		// Genuinely no co-authors.
+		setAuthors( [] );
 
 		return () => {
 			cancelled = true;
 		};
-	}, [ JSON.stringify( termIds ) ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ JSON.stringify( termIds ), postIdFallback ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return { authors, isLoading };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,6 +30,31 @@ export const extractTermIds = ( coauthors ) => {
 };
 
 /**
+ * Decide whether the post's co-authors must be resolved by post ID rather than
+ * from the entity store's `coauthors` value.
+ *
+ * The sidebar normally reads the author taxonomy's default REST output — an
+ * array of term IDs — from `getEditedPostAttribute( 'coauthors' )`. Some sites
+ * override that REST field (commonly a `register_rest_field( 'post', 'coauthors',
+ * … )` carried over from before Co-Authors Plus exposed the field itself), so it
+ * arrives as full author objects with no `term_id`. `extractTermIds` then yields
+ * nothing and the panel would render empty even though the post has co-authors.
+ *
+ * When that happens we fall back to the plugin's own `/coauthors/v1/authors/{id}`
+ * endpoint, which returns the authors regardless of the REST field's shape.
+ *
+ * @param {Array|undefined} coauthors Raw value from getEditedPostAttribute.
+ * @return {boolean} True when the post has co-authors but no usable term IDs.
+ */
+export const needsPostIdFallback = ( coauthors ) => {
+	return (
+		Array.isArray( coauthors ) &&
+		coauthors.length > 0 &&
+		0 === extractTermIds( coauthors ).length
+	);
+};
+
+/**
  * Move an item up or down in an array.
  *
  * @param {string} targetItem Item to move.

--- a/tests/e2e/plugins/cap-coauthors-rest-override.php
+++ b/tests/e2e/plugins/cap-coauthors-rest-override.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Plugin Name: CAP Coauthors REST Override
+ * Description: Reproduces the widespread third-party snippet that overrides the
+ *              `coauthors` REST field on posts to return full author objects
+ *              (carrying user_id, no term_id) instead of the author taxonomy's
+ *              default term-ID array. This is the shape that broke the block
+ *              editor Authors panel after 4.x moved to the core entity store.
+ * Version:     1.0.0
+ *
+ * @package CoAuthorsPlus\Tests
+ */
+
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_field(
+			'post',
+			'coauthors',
+			array(
+				'get_callback' => function ( $post_arr ) {
+					if ( ! function_exists( 'get_coauthors' ) ) {
+						return array();
+					}
+
+					return array_map(
+						function ( $coauthor ) {
+							// Deliberately object-shaped, with a user_id and NO
+							// term_id — the exact payload reported in #1277.
+							return array(
+								'user_id'       => (int) $coauthor->ID,
+								'display_name'  => $coauthor->display_name,
+								'user_nicename' => $coauthor->user_nicename,
+							);
+						},
+						get_coauthors( $post_arr['id'] )
+					);
+				},
+				'schema'       => null,
+			)
+		);
+	},
+	20
+);

--- a/tests/e2e/rest-field-override.spec.js
+++ b/tests/e2e/rest-field-override.spec.js
@@ -1,0 +1,101 @@
+/**
+ * Regression coverage for sites where third-party code overrides the
+ * `coauthors` REST field on posts.
+ *
+ * A widespread snippet — predating Co-Authors Plus exposing co-authors in
+ * REST itself — registers a `coauthors` field returning full author objects
+ * (with a `user_id`, no `term_id`) instead of the author taxonomy's term-ID
+ * array. After 4.x moved the Authors panel onto the core entity store, that
+ * shape yielded no term IDs, so the panel rendered empty even though the post
+ * had co-authors (issue #1277). The panel now falls back to resolving the
+ * byline by post ID.
+ *
+ * The override fixture lives in tests/e2e/plugins/, mounted via the
+ * `mappings` entry in .wp-env.json, and is activated only for this spec.
+ */
+
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const {
+	addCoAuthor,
+	getCoAuthorNames,
+	getSavedCoAuthors,
+	openAuthorsPanel,
+} = require( './helpers/co-authors' );
+const { createCoAuthorUser } = require( './helpers/fixtures' );
+
+test.describe( 'Authors panel with an overridden coauthors REST field', () => {
+	let postId;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( 'cap-coauthors-rest-override' );
+
+		await createCoAuthorUser( requestUtils, {
+			username: 'e2eodette',
+			displayName: 'Odette Override',
+		} );
+		await createCoAuthorUser( requestUtils, {
+			username: 'e2eoscar',
+			displayName: 'Oscar Object',
+		} );
+
+		// A draft that already carries two co-authors, assigned server-side —
+		// the state an affected site's existing posts are in.
+		const post = await requestUtils.createPost( {
+			title: 'Overridden byline',
+			status: 'draft',
+		} );
+		postId = post.id;
+
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/coauthors/v1/authors/${ postId }`,
+			data: { new_authors: 'admin,e2eodette' },
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'cap-coauthors-rest-override' );
+		await requestUtils.deleteAllPosts();
+		await requestUtils.deleteAllUsers();
+	} );
+
+	test( 'panel populates from the post ID and edits persist', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		// Precondition: the override is in effect, so the post's REST field
+		// carries author objects with a user_id and no term_id — the exact
+		// payload reported in #1277. If this fails, the fixture plugin is not
+		// active and the rest of the spec would pass vacuously.
+		const post = await requestUtils.rest( {
+			path: `/wp/v2/posts/${ postId }`,
+			params: { context: 'edit' },
+		} );
+		expect( post.coauthors ).toHaveLength( 2 );
+		for ( const coauthor of post.coauthors ) {
+			expect( coauthor ).toHaveProperty( 'user_id' );
+			expect( coauthor ).not.toHaveProperty( 'term_id' );
+		}
+
+		await admin.editPost( postId );
+		await editor.openDocumentSettingsSidebar();
+		await openAuthorsPanel( page );
+
+		// The regression: before the post-ID fallback, the panel rendered
+		// empty here despite the post having two co-authors.
+		await expect
+			.poll( () => getCoAuthorNames( page ) )
+			.toEqual( [ 'admin', 'Odette Override' ] );
+
+		// The (read-only) override does not touch the write path: an edit
+		// still persists term IDs through the entity store.
+		await addCoAuthor( page, 'Oscar Object' );
+
+		const publishedId = await editor.publishPost();
+		await expect
+			.poll( () => getSavedCoAuthors( requestUtils, publishedId ) )
+			.toEqual( [ 'admin', 'Odette Override', 'Oscar Object' ] );
+	} );
+} );


### PR DESCRIPTION
## Summary

For years before Co-Authors Plus exposed co-authors in REST, the community's de facto fix was a `register_rest_field( 'post', 'coauthors', … )` snippet returning full author objects. That snippet still runs on many sites — in theme `functions.php` files and headless setups — and it overrides the author taxonomy's own `coauthors` field, which the 4.x Authors panel reads from the entity store expecting an array of term IDs. On those sites the panel found no term IDs and rendered empty even though the byline was intact: authors showed in the posts list, but there was no way to edit them. This is #1277, echoed in support-forum reports where cache flushing made no difference and 3.7.0 was described as the last working version.

Asking every affected site to find and remove its custom code doesn't scale, so the panel now degrades gracefully instead. When the stored value yields no usable term IDs but the post does have co-authors, the details hook resolves the byline through the plugin's own `coauthors/v1/authors/{post_id}` endpoint, which is authoritative regardless of the field's shape. The results prime the same term-ID cache, so once an edit writes real term IDs back to the entity store they resolve without another request. Stock installs never take the fallback — the term-ID fast path is untouched.

The write path needed no change: term assignment happens through core's taxonomy handling of the request body, which a read-only `get_callback` override cannot affect. The end-to-end test proves that round-trip.

## Testing

- Unit tests cover which co-author shapes trigger the fallback (`needsPostIdFallback()`) and the hook's fallback fetch, cache priming, and untouched term-ID path (`npm run test:unit`).
- A new E2E spec reproduces the bug with a fixture plugin (`tests/e2e/plugins/`, mounted through a new wp-env `mappings` entry and activated only for this spec) that reapplies the widespread override snippet. The spec asserts the panel populates from the post ID and that an added author survives a publish. Run against the unfixed build it fails with an empty panel — the exact reported symptom.

Fixes #1277.