### PR TITLE
Absorb VIPCS NoPaging drift breaking the required tests lint

### DIFF
--- a/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
+++ b/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
@@ -105,6 +105,7 @@ class CreateGuestAuthorTest extends TestCase {
 			array(
 				'post_type'   => $guest_author_obj->post_type,
 				'post_status' => 'any',
+				// phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts -- Test-only: exhaustively count guest author posts in the isolated test database.
 				'numberposts' => -1,
 			)
 		);
@@ -137,6 +138,7 @@ class CreateGuestAuthorTest extends TestCase {
 			array(
 				'post_type'   => $guest_author_obj->post_type,
 				'post_status' => 'any',
+				// phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts -- Test-only: exhaustively count guest author posts in the isolated test database.
 				'numberposts' => -1,
 			)
 		);


### PR DESCRIPTION
## Summary

Every PR raised today fails the required "Basic CS and QA checks" job — including branches that touch no PHP at all — on two `numberposts => -1` lines in `tests/Integration/GuestAuthors/CreateGuestAuthorTest.php`. That file last changed on 24 June and the check was green on 26 June, so the code didn't regress: the workflow installs `automattic/vipwpcs` unpinned, and a release since then promotes `WordPressVIPMinimum.Performance.NoPaging` to an error on those lines. This is the PHP-side twin of #1361, which absorbed the equivalent tooling drift from Prettier.

The unbounded query is deliberate in this test: it counts every guest author post in the isolated test database, before and after a forced failure, to prove no orphaned post is left behind. Capping the count would quietly weaken that assertion, so the sniff is suppressed on those two lines with a justification comment instead — the same pattern the test suite already uses for other test-only sniff exceptions.

`composer cs -- tests/` (the exact CI invocation) passes locally against current VIPCS with this change.

Once merged, the currently red PRs (#1363 and friends) go green by updating from develop.