### PR TITLE
Pin current WP-CLI command behaviour before the command-class refactor

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -1,0 +1,956 @@
+# WP-CLI command behaviour notes
+
+A catalogue of the *current, observed* behaviour of the `wp co-authors-plus`
+subcommands, recorded while writing the Behat characterisation suite in
+`features/`.
+
+**These describe what the code does today, not what it should do.** Several
+entries are bugs or clear infelicities. They are pinned as-is by the feature
+files so that the planned refactor (splitting `CoAuthorsPlus_Command` into one
+class per command) can be proven behaviour-preserving. Each entry is therefore a
+candidate for its own fix PR, where the fix and the corresponding re-pinned
+scenario land together.
+
+Every entry below was verified against a live environment (WordPress trunk,
+PHP 8.4) rather than inferred from reading the source.
+
+## assign-coauthors
+
+(Calibrated against the live env 2026-09-01; all scenarios green.)
+
+- Summary lines never pluralise: `- 1 posts now have the proper co-author`,
+  `- 1 posts already had the co-author assigned` even for a single post
+  (php/class-wp-cli.php:415-425). Confirmed.
+- When a run matches nothing, the output is just `All done! Here are your results:`
+  with no result lines at all — there is no "0 posts" line and no per-post output.
+  Confirmed.
+- The "already associated" path (meta value loosely matches an existing co-author,
+  e.g. via the post_author fallback in `get_coauthors()`) `continue`s BEFORE
+  `add_coauthors()` runs (php/class-wp-cli.php:388-392), so the command never
+  backfills an author term for such a post. Term-based tooling (e.g.
+  `swap-coauthors`' tax_query) will therefore not see it. Note: in practice a post
+  created with a valid `post_author` gets its author term immediately from the
+  plugin's own `save_post` hook (`coauthors_update_post()`), so the pinned scenario
+  removes that term first (`wp post term remove`) to exercise the fallback, then
+  asserts `--format=count` = 0 after the command runs. Confirmed.
+- The effective default `--meta_key` is `_original_import_author`; neither the
+  docblock nor the synopsis documents this default. (The phase 0 brief's note that
+  the default is `author` does not match the code.)
+- Posts lacking the meta key are invisible to the command (the WP_Query filters on
+  meta-key existence), so they are not counted in any total. Confirmed.
+- The log echoes the RAW meta value while assigning the co-author found via the
+  `sanitize_title()` fallback: meta `Author One` assigns user `author-one` but logs
+  `... has been assigned "Author One" as the author`. Confirmed.
+
+- Re-calibrated 2026-09-02 after adversarial review: 10 scenarios, all green.
+- The three summary blocks are emitted in a FIXED source order — already-associated,
+  then missing, then associated (php/class-wp-cli.php:415-425) — and no single-outcome
+  scenario can show that. Now pinned in "Report every outcome in one run and ignore
+  posts the query cannot reach", where one run produces all three blocks and the
+  per-post counter runs across the mixed outcomes (`1:` assigned, `2:` already,
+  `3:` missing).
+- The WP_Query at :369 filters on meta-key EXISTENCE only and sets no `post_status`,
+  and WP-CLI runs unauthenticated, so two whole classes of post are invisible to this
+  command: posts without the meta key, and DRAFT/pending/private posts that have it.
+  Neither is counted in any total or summary line, and there is no `--post_status`
+  flag to opt in — an editorial team backfilling before publication is silently
+  skipped. That same mixed scenario now carries a no-meta post and a draft-with-meta
+  post as discriminators: neither is enumerated, and both end with zero author terms.
+- The `sanitize_title()` fallback path is NOT idempotent. The already-associated check
+  compares the RAW meta value against `$existing_coauthor->user_login` (:381-386),
+  while assignment uses the co-author's nicename (:401), so meta `Author One` -> user
+  `author-one` re-assigns and re-counts on EVERY run — `1: Post #N has been assigned
+  "Author One" as the author` / `- 1 posts now have the proper co-author`, for ever.
+  On a large import that is a needless write storm (`add_coauthors()` plus
+  `wp_set_post_terms()` per post per run). Pinned by the second run in "Fall back to a
+  sanitised meta value, re-assigning on every run". The exact-match path IS idempotent
+  (its second run reports "already has ... associated as a co-author").
+- An empty meta VALUE is processed, not skipped: the key exists, `get_post_meta()`
+  returns '', both `get_coauthor_by()` lookups fail, and the post is reported as
+  `does not have "" associated as a co-author but there is not a co-author profile`.
+  The summary then implodes that empty string into the missing list, so the last line
+  reads `  ghostwriter, phantom, ` with a dangling comma and trailing space (:422).
+  Pinned in "Report missing co-author profiles once each in the summary" (the
+  wp-env harness trims the trailing space; a run whose ONLY missing value is empty
+  loses the whole line, because the harness drops whitespace-only lines).
+  NB `wp post meta update <id> <key> ""` does NOT store an empty string — WP-CLI
+  replies `Success: Value passed for custom field '<key>' is unchanged.` and writes
+  nothing — so the fixture uses `wp eval 'update_post_meta( ..., "" );'`.
+- Assigning an unlinked guest author sets the author term but leaves
+  `wp_posts.post_author` on the previous user: `add_coauthors()` bails at
+  php/class-coauthors-plus.php:1705-1709 and returns false AFTER
+  `wp_set_post_terms()` has run, and `assign_coauthors()` ignores that return value,
+  still logging `has been assigned` and counting the post as successfully associated.
+  Pinned in "Assign an unlinked guest author from the meta value": term becomes
+  `cap-jane-doe`, `post_author` stays the author1 user ID. Note the value handed to
+  `add_coauthors()` is `$coauthor->user_nicename`, which for a guest author is
+  `sanitize_title( user_login )` (`jane-doe`, NOT the `cap-`-prefixed post_name); the
+  prefix is re-added inside `get_post_meta_key()` during the nicename lookup, so a
+  refactor that "normalised" this to `user_login` (as swap-coauthors does) would
+  happen to keep working, whereas one that passed the post_name would double-prefix.
+
+## swap-coauthors
+
+(Calibrated against the live env 2026-09-01; all scenarios green.)
+
+- `--dry` uses the raw string value in a boolean context (php/class-wp-cli.php:690,
+  749), so ANY non-empty value — including `--dry=false` — enables dry-run mode.
+  Pinned in the "Treat --dry=false as a dry run" scenario. Confirmed.
+- When a post has multiple co-authors, the swap rewrites `post_author` to the FIRST
+  remaining co-author with a WP user (term-name order from `get_coauthors()`), not
+  necessarily the `--to` author, even though the log claims the `--to` author "has
+  been assigned". Pinned in "Preserve other co-authors when swapping" (post_author
+  ends up as author3, not author2). Confirmed.
+- WP-CLI accepts an explicit empty value for the required parameter (`--to=`), so
+  the plugin's own `--to param must not be empty` guard is reachable and fires.
+  Confirmed.
+- The `--to param must not be empty` guard (php/class-wp-cli.php:704-706) runs only
+  AFTER the `--from` lookup, so an invalid `--from` combined with an empty `--to`
+  reports `No co-author found` first.
+- The tax_query only matches the prefixed `cap-<user_login>` slug
+  (php/class-wp-cli.php:695, 722-728), so posts carrying a legacy unprefixed author
+  term for the `--from` co-author are not swapped (not pinned in a scenario; noted
+  from source).
+
+- Re-calibrated 2026-09-02 after adversarial review: 11 scenarios, all green. The
+  `--from`-before-`--to` guard order above is now pinned in "Validate --from before an
+  empty --to", and all five error scenarios assert `the return code should be 1` plus
+  `STDOUT should be empty`. The `missing --from parameter` scenario was LOOSENED to
+  `STDERR should contain:` because the surrounding `Error: Parameter errors:`
+  rendering belongs to WP-CLI, not to CAP (and CI installs wp-env, hence WP-CLI,
+  unpinned), so a one-class-per-command split that swaps `@synopsis` for a
+  `## OPTIONS` docblock must not fail this file.
+- **Unbounded loop — do NOT characterise with a live run.** Outside dry mode the
+  command never advances `paged` (php/class-wp-cli.php:770-773 increments it only
+  `if ( $dry )`); it relies on `add_coauthors()` removing the `cap-<from>` term so the
+  identical `WP_Query` shrinks to zero. Two reachable inputs never remove that term:
+  (a) `--from` === `--to`, where the login is `unset()` from `$coauthors` and
+  immediately re-appended (:751-761) so the same term is rewritten unchanged; and
+  (b) a `--from` whose case differs from the stored `user_login` (e.g. `--from=Author1`)
+  — `get_coauthor_by()` and the slug tax_query both match case-insensitively, but the
+  removal loop compares with `===` at :753. Either way `while ( $posts->post_count )`
+  runs forever, emitting `N: Post #X has been assigned ...` until the process is
+  killed; on CI the job would burn its whole runner allowance (the workflow sets no
+  `timeout-minutes`). A third trigger is the `continue` at :741-743 for a post whose
+  `get_coauthors()` is empty. `rename-coauthor` has an equivalent guard ("New
+  user_login value conflicts with existing co-author"); `swap-coauthors` has none.
+  Candidate fix: error when `$from_userlogin === $to_userlogin`, compare logins
+  case-insensitively, and/or break out when a page yields no removals. A Gherkin
+  comment at the top of features/swap-coauthors.feature warns authors off adding such
+  a scenario.
+- `--dry` truthiness, now calibrated end to end in "Preview with --dry, where only 0
+  and a valueless flag swap for real": `--dry=true` and `--dry=false` are BOTH
+  previews (any non-empty string is truthy), but `--dry=0` performs a REAL,
+  irreversible swap because PHP treats the string "0" as falsy at :749. Worse, the
+  valueless flag form `--dry` also swaps for real: WP-CLI matches it against the
+  `[--dry=<dry>]` synopsis, prints `Warning: --dry parameter needs a value`, DISCARDS
+  the argument, and the `false` default then applies — so the most natural way to ask
+  for a preview is the one that mutates the site, and it still exits 0. That warning
+  text is WP-CLI's, so the scenario pins only CAP's own lines, via
+  `STDOUT should contain:`.
+- The command is TERM-driven, not `post_author`-driven. A post whose only link to the
+  `from` author is `wp_posts.post_author` (its `cap-<from>` term removed) is reported
+  as `Found 0 posts to update.` / `Success: All done!` and left untouched — unlike
+  `assign-user-to-coauthor` and `get_coauthors()`, which both fall back to
+  `post_author`. Sites migrating from plain WordPress authorship therefore get a
+  silent no-op. Pinned in "Ignore posts the swap query cannot reach".
+- The WP_Query at :715-730 sets no `post_status` and WP-CLI runs unauthenticated, so
+  only public statuses match: a DRAFT post carrying the `cap-<from>` term (CAP's
+  `save_post` hook gives it one) is silently skipped and is not even counted in
+  `Found N posts to update.`. There is no `--post_status` flag to opt in. Pinned in
+  the same scenario; `assign-coauthors` has the identical restriction.
+- Swapping TO an unlinked guest author leaves `wp_posts.post_author` pointing at the
+  previous WP user indefinitely: `wp_set_post_terms()` has already run by the time
+  `add_coauthors()` bails at php/class-coauthors-plus.php:1705-1709 and returns false,
+  and `swap_coauthors()` ignores that return value — so the byline changes, the log
+  still says `has been assigned` and the command still reports `Success: All done!`.
+  Pinned in "Swap to a guest author with no linked account" (term becomes
+  `cap-jane-doe`, `post_author` stays the author1 user ID).
+- NOT a bug — an adversarial-review claim tested live on 2026-09-02 and REJECTED:
+  logins whose `user_nicename` differs from the raw login, e.g. `john.doe` (nicename
+  `john-doe`, term `cap-john-doe`), ARE swapped correctly even though the tax_query
+  slug is built naively as `'cap-' . $from_userlogin` (:694-695). `WP_Tax_Query`
+  sanitises `slug` terms with `sanitize_term_field()`, so `cap-john.doe` becomes
+  `cap-john-doe` before the query runs. Verified: `swap-coauthors --from=john.doe`
+  reported `Found 1 posts to update.` and moved the term. No scenario added.
+- Multi-post behaviour is now pinned (3 posts): `Found 3 posts to update.`, per-post
+  counter `1:`/`2:`/`3:` in ascending ID order, and a re-run reporting
+  `Found 0 posts to update.` — which is also the only proof that the non-dry drain
+  loop terminates because the `from` term really is removed. The `cap-<from>` term
+  itself survives with count 0 (`--slug=cap-author1 --format=count` is 1).
+- Test-isolation note: the Background now deletes every author term before each
+  scenario (same convention as migrate-author-terms.feature and
+  reassign-terms.feature), because author terms survive `reset_database_state()`. Two
+  assertions in this file are global by nature (`--slug=cap-author1|cap-author2
+  --format=count`), and without that cleanup an orphan `cap-author2` term left by any
+  other feature — guest-author terms are never cleaned up at all — would fail the dry
+  scenario with an unrelated "dry run created a term" message.
+
+## (shared test environment — affects everyone's calibration)
+
+- Author taxonomy terms survive the Behat reset: `reset_database_state()` deletes
+  posts and non-admin users but never author terms. User deletion removes that
+  user's own term (CAP `delete_user` hook), but terms with no matching user persist
+  forever — the live tests DB currently carries an orphan `cap-renamed-admin` term
+  (residue of rename-coauthor.feature renaming admin's term to a login with no
+  user). GLOBAL assertions such as `wp term list author --format=count` or
+  unscoped `--field=slug` listings are therefore unreliable; scope them with
+  `--object_ids=<ids>` or `--slug=<slug>` instead.
+- CORRECTION (2026-09-02): `--slug=<slug>` scoping is only safe for NEGATIVE or
+  count assertions. For a POSITIVE "the command created this term" assertion it is
+  a tautology — a leftover `cap-<x>` term from any earlier feature or earlier run
+  satisfies it, and `CoAuthors_Plus::get_author_term()` matches on slug alone, so
+  `create()` silently REUSES such a term rather than inserting one. Use
+  `--object_ids=<the post the command just created>`; term relationships are
+  deleted with the post, so residue cannot satisfy them. Better still, add the
+  Background term wipe (see migrate-author-terms.feature) so the term really is new.
+  The guest-authors group's three features now do both.
+- CAP's `save_post` hook (`coauthors_update_post()`) fires on `wp post create`, so
+  any post created with a valid `--post_author` already has that author's
+  `cap-<nicename>` term (creating the term if needed) before any CLI subcommand
+  runs. Posts created without `--post_author` get post_author 0 and no term.
+
+## reassign-terms
+
+(Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 11 scenarios.)
+
+- The documented `--author-mapping=<file>` flag IS dead code: WP-CLI passes the
+  assoc arg under the hyphenated key `author-mapping`, but the method reads
+  `$this->args['author_mapping']` (underscore) after `wp_parse_args`
+  (php/class-wp-cli.php:537-546). The mapping file is never `require`d, and the
+  `author_mapping doesn't exist` error (line 553) is unreachable — even a
+  nonexistent file path is accepted silently. Confirmed: running with a valid
+  mapping fixture still emits `Warning: Undefined variable $authors_to_migrate`
+  (proof the file was not required) and reports an all-zero summary with rc 0.
+  The underscore spelling `--author_mapping` is rejected by WP-CLI synopsis
+  validation (`Error: Parameter errors:` / ` unknown --author_mapping parameter`).
+  Pinned via the three --author-mapping scenarios in features/reassign-terms.feature.
+- Re-calibrated 2026-09-02: WP-CLI's synopsis rejection also prints a third line,
+  `Did you mean '--author-mapping'?`, which the wp-env harness leaves on STDOUT
+  (it is neither `Error:`-prefixed nor indented, so the STDERR splitter stops the
+  error block before it). Now pinned exactly: STDERR is the two-line
+  `Error: Parameter errors:` block, STDOUT is the `Did you mean` suggestion.
+  Ironically WP-CLI names the working spelling of a flag that does nothing.
+- When neither a usable mapping nor `--old_term`/`--new_term` is supplied,
+  `$authors_to_migrate` is never defined, so the `foreach` at line 571 raises PHP
+  warnings on PHP 8+ — yet the command still prints the zero-count summary and
+  exits 0. Confirmed; each warning appears TWICE in combined output (once as a
+  timestamped `[date] PHP Warning:  ...` debug-log echo, once as the
+  `display_errors` copy `Warning: Undefined variable $authors_to_migrate in
+  .../php/class-wp-cli.php on line 571` and `Warning: foreach() argument must be
+  of type array|object, null given ... on line 571`). Pinned exactly (minus the
+  timestamped copies) in the no-args scenario.
+- The rename path (target term absent) sets the surviving term's slug AND name to
+  the raw `--new_term` value with NO `cap-` prefix (lines 598-603), inconsistent
+  with the plugin's `cap-<nicename>` slug convention. The old guest author profile
+  keeps its original `user_login`/`post_name`, so term and profile drift apart.
+  Confirmed (term list shows `newuser,newuser` next to `admin,cap-admin`).
+- "Error: Term 'x' doesn't exist, skipping" is emitted via `WP_CLI::log` to STDOUT
+  and the exit code stays 0 (line 580), so scripted callers cannot detect the miss
+  from the exit code. Confirmed.
+- Summary lines never pluralise: `- 1 authors were successfully reassigned terms`
+  (lines 610-612). Confirmed.
+- The merge message's post count comes straight from `$old_term->count` and read
+  `Reassigning 1 posts` for one published post carrying the term — CAP's custom
+  `_update_users_posts_count` had run on `wp post term add`. Confirmed.
+
+- Re-calibrated 2026-09-02 after adversarial review: 11 scenarios, all green.
+- The no-args PHP warnings are no longer pinned with their location (`... in
+  /var/www/html/.../php/class-wp-cli.php on line 571`); the exact `STDERR should be:`
+  block was replaced by two location-free `STDERR should contain:` blocks. The line
+  number is incidental — any edit above it, and certainly the planned
+  one-class-per-command split, would break a green test with no behaviour change.
+  Same reasoning for the underscore-variant scenario: the `Error: Parameter errors:`
+  framing and the `Did you mean '--author-mapping'?` suggestion are owned by
+  wp-cli/wp-cli (Dispatcher/Subcommand.php) and the wp-env image's WP-CLI version
+  floats, so only rc 1 + `unknown --author_mapping parameter` is pinned now.
+- Supplying only `--old_term` (no `--new_term`) falls into exactly the same
+  undefined-variable path as supplying nothing — `Warning: Undefined variable
+  $authors_to_migrate`, rc 0, all-zero summary. The `if ( $old_term && $new_term )`
+  guard at :557 has no else branch and there is no validation of the pair. Pinned in
+  the no-args scenario.
+- NEW (silent false success): the rename branch ignores `wp_update_term()`'s return
+  value (:598-606). When the target slug is already taken by an unrelated author
+  term, `wp_update_term()` returns `WP_Error( 'duplicate_term_slug' )`, nothing is
+  renamed, and the command still logs `Success: Converted 'olduser' term to
+  'newuser'` and counts `- 1 authors were successfully reassigned terms`. Confirmed:
+  `cap-olduser` survives untouched next to the pre-existing `newuser` term. Pinned in
+  "A target slug already taken by another term still reports success".
+- NEW (unresolved numeric `--new_term`): `--new_term=999999` with no such user makes
+  `get_user_by( 'id', ... )` return false, and PHP 8.4 emits `Warning: Attempt to
+  read property "user_login" on false` (:574). `$new_user` becomes null, the rename
+  branch calls `wp_update_term()` with a null name/slug, and that WP_Error is
+  discarded too. rc stays 0 and the summary still prints. Nothing is renamed —
+  the scenario asserts the unchanged term list, so the pin holds whichever way a
+  refactor resolves this.
+- NEW (data loss): `--old_term=x --new_term=x` takes the MERGE branch, because both
+  lookups return the same term object. `wp_delete_term( $id, 'author', array(
+  'default' => $id, 'force_default' => true ) )` reassigns the term's posts to the
+  term that is about to be deleted, so those posts end up with NO author term at all
+  while the summary reports `- 1 authors had their old term merged to their new
+  term`. Confirmed. Pinned in "Reassigning a term to itself deletes the term and
+  orphans its posts".
+- The docblock (:518-525) advertises cleaning up after an import that created
+  'author' terms under the OLD user_login, but the old-term lookup goes through
+  `get_coauthor_by( 'login', ... )` -> `get_author_term()`, which returns null for a
+  non-object. An orphan author term with no user or guest author behind it is
+  therefore reported as `Error: Term 'orphan' doesn't exist, skipping` and left in
+  place, so the documented use case cannot be served. Pinned (with a term_id state
+  assertion showing the term survives) in "A missing old term is reported and skipped
+  without an error exit", alongside the never-existed slug, so the two causes of the
+  same message are now distinguishable.
+- Idempotency: a second identical run reports the old term as missing even though
+  `get_coauthor_by( 'login', 'olduser' )` still finds the guest-author profile — the
+  rename left `post_name` as `cap-olduser` while the term became `newuser`, so
+  `get_author_term()` (which tries `cap-<nicename>` then `<nicename>`) finds nothing.
+  This command never touches the guest-author profile (contrast rename-coauthor);
+  both the rename and merge scenarios now assert `wp post list
+  --post_type=guest-author --field=post_name`. NB guest-author post IDs follow
+  `get_users()` login order (admin, newuser, olduser), not user creation order.
+
+## migrate-author-terms
+
+(Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 8 scenarios.)
+
+- The merge branch (bare term with a prefixed sibling) has no `continue`; after
+  merging it falls through and also logs "Term x (id) isn't prefixed, adding one"
+  before re-slugging the surviving bare term (php/class-wp-cli.php:857-872). The
+  net state is correct but the log narrates two operations for one term.
+  Confirmed, including that the surviving term keeps the BARE term's term_id with
+  the `cap-` slug and that the prefixed sibling's post relationships are
+  reassigned to it (`force_default`).
+- "Now migrating up to N terms" counts ALL author terms, including already
+  prefixed ones that will only be skipped (line 850). Confirmed.
+- Grammar oddities pinned as-is: "Now migrating up to 1 terms" and the success
+  message "All done! Grab a cold one (Affogatto)" (line 874). Confirmed.
+- Terms are processed in `get_terms` default order (name ASC), so `cap-someone`
+  is skipped before the bare `someone` is merged/prefixed. Confirmed.
+- Only the SLUG is prefixed; the term NAME is left untouched. Confirmed
+  2026-09-02: a term created as `Legacy Author` (slug `legacy-author`) ends up as
+  name `Legacy Author` / slug `cap-legacy-author`, and the log line reports the
+  SLUG (`Term legacy-author (N) isn't prefixed, adding one`), so name and slug
+  drift apart. Pinned in "The term name keeps its original value...".
+
+- Re-calibrated 2026-09-02 after adversarial review: 8 scenarios, all green.
+- Taxonomy scoping is now pinned. With a `guardian` category and a `cap-guardian`
+  post_tag in the database, `Now migrating up to 1 terms` proves `get_terms()` is
+  scoped to the author taxonomy, and the surviving post_tag proves the sibling
+  lookup `get_term_by( 'slug', 'cap-' . $slug, $coauthors_plus->coauthor_taxonomy )`
+  (:858) is too. That `$taxonomy` argument is optional in core, so a refactor that
+  dropped it would start `wp_delete_term()`-ing same-slug terms from other
+  taxonomies. NB category/post_tag terms are NOT cleared by the Behat reset either,
+  so the scenario deletes its own two terms first via `wp eval`.
+- Reverse `get_terms()` ordering is now pinned. With names "Aaa" (slug `someone`) and
+  "Zzz" (slug `cap-someone`) the BARE term is processed first, its prefixed sibling
+  is deleted mid-loop, and the loop then still logs `Term cap-someone (<id>) is
+  already prefixed, skipping` for a term that no longer exists — the `foreach`
+  iterates over term objects fetched before the loop, so it narrates a skip for a
+  deleted row. Confirmed exactly. The survivor keeps the bare term's term_id and its
+  original name ("Aaa") with slug `cap-someone`.
+- Return code 0 is now asserted on the primary happy paths: `I run` does not check
+  exit codes despite its docblock, and when the exit code is non-zero the harness
+  moves `Error:` lines off STDOUT, so a command that died after printing the expected
+  lines would previously have satisfied every `STDOUT should be:` block here.
+
+## remove-terms-from-revisions
+
+(Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 7 scenarios.)
+
+- The taxonomy is hardcoded as `'author'` in the `wp_set_post_terms` call
+  (php/class-wp-cli.php:977) instead of `$coauthors_plus->coauthor_taxonomy`, and
+  revisions are read via direct SQL on `post_type='revision' AND
+  post_status='inherit'` (line 965).
+- All output is `WP_CLI::log` — there is no `WP_CLI::success` and the exit code is
+  always 0. Count lines never pluralise: "Found 1 revisions to look through",
+  "1 revisions had author terms removed". Confirmed.
+- Current plugin code no longer adds author terms to revisions
+  (`coauthors_update_post` bails for unsupported post types such as `revision`),
+  so the characterisation scenarios attach terms to revisions manually to
+  exercise the removal path; a plain `wp post update` produces a term-less
+  revision (pinned in "Leave a revision without author terms untouched") and
+  exactly ONE revision per update on WP trunk. Confirmed.
+- `wp post term add <revision-id> author <slug>` does NOT work for the manual
+  attachment: entity-command rejects it with `Error: Invalid taxonomy author.`
+  because the author taxonomy is not registered for the `revision` post type.
+  The scenarios use `wp eval 'wp_set_post_terms( <id>, array( "cap-..." ),
+  "author" );'` instead, which bypasses the object-type check — the same
+  ability the plugin itself historically used to pollute revisions.
+- Removal logs slugs in term insertion order (`cap-admin,cap-alice` as attached),
+  and the parent post's own author terms are untouched. Confirmed.
+- `wp_set_post_terms( $post_id, array(), 'author' )` detaches the terms but does
+  NOT delete them, so a merely-emptied term survives; and the revision post
+  itself is left in place. Both pinned as state assertions.
+- Test-isolation note (2026-09-02): the Background now deletes every author term
+  before `create-guest-authors`, because `reset_database_state()` does not clear
+  author terms between scenarios. Without it, `wp term create author alice
+  --slug=cap-alice` collides with residue from an earlier run and the unscoped
+  `wp term list author` assertion is nondeterministic. See the shared
+  test-environment section above.
+
+- Re-calibrated 2026-09-02 after adversarial review: 7 scenarios, all green.
+- The `$affected` counter is now exercised above 1 ("Every revision with author terms
+  is counted": two tagged revisions -> `All done! 2 revisions had author terms
+  removed`). The driving query (:964) has no ORDER BY, so that scenario asserts with
+  `should contain:` blocks rather than one exact block.
+- The comma-joined slug list for a multi-term revision is an incidental ordering:
+  `cap_get_coauthor_terms_for_post()` orders by `term_order`, which is always 0 for
+  this taxonomy, so every row ties and the database decides. Relaxed from an exact
+  `cap-admin,cap-alice` to `STDOUT should match
+  /Removing (cap-admin,cap-alice|cap-alice,cap-admin)/` (note `should match` does not
+  substitute {VAR}, so the revision ID stays out of the pattern).
+- Revision-ID captures now use `--posts_per_page=1 --orderby=ID --order=DESC`, and
+  the first removal scenario asserts a global revision count of 1 before running the
+  command. If WP trunk ever stores an extra revision, the setup now fails loudly
+  instead of splicing two IDs into a `wp eval` call whose silent failure `I run`
+  would swallow.
+- `I run` never asserts exit status, so both `STDOUT should be empty` assertions are
+  paired with `And the return code should be 0` (otherwise they also pass when the
+  `wp term list` step itself errored), and rc 0 is asserted on the happy paths.
+
+## create-author
+
+(Calibrated against the live env 2026-09-01; all scenarios green.)
+
+- Any omitted optional flag produces a PHP `Warning: Undefined array key "<key>"` from
+  `create_guest_author()` (php/class-wp-cli.php:1156-1163), because the args array is
+  built with unguarded key access. Pinned via `should contain:` in
+  features/create-author.feature. Confirmed. Each warning appears TWICE in the
+  combined output: once as a timestamped debug-log echo
+  (`[01-Sep-2026 ...] PHP Warning:  Undefined array key ...` — the container routes
+  `error_log` output back to the terminal) and once as the `display_errors` copy
+  (`Warning: Undefined array key "<key>" in .../php/class-wp-cli.php on line NNNN`).
+- The `avatar` key is warned about on EVERY invocation: the `create-author` synopsis has
+  no `--avatar` flag (WP-CLI rejects unknown parameters), so `$author['avatar']` at
+  :1163 is always undefined even when every documented flag is supplied.
+- Validation failures (missing `display_name` or `user_login`) are reported via
+  `WP_CLI::warning()` and the command exits 0 — callers/scripts cannot detect failure
+  from the exit code. The command also prints `-- Not found; creating profile.` BEFORE
+  validation, even when nothing ends up being created.
+- Running with no arguments at all is accepted by the synopsis (all flags optional) and
+  goes through the same warn-and-exit-0 path.
+- Duplicate detection checks `user_email` postmeta first, then `user_login` (with a
+  post_name fallback), so an existing profile with the same email but a different login
+  is treated as "already exists" and the requested new login is silently ignored.
+
+- Re-calibrated 2026-09-02: all of the above confirmed again on the live env
+  (PHP 8.4, WP trunk). Two additions:
+  - Supplying `--avatar=<n>` is rejected by WP-CLI's synopsis check with
+    `Error: Parameter errors:` / ` unknown --avatar parameter` and exit code 1, so the
+    `avatar` value that `create_guest_author()` reads at :1163 can never be set through
+    this subcommand. Pinned as its own scenario.
+  - The profile written on the happy path holds exactly `cap-display_name`,
+    `cap-first_name`, `cap-last_name`, `cap-user_login`, `cap-user_email`,
+    `cap-website`, `cap-description` and `_original_author_login` — there is no
+    `cap-avatar` meta, and `_original_author_id` is never written from this path
+    either. Pinned with an exact `wp post meta list --format=csv` assertion.
+
+- Hardened 2026-09-02 after adversarial review: 11 scenarios, all green.
+- **Silent author-term hijack (new, and the most significant finding here).** A
+  `--user_login` that matches an existing WP USER is accepted and the guest author is
+  created, sharing that user's author term. `create_guest_author()` only dedupes
+  against guest-author posts (:1136-1141) and `Guest_Authors::create()` only rejects a
+  collision when the existing co-author's `type` is `guest-author`
+  (php/class-coauthors-guest-authors.php:1402-1406), while `get_author_term()` matches
+  on the `cap-<nicename>` slug alone — so `update_author_term()` finds the user's term,
+  REWRITES its description with the guest author's search values, and
+  `wp_set_post_terms()` attaches the new profile to it. Verified live: user `jane-doe`
+  (term_id 428, description `Jane Doe   jane-doe 166 jane-user@example.com`) plus
+  `create-author --display_name="Jane Guest" --user_login=jane-doe` gives rc 0,
+  `Success: -- Created as guest author #760`, the guest-author post carrying term_id
+  428, and that term's description now reading `Jane Guest   jane-doe 760
+  jane-guest@example.com`. The user's own published post therefore resolves to the
+  guest author. Pinned in "A user_login that collides with an existing user reuses
+  that user's author term" (term_id equality + the rewritten description). Note this
+  makes the `term-creation-failed` / "The author slug may conflict with an existing
+  user" error string unreachable from this path.
+- **No sanitisation at all.** `create_author()` hands `$assoc_args` straight to
+  `create_guest_author()`, so `--display_name="<b>Raw</b> Name"` is stored (and used as
+  `post_title`) verbatim, `--user_login="Raw User!"` is stored verbatim, an unschemed
+  `--website=example.com/raw` is stored as typed, and `--description="<script>x</script>bio"`
+  lands in `cap-description` unfiltered. Only `post_name` is normalised, by
+  `create()`'s own `sanitize_title()` (`cap-raw-user`), which is also what the term
+  slug becomes. This is the exact opposite of `create-guest-authors-from-csv`, which
+  sanitises every cell — a shared `build_guest_author_data()` helper during the split
+  would silently change one command or the other. Pinned in "Field values are stored
+  exactly as given, without sanitisation".
+- The six `Undefined array key` warnings are now pinned as six separate
+  `STDOUT should contain:` steps instead of one ordered `.*`-chained regex: their order
+  is just the literal order of the array literal at :1156-1163, so a behaviour-preserving
+  reorder must not fail the suite.
+- The `--avatar` rejection now pins only `unknown --avatar parameter` (rc 1); the
+  surrounding `Error: Parameter errors:` framing is WP-CLI's, not CAP's, and the wp-env
+  image's WP-CLI floats. Same treatment for the CSV/WXR `missing --file parameter`.
+- Background now wipes author terms (same convention as migrate-author-terms.feature)
+  and the term assertion is scoped `--object_ids={GUEST_AUTHOR_ID}`; see the correction
+  in the shared test-environment section above.
+
+## create-terms-for-posts
+
+(Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
+
+- When a post's `post_author` user does not exist, `update_author_term()` returns
+  `false` and the command dereferences it anyway (php/class-wp-cli.php:131-132).
+  Confirmed live: `Warning: Attempt to read property "slug" on false in .../php/class-wp-cli.php on line 131`
+  and the same for `"user_nicename"` on line 132 (PHP 8.4 says "on false", not
+  "on bool"). Each warning appears TWICE in combined output: once as a
+  timestamped debug-log line (`[date] PHP Warning: ...`) and once as a plain
+  `Warning: ...` display line. No `trim(): Passing null` deprecation from
+  `wp_set_object_terms()` was observed. The post is still logged as
+  `Added - Post #N ... now has an author term for: ` (trailing empty author),
+  counted in `$affected`, and the final message claims
+  `Success: Done! Of 1 posts, 1 now have author terms.` even though NO term was
+  set (verified: `wp term list author --object_ids=N --format=count` is 0).
+  Pinned with `should contain:` + the count state assertion.
+- `Updating author terms with new counts` is misleading: `update_author_term()`
+  only refreshes the term description; it never recalculates counts
+  (`update_author_term_post_count()` is not called here).
+- The command walks every supported post type (post AND page by default), unlike
+  `create-author-terms-for-posts` which defaults to `post` only. Pinned in the
+  "Pages are inspected by default" scenario.
+- Never-pluralised grammar: `Of 1 posts, 1 now have author terms.`
+- The unused global `$wp_post_types` is imported at :89.
+- The two per-post log lines use DIFFERENT identifiers for the same term: the
+  "Skipping" line prints term NAMES (`already has these terms: admin`) while the
+  "Added" line prints the user's `user_nicename` (`... an author term for:
+  writer`) — neither shows the `cap-` prefixed slug that is actually stored.
+  Confirmed 2026-09-02 and pinned in "The author term reflects the post author
+  rather than always being admin" (log says `writer`, stored slug is
+  `cap-writer`).
+- The "Skipping" line uses `{$posts->found_posts}` as the denominator while the
+  "Added" line uses `$total_posts` (:118 vs :129). They are equal today only
+  because `found_posts` is re-read from an identical query each page.
+
+- Hardened 2026-09-02 after adversarial review: 9 scenarios, all green.
+- Drafts, pending and private posts are INVISIBLE to this command. The WP_Query at
+  :94-101 sets no `post_status`, and a CLI request has no current user, so only
+  public statuses are inspected — despite the docblock's claim that it walks all
+  posts, and unlike `create-author-terms-for-posts`, which exposes
+  `--post-statuses`. Pinned in "Draft and private posts are never inspected": the
+  command reports `Now inspecting or updating 0 total posts.` and both posts end
+  with zero author terms. A "tidy-up" adding `'post_status' => 'any'` would be a
+  silent scope change.
+- The skip guard is "has ANY term in the author taxonomy", not "has the term for
+  this post's author", so a post deliberately attributed to somebody other than
+  `post_author` is skipped and never reconciled. Pinned in "A post whose existing
+  author term is not its post author is left alone" (post authored by admin but
+  carrying only `cap-writer`: `Skipping - ... already has these terms: writer`,
+  and the stored term is still `cap-writer` afterwards). Changing the guard to
+  "has the term for post_author" would overwrite such attributions.
+- The per-post memoisation (`$authors[ $single_post->post_author ]` /
+  `$author_terms[ ... ]`, :123-127) is now exercised with two distinct authors in
+  "Each post gets an author term for its own author", so hoisting the lookup out
+  of the loop can no longer pass.
+- The orphan-author "Added" line is now pinned with an end-anchored regex
+  (`... now has an author term for: ?$`) instead of a substring, so a refactor
+  that substituted a placeholder nicename would fail.
+
+## create-author-terms-for-posts
+
+(Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02. All draft predictions confirmed,
+including `Processing page 2.` with `--records-per-batch=1` re-selecting only
+still-missing posts, and `wp post create --post_author=1` auto-assigning the
+cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`)
+
+- An invalid ID range (`--above-post-id` >= `--below-post-id`) surfaces as an
+  UNCAUGHT PHP exception/fatal (`Exception` thrown at php/class-wp-cli.php:1241),
+  not a `WP_CLI::error()`. Re-calibrated 2026-09-02: exit code is **1**, and the
+  user-facing output is a full PHP stack trace (printed twice — once as the
+  timestamped debug-log copy, once as the `display_errors` copy) followed by
+  WP-CLI's generic
+  `Error: There has been a critical error on this website.Learn more about
+  troubleshooting WordPress. There has been a critical error on this website.`
+  That generic line is the ONLY thing routed to STDERR, so an operator who reads
+  just STDERR never learns which parameter was wrong. Pinned as: return code 1,
+  STDOUT contains `Fatal error: Uncaught Exception: The $above_post_id param must
+  be less than the $below_post_id param.`, STDERR contains the critical-error
+  line. (The stack trace itself is incidental and is not pinned.)
+- `--above-post-id` may be given WITHOUT `--below-post-id` (and vice versa); the
+  bound is then open-ended. Pinned in the "no upper bound" scenario.
+- `--post-types` / `--post-statuses` accept comma separated lists; the SQL builds
+  one placeholder per value. Pinned with `--post-statuses=publish,draft`.
+- The skip-postmeta warning interpolates `$wpdb->users`, which is `wp_users` in
+  the wp-env tests container (default prefix). Pinned exactly.
+- `--specific-post-ids` takes precedence over `--above-post-id`/`--below-post-id`
+  (elseif at :1235-1239), so an invalid range combined with specific IDs is
+  silently ignored. Noted from source; not pinned.
+- Posts with `post_author = 0` are excluded by the SQL (`post_author <> 0` at
+  :1265) and are therefore invisible to this command, while
+  `list-posts-without-terms` DOES list them. Pinned.
+- `Updating author terms with new counts` is misleading here too:
+  `update_author_term()` only refreshes descriptions; the direct
+  `$wpdb->insert` into term_relationships never updates term counts either.
+- Grammar: `Found 1 posts`, `1 records affected` (never pluralised).
+- A post whose author is missing is counted in `Found N posts` but produces
+  `0 records affected` after the skip postmeta warning; the run still ends with
+  `Success: Done!`.
+
+
+- Hardened 2026-09-02 after adversarial review: 14 scenarios for this command
+  (20 in the file, the rest being delete-postmeta-that-skip-author-term-backfill).
+- The invalid-range scenario no longer pins WP core's
+  `Error: There has been a critical error on this website.` copy. That string is
+  owned by core's fatal error handler and the tests env tracks WordPress trunk, so
+  it is re-worded from release to release; the scenario now asserts rc 1, the
+  CAP-owned `Fatal error: Uncaught Exception: The $above_post_id param must be
+  less than the $below_post_id param.` on STDOUT, and STDERR not empty. The `<=`
+  boundary is pinned too: `--above-post-id=5 --below-post-id=5` throws as well.
+- `--below-post-id` on its own now has its own scenario (previously only
+  `--above-post-id` alone and both together were covered, which the symmetric
+  `array_unshift()` argument ordering at :1245-1255 could hide).
+- `--specific-post-ids` precedence is now pinned, not just noted: a multi-ID CSV
+  combined with an invalid range (`--above-post-id=10 --below-post-id=5`) exits 0
+  and processes the named IDs, because the specific-IDs branch is an `elseif` that
+  short-circuits the range validation. This also pins the CSV `explode()` and the
+  `IN ( %d, %d )` placeholder generation.
+- Per-post author resolution and the author-loop running percentage are pinned
+  with two authors: `Success: Updated author term for author N (alpha) (50.00%).`
+  then `... (beta) (100.00%).`
+- Batched forward progress depends on the skip postmeta. Each batch re-runs the
+  same `LIMIT n` query with NO offset, so a post that cannot be processed must
+  drop out of the result set. Pinned in the `--records-per-batch=1` scenario,
+  which now leads with an orphan-author post (lowest ID): the run prints
+  `Processing page 2.` and `Processing page 3.` and terminates. Remove or defer
+  `skip_backfill_for_post()` and this command becomes an infinite loop on any site
+  with an orphaned `post_author`.
+- CORRECTION to a review suggestion: the author term `count` is NOT derived from
+  term relationships, so it cannot discriminate the raw `$wpdb->insert` into
+  `wp_term_relationships` from `wp_set_object_terms()`. CAP registers the author
+  taxonomy with `update_count_callback => _update_users_posts_count`
+  (php/class-coauthors-plus.php:279), and that callback counts published posts
+  where the TERM matches **or** `post_author` matches the co-author
+  (php/class-coauthors-plus.php:867-883). Measured live: two published posts by
+  admin give `cap-admin` count 2; `wp post term remove <id> author --all` on both
+  leaves the count at 2; after the backfill it is still 2. The feature pins 2 to
+  document those semantics (an author term's count survives having every one of
+  its relationships removed), not as a guard against the API swap.
+## delete-postmeta-that-skip-author-term-backfill
+
+(Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
+
+- Success/failure per post is reported with bare emoji (`Success: 👍` /
+  `Error: 👎`). Confirmed live: both survive the wp-env output filter and pin
+  as exact-match assertions (the `Error: 👎` line splits to STDERR with exit 1).
+- `WP_CLI::error( '👎' )` (php/class-wp-cli.php:335) aborts the whole loop on the
+  FIRST post whose meta cannot be deleted (e.g. an ID without the meta), leaving
+  any later IDs in `--specific-post-ids` unprocessed, with exit code 1 — even if
+  earlier deletions succeeded. Confirmed and pinned 2026-09-02 in the
+  "stops at the first post that does not have it" scenario: given
+  `--specific-post-ids=<no-meta-post>,<has-meta-post>`, STDOUT holds only the
+  `Deleting postmeta key ... for Post ID <no-meta-post>` line, STDERR is
+  `Error: 👎`, rc 1, and the second post STILL has its
+  `_cap_skip_backfill` meta. A partial run is therefore indistinguishable from a
+  total failure, and re-running is the only recovery.
+- With no `--specific-post-ids` the lookup WP_Query uses defaults
+  (`post_type=post`, `post_status=publish`), so skip metas on drafts, pages or
+  other post types are never found in the no-args mode. Noted; not pinned.
+- When there is nothing to delete the command prints nothing at all (no summary,
+  exit 0). Pinned.
+
+
+- Hardened 2026-09-02 after adversarial review: 6 scenarios for this command.
+- Bare (no `--specific-post-ids`) mode never sees skip metas on unpublished posts.
+  The lookup WP_Query at :315-323 sets only `meta_key` and `fields`, so it
+  inherits `post_type=post` and `post_status=publish`. Now pinned: a DRAFT post
+  given the skip meta by `create-author-terms-for-posts --post-statuses=draft` is
+  invisible to the bare delete, which prints nothing and exits 0 while the meta
+  remains. Same blind spot applies to pages and any other post type.
+- Bare mode also silently caps at `posts_per_page` (the site option, 10 by
+  default), with no warning and no summary. Pinned with 11 posts carrying the
+  meta: exactly 10 `Deleting postmeta key ...` lines are emitted (asserted as
+  match `{10}` plus not-match `{11}`) and 1 post still has the meta afterwards.
+  An operator who backfills 30 pages and then runs the bare delete gets no
+  output, exit 0, and nothing deleted. NB this is deliberately NOT pinned by
+  changing the `posts_per_page` option: the Behat reset clears posts, users,
+  transients and cache but not options, so an option change would leak into every
+  other feature sharing the tests database.
+- The "nothing to delete" scenario now asserts rc 0 and empty STDERR. On its own
+  `STDOUT should be empty` is vacuous: the harness moves `Error:`/`Warning:` lines
+  into STDERR whenever the exit code is non-zero, so an unregistered subcommand
+  after the class split would have kept that scenario green.
+## list-posts-without-terms
+
+(Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
+
+- The tests site uses pretty DATE-BASED permalinks (e.g.
+  `http://localhost:<port>/2026/09/01/alpha-post/`), not plain `?p=<ID>` links
+  as the draft assumed. The port comes from the git-ignored
+  `.wp-env.override.json` (9893 locally), so the feature pins the permalink
+  shape via regex with `localhost:\d+` rather than a literal port.
+
+- The command only ever prints CSV-ish lines; there is no summary and no
+  success message, and an empty result prints nothing (exit 0). Pinned.
+- Post titles go through `addslashes()` (php/class-wp-cli.php:818), so an
+  apostrophe renders as `\'` in the output — PHP-style escaping inside
+  CSV-style quoting. Pinned.
+- Only `publish` posts are inspected (WP_Query default status with no logged-in
+  user), so drafts without terms are silently excluded. Pinned.
+- `$assoc_args` is merged straight into the WP_Query args (wp_parse_args at
+  :807), so ANY WP_Query var (e.g. `--year=`) is accepted, not just the
+  documented `--post_type`. Noted; not pinned.
+
+
+- Hardened 2026-09-02 after adversarial review: 7 scenarios.
+- The permalink assertion has been RELAXED on purpose. The date-based structure
+  `/%year%/%monthnum%/%day%/%postname%/` is applied by @wordpress/env when it
+  configures the environment (`wp rewrite structure ... --hard`), not by this repo
+  and not by CAP, and CI installs @wordpress/env unpinned; the host and port come
+  from wp-env too. The feature now pins the CAP-owned CSV shape only —
+  `#^"\d+","Alpha post","[^"]+","\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"$#m` —
+  plus a `should contain:` block proving a permalink is emitted.
+- Every `STDOUT should be empty` now carries `the return code should be 0` and
+  `STDERR should be empty`. Without them those four scenarios pass against a
+  completely broken command: `Error: '...' is not a registered subcommand` is
+  moved out of STDOUT by the harness when the exit code is non-zero.
+- Multi-post output is now pinned: one CSV line per qualifying post, in ascending
+  post ID order (`'order' => 'ASC', 'orderby' => 'ID'` at :797-798). Note that
+  `STDOUT should match` does NOT run `{VAR}` substitution
+  (`WpEnvFeatureContext::stdout_should_match()` never calls `replace_variables()`),
+  so the ordering regex keys on the post titles rather than on saved IDs.
+- The draft scenario now asserts the draft genuinely has no author term before the
+  command runs, so its empty output can only be explained by the post_status
+  filter.
+## update-author-terms
+
+(Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
+
+- The `changed from A to B` message NEVER shows the corrected count. Confirmed
+  live: with a term count forced to 5 (real count 1), the command prints
+  `Term cap-admin (N) changed from 5 to 5 and the description was refreshed`,
+  yet a fresh process then reads count 1 from the DB. Cause:
+  `update_author_term_post_count()` writes the correct count via a direct
+  `$wpdb->update`, but the command re-reads the term after
+  `wp_cache_delete( $term_id, 'author' )` — the wrong cache group (core caches
+  terms in the `terms` group) — so `get_term_by( 'id', ... )` returns the stale
+  cached object and `$new_count` always equals `$old_count`. Pinned: misleading
+  `5 to 5` message plus the state assertion that the DB count really is 1.
+- `Term X (N) changed from A to B and the description was refreshed` is printed
+  even when NO co-author matches the term slug: `update_author_term( false )`
+  returns false and `update_author_term_post_count()` returns a silent WP_Error,
+  so nothing is refreshed at all. Confirmed and pinned in the orphan-term
+  scenario (`changed from 0 to 0`).
+- The guest author pass queries the `guest-author` CPT with WP_Query's default
+  post_status (`publish`), but guest author posts created via
+  `CoAuthors_Guest_Authors::create()` (and hence `create-guest-authors`) are
+  DRAFTS (`wp_insert_post` default). Confirmed live: the pass reports
+  `Now inspecting or updating 0 Guest Authors.` even when guest authors exist;
+  publishing the guest-author post makes it visible and its term is created.
+  Pinned in the drafts-invisible and published-guest-author scenarios.
+- `wp term list author --field=slug` returns name-ascending order (`cap-admin`
+  before `cap-ghost`/`cap-guest-one`) — confirmed, relied on by exact
+  assertions.
+- Author terms are created for EVERY user returned by `get_users()` regardless
+  of role or post count.
+- Grammar: `Now updating 1 terms`; final message is `Success: All done` (no
+  full stop), unlike other subcommands' `All done!`.
+
+
+- Hardened 2026-09-02 after adversarial review: 8 scenarios.
+- The headline "and the description was refreshed" is now pinned as STATE, not
+  just as log text. Seeding a term with `wp term create author admin
+  --slug=cap-admin --description="stale description"` and running the command
+  rewrites the description to `admin   admin 1 wordpress@example.com` — that is
+  `implode( ' ', ... )` over `CoAuthors_Plus::$ajax_search_fields`
+  (display_name, first_name, last_name, user_login, ID, user_email), hence the
+  three consecutive spaces for the wp-env admin's empty first/last names. Pinned
+  with `#^admin {3}admin 1 \S+@\S+$#` so the environment's admin e-mail address
+  is not hard-coded, plus a `should not match /stale description/`. Dropping
+  `update_author_term( $coauthor )` from the term loop now fails a scenario;
+  previously the whole suite stayed green because the count correction comes from
+  the separate `update_author_term_post_count()` call.
+- The `get_users()` pass creating a term for EVERY user is now pinned, not just
+  noted: a freshly created SUBSCRIBER who has never authored anything gets
+  `cap-zsub`. This is unbounded term growth on sites with large, low-privilege
+  user bases, and narrowing the query (e.g. to `who => authors`) would be a
+  silent behaviour change that the previous single-admin scenarios could not
+  detect.
+- The two multi-line `wp term list author --field=slug` assertions now pass
+  `--orderby=slug --order=asc`. They previously relied on `wp term list`'s default
+  name-ascending order coinciding with slug order, which only held because the
+  admin term is named "admin".
+## create-guest-authors-from-csv
+
+(Calibrated against the live env 2026-09-01; all scenarios green.)
+
+- The predicted PHP 8.4 `Deprecated: fgetcsv(): the $escape parameter...` notice does
+  NOT appear (PHP 8.4.25). `fgetcsv( $file )` is called with only the stream argument
+  (php/class-wp-cli.php:1073), and the deprecation only fires when other optional
+  parameters are passed without an explicit `$escape`. The assertion was dropped from
+  the feature; the happy-path output is clean of warnings/deprecations because the CSV
+  flow populates every array key that `create_guest_author()` reads.
+- There is no validation of required CSV columns (`// TODO: bail if required fields not
+  found` at :1076). A CSV without `user_login`/`user_email` columns would hit undefined
+  array keys at :1097. Not pinned — the fixture supplies all columns.
+- Per-author failures are warnings only; once the file is readable the command always
+  exits 0.
+
+- Re-calibrated 2026-09-02: confirmed, plus a new branch finding.
+  - The first/last-name logic at :1108-1119 has a GAP: the `if` needs a space in
+    `display_name` AND both name columns empty; the `elseif` needs BOTH columns
+    populated. A row with a single-word `display_name` and empty `first_name`/
+    `last_name` (or only one of the two populated) matches neither branch, so the keys
+    are never added to `$guest_author_data` and `create_guest_author()` emits
+    `Undefined array key "first_name"` / `"last_name"` at :1159-1160 — the only way the
+    CSV path can produce those warnings. The created profile then has no
+    `cap-first_name`/`cap-last_name` meta at all. Pinned with
+    features/fixtures/guest-authors-single-name.csv (display_name `Prince`).
+  - Count line does not pluralise: a one-row CSV logs `Found 1 authors in CSV`
+    (:1090). Pinned.
+
+- Hardened 2026-09-02 after adversarial review: 10 scenarios, all green.
+- **The sanitisation layer is now pinned** (features/fixtures/guest-authors-dirty.csv),
+  because this is the ONLY one of the three commands that sanitises and the difference
+  would otherwise vanish in a refactor. Live results for the row
+  `<b>Dirty</b> Name,Dirty Login!,DIRTY@Example.com,example.com/x?a=1&b=2,<script>alert(1)</script><em>Bio</em>,abc,,`:
+  - `Processing author Dirty Login! (DIRTY@Example.com)` — the log echoes the RAW
+    cells; sanitisation happens after it.
+  - `sanitize_text_field()` strips the markup: `cap-display_name` is `Dirty Name`.
+  - The first/last split reads the RAW `display_name`, so first name is `<b>Dirty</b>`
+    before `sanitize_text_field()` reduces it to `Dirty`; last name `Name`.
+  - `sanitize_user()` is called WITHOUT `$strict`, so `Dirty Login!` is stored intact
+    (spaces and `!` and all) in `cap-user_login` and `_original_author_login`. Only
+    `post_name`/term slug are normalised, to `cap-dirty-login`.
+  - `sanitize_email()` does NOT lowercase: `DIRTY@Example.com` is stored as typed.
+  - `esc_url_raw()` adds the missing scheme: `http://example.com/x?a=1&b=2` (the `&`
+    is left raw, since the `db` context skips entity encoding).
+  - `wp_filter_post_kses()` removes the `<script>` TAGS but keeps their text content
+    and the allowed `<em>`: `cap-description` is `alert(1)<em>Bio</em>`. Stripping
+    markup is not the same as neutralising a payload.
+  - `absint( 'abc' )` is 0, so no featured image is set and (as always) no `cap-avatar`
+    meta exists — `avatar` is not one of `get_guest_author_fields()`.
+- **A header that omits columns still imports, noisily.** With header
+  `display_name,user_login` the command's own code emits `Undefined array key` for
+  `user_email` twice (:1097 in the `Processing author %s (%s)` log, then :1102) and
+  once each for `website` (:1103), `description` (:1104) and `avatar` (:1105), logs
+  `Processing author casey-missing ()` with an empty email, and creates the profile
+  anyway. No PHP 8.4 "Passing null to parameter" deprecations appear —
+  `sanitize_email( null )`, `esc_url_raw( null )`, `wp_filter_post_kses( null )` and
+  `absint( null )` are all quiet on WP trunk. Pinned with
+  features/fixtures/guest-authors-missing-columns.csv, whose header also ends in a
+  NAMELESS column carrying a value, exercising the `if ( empty( $field_keys[ $col_num ] ) )
+  { continue; }` branch (:1099-1101) — the exact meta block shows the value is dropped.
+  The `// TODO: bail if required fields not found` at :1076 is still a TODO.
+- **A failing row does not stop the import.** features/fixtures/guest-authors-invalid-row.csv
+  (empty `display_name` on row 1, a good row 2) gives `Found 2 authors in CSV`,
+  `Warning: -- Failed to create guest author: display_name is a required field`, then
+  `Processing author valid-person (valid@example.com)` / `Success:` / `All done!`,
+  rc 0, and exactly ONE guest author (`cap-valid-person`). So the `Found N` counter is
+  unrelated to the number created, and a scripted caller cannot tell from the exit code
+  that rows were dropped. Now pinned rather than merely asserted in this document.
+- **The name-splitting gap now includes the half-filled case.** A row with exactly one
+  of `first_name`/`last_name` populated matches neither the `if` (:1110, needs both
+  empty) nor the `elseif` (:1116, needs both non-empty), so the value supplied is
+  silently DISCARDED and the profile gets no name meta at all — even when the display
+  name does contain a space. Verified with features/fixtures/guest-authors-half-named.csv
+  (`Half Named,half-named,...,Halfy,`): `Undefined array key "first_name"` /
+  `"last_name"` from :1159-1160 and a profile holding only display_name, user_login,
+  user_email and `_original_author_login`. Pinned alongside the single-word case.
+- `--file=<a directory>` is NOT the way to reach `WP_CLI::error( 'Failed to read file.' )`:
+  `is_readable()` passes, `fopen( 'features/fixtures', 'rb' )` SUCCEEDS on Linux/PHP 8.4,
+  and `fgetcsv()` immediately returns false — so the command reports
+  `Found 0 authors in CSV` / `All done!` and exits 0 for an operator typo. Deliberately
+  NOT pinned as a scenario: fopen-on-a-directory is platform/PHP behaviour, not CAP's.
+  The `Failed to read file.` branch remains unreached by any scenario.
+- Term assertions are now `--object_ids=` scoped and the Background wipes author terms;
+  the previous `--slug=cap-jane-doe` assertion was satisfiable by residue from
+  create-author.feature (which runs first and uses the same login). See the correction
+  in the shared test-environment section.
+
+## create-guest-authors-from-wxr
+
+(Calibrated against the live env 2026-09-01; all scenarios green.)
+
+- If the wordpress-importer plugin is not installed, the command dies with an uncaught
+  PHP fatal (`require_once` of `wordpress-importer/parsers.php` at
+  php/class-wp-cli.php:1002) instead of a clean `WP_CLI::error()`. Confirmed, with a
+  twist: the exit code is 1 (not 255) because WP's fatal-error recovery handler
+  catches the shutdown and WP-CLI then prints core's
+  `Error: There has been a critical error on this website...` line and exits 1.
+  STDOUT keeps both the timestamped `PHP Fatal error:` debug-log echo and the
+  `Fatal error: Uncaught Error: Failed opening required
+  '.../wordpress-importer/parsers.php'` display copy (plus the full stack trace).
+  Pinned via `should contain:` on `Fatal error` / `wordpress-importer/parsers.php`.
+- The clean `Error: Failed to read WXR file.` exit (php/class-wp-cli.php:1009) is
+  UNREACHABLE with the wordpress-importer version that `wp plugin install` fetches
+  today (0.9.6). Feeding a non-XML file does not return a `WP_Error`: `WXR_Parser`
+  falls through to `WXR_Parser_XML_Processor`, which fatals with
+  `Uncaught Error: Class "WordPress\DataLiberation\EntityReader\WXREntityReader"
+  not found` in wordpress-importer/parsers/class-wxr-parser-xml-processor.php:357,
+  because CAP `require`s only parsers.php (line 1002) without the importer's
+  autoloader for the Data Liberation library. Exit code 1 via the same
+  critical-error handler. The draft's clean-error scenario was rewritten as
+  "Fatal error on a file that is not a WXR file" (pinned: exit 1, `Fatal error`,
+  the xml-processor path, and 0 guest authors created). A valid WXR file parses
+  fine (the SimpleXML parser succeeds before the fallback chain is reached).
+- The WXR flow never sets `website`, `description`, or `avatar` keys, so
+  `create_guest_author()` emits `Undefined array key` warnings for each of them
+  (:1161-1163) for every author processed. Confirmed.
+- `_original_author_id` is NEVER saved: the guard checks `isset( $author['author_id'] )`
+  (:1173) but the WXR flow passes the ID under the key `ID` (:1024), so the check never
+  matches. (Had it matched, it would have stored `$author['ID']` anyway.) Pinned via a
+  `wp post meta list --keys=_original_author_id --format=count` = 0 assertion. Confirmed.
+
+- Re-calibrated 2026-09-02: every point above reproduced exactly (wordpress-importer
+  0.9.6, PHP 8.4). Notes for whoever runs this file next:
+  - The shared wp-env tests container already had wordpress-importer installed
+    (inactive), so the "not installed" scenario has to `wp plugin uninstall
+    wordpress-importer --deactivate` first, and the later scenarios re-`install` it.
+    The install is served from the WP-CLI download cache mounted from the host
+    (`~/.wp-cli/cache/plugin/wordpress-importer-0.9.6.zip`), so it does not need the
+    network once warm — but a cold CI cache does. Scenario ORDER matters: the
+    uninstalling scenario is deliberately placed before the ones that install.
+  - Output splitting artefact of the Behat context: on the fatal paths (`I try`,
+    exit 1) the `display_errors` copy `Warning: require_once(...): Failed to open
+    stream...` is moved to STDERR because it starts with `Warning:`, while the
+    timestamped `[...] PHP Warning:` copy and the whole `Fatal error: Uncaught Error:`
+    block stay in STDOUT. Assertions are split accordingly.
+  - The non-WXR-file scenario asserts only `Fatal error: Uncaught Error:` plus a
+    `/wordpress-importer/` match and `STDERR should not match /Failed to read WXR
+    file/` (proving the clean-error branch is dead), rather than the exact
+    class-wxr-parser-xml-processor.php:357 path, so it does not break on the next
+    wordpress-importer release.
+
+- Hardened 2026-09-02 after adversarial review: 7 scenarios, all green.
+- **wordpress-importer is now pinned to 0.9.6** in the Background
+  (`wp plugin install wordpress-importer --version=0.9.6`, immediately followed by
+  `wp plugin get wordpress-importer --field=version` = `0.9.6`). Two reasons: the
+  crash characterised below is that release's parser fallback chain, not CAP's, so an
+  unpinned install would turn a green suite red on an upstream release with no change
+  to this repo; and `I run` does not check exit codes, so an unpinned `I try` install
+  could fail silently on a cold CI cache and surface as a confusing `require_once
+  parsers.php` fatal in the happy-path scenario instead of "the importer is missing".
+  If wp-env ever ships a different importer version the Background now fails first,
+  with the version diff as the message. When the pin is eventually moved, expect the
+  "not a WXR file" scenario to need recalibrating.
+- Scenario ORDER no longer matters. The install lives in the Background, and the
+  "not installed" scenario uninstalls at the start and reinstalls (with the version
+  re-asserted) at the end, so running a single scenario with `--name` no longer leaves
+  the container without the importer.
+- The `require_once` fatal is no longer pinned with the absolute container path or
+  PHP's exact wording. It is now `STDERR should match #require_once\(.*/wordpress-importer/parsers\.php\)#`
+  and `STDOUT should match #Failed opening required '.*/wordpress-importer/parsers\.php'#`
+  — the path is a wp-env layout detail (CAP builds it from `WP_CONTENT_DIR`) and the
+  "Failed to open stream: No such file or directory" phrasing is PHP's.
+- The "not a WXR file" scenario now uses its own features/fixtures/not-a-wxr.xml
+  instead of borrowing the CSV group's fixture, and asserts only rc 1, loose
+  `/Fatal error/` + `/wordpress-importer/` matches, `STDERR should not match /Failed to
+  read WXR file/` and 0 guest authors. Same fatal as with a CSV file
+  (`Class "WordPress\DataLiberation\EntityReader\WXREntityReader" not found`), so
+  CAP's clean `Failed to read WXR file.` branch stays dead at the pinned version.
+- A valid WXR with NO `<wp:author>` nodes (features/fixtures/no-authors.wxr) prints
+  exactly `All done!`, exits 0 and creates nothing — `$import_data['authors']` is an
+  empty array rather than an undefined key, so the `foreach` at :1017 is quiet. Now
+  pinned as the cheapest guard on that loop.
+- CORRECTION to the note above: the `_original_author_id` = 0 assertion this document
+  claimed was present was NOT in the feature file; the absence was only implied by the
+  exact meta block. `wp post meta list {JANE_ID} --keys=_original_author_id --format=count`
+  = 0 is now an explicit step (in this file, create-author.feature and
+  create-guest-authors-from-csv.feature), with a Gherkin comment naming the
+  `isset( $author['author_id'] )` vs `ID` guard bug, so the intent survives any
+  reshuffle of the meta block.
+- The second author's profile is now pinned too (exact meta block plus an
+  `--object_ids` term assertion for `wxr-bob`), so the whole flow no longer rests on
+  the first author alone.
+- The three `Undefined array key` warnings are now separate `STDOUT should contain:`
+  steps rather than one ordered `.*`-chained regex, and the `missing --file parameter`
+  error pins only the CAP-independent fragment (the `Error: Parameter errors:` framing
+  belongs to WP-CLI).

--- a/features/assign-coauthors.feature
+++ b/features/assign-coauthors.feature
@@ -1,0 +1,299 @@
+Feature: Co-authors can be assigned to posts from a post meta value
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+
+	Scenario: Report every outcome in one run and ignore posts the query cannot reach
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp post create --post_title="Fresh" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		And I run `wp post meta update {POST_ID_1} _original_import_author author1`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Already" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_2}
+		And I run `wp post meta update {POST_ID_2} _original_import_author author1`
+		And I run `wp post create --post_title="Ghost" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_3}
+		And I run `wp post meta update {POST_ID_3} _original_import_author ghostwriter`
+		And I run `wp post create --post_title="No meta" --post_status=publish --porcelain`
+		And save STDOUT as {NO_META_ID}
+		And I run `wp post create --post_title="Draft import" --post_status=draft --porcelain`
+		And save STDOUT as {DRAFT_ID}
+		And I run `wp post meta update {DRAFT_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID_1} has been assigned "author1" as the author
+		2: Post #{POST_ID_2} already has "author1" associated as a co-author
+		3: Post #{POST_ID_3} does not have "ghostwriter" associated as a co-author but there is not a co-author profile
+		All done! Here are your results:
+		- 1 posts already had the co-author assigned
+		- 1 posts reference co-authors that don't exist. These are:
+		  ghostwriter
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp term list author --object_ids={NO_META_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp term list author --object_ids={DRAFT_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Assign a co-author from the default meta key and re-run safely
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp post create --post_title="Imported post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta update {POST_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "author1" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run the previous command again
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} already has "author1" associated as a co-author
+		All done! Here are your results:
+		- 1 posts already had the co-author assigned
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""
+
+	Scenario: Assign a co-author from a custom --meta_key
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And I run `wp post create --post_title="Custom key post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta update {POST_ID} author author1`
+		And I run `wp co-authors-plus assign-coauthors --meta_key=author`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "author1" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+
+	Scenario: Do not backfill the author term for a post whose author already matches
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Own post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp post term remove {POST_ID} author cap-author1 --by=slug`
+		And I run `wp post meta update {POST_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} already has "author1" associated as a co-author
+		All done! Here are your results:
+		- 1 posts already had the co-author assigned
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Report missing co-author profiles once each in the summary
+		When I run `wp post create --post_title="Ghost post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		And I run `wp post meta update {POST_ID_1} _original_import_author ghostwriter`
+		And I run `wp post create --post_title="Ghost post two" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_2}
+		And I run `wp post meta update {POST_ID_2} _original_import_author ghostwriter`
+		And I run `wp post create --post_title="Phantom post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_3}
+		And I run `wp post meta update {POST_ID_3} _original_import_author phantom`
+		And I run `wp post create --post_title="Blank import" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_4}
+		And I run `wp eval 'update_post_meta( {POST_ID_4}, "_original_import_author", "" );'`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID_1} does not have "ghostwriter" associated as a co-author but there is not a co-author profile
+		2: Post #{POST_ID_2} does not have "ghostwriter" associated as a co-author but there is not a co-author profile
+		3: Post #{POST_ID_3} does not have "phantom" associated as a co-author but there is not a co-author profile
+		4: Post #{POST_ID_4} does not have "" associated as a co-author but there is not a co-author profile
+		All done! Here are your results:
+		- 4 posts reference co-authors that don't exist. These are:
+		  ghostwriter, phantom,
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1},{POST_ID_2},{POST_ID_3},{POST_ID_4} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Replace existing co-authors by default
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp post create --post_title="Imported post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta update {POST_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		And I run `wp post meta update {POST_ID} _original_import_author author2`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "author2" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		"""
+		When I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR2_ID}
+		"""
+
+	Scenario: Append to existing co-authors with --append_coauthors
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp post create --post_title="Imported post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta update {POST_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		And I run `wp post meta update {POST_ID} _original_import_author author2`
+		And I run `wp co-authors-plus assign-coauthors --append_coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "author2" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		cap-author2
+		"""
+		When I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""
+		When I run `wp user create author3 author3@example.com --role=author --porcelain`
+		And I run `wp post meta update {POST_ID} _original_import_author author3`
+		And I run `wp co-authors-plus assign-coauthors --append_coauthors=false`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "author3" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		cap-author2
+		cap-author3
+		"""
+
+	Scenario: Process only the given --post_type
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And I run `wp post create --post_type=page --post_title="A page" --post_status=publish --porcelain`
+		And save STDOUT as {PAGE_ID}
+		And I run `wp post meta update {PAGE_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		All done! Here are your results:
+		"""
+		When I run `wp co-authors-plus assign-coauthors --post_type=page`
+		Then STDOUT should be:
+		"""
+		1: Post #{PAGE_ID} has been assigned "author1" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+
+	Scenario: Fall back to a sanitised meta value, re-assigning on every run
+		When I run `wp user create author-one author-one@example.com --role=author --porcelain`
+		And I run `wp post create --post_title="Display name import" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta update {POST_ID} _original_import_author "Author One"`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "Author One" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run the previous command again
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "Author One" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author-one
+		"""
+
+	Scenario: Assign an unlinked guest author from the meta value
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com --first_name=Jane --last_name=Doe --website=https://example.com/jane --description="Jane writes about testing"`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Imported post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta update {POST_ID} _original_import_author jane-doe`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_ID} has been assigned "jane-doe" as the author
+		All done! Here are your results:
+		- 1 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+		When I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -1,0 +1,505 @@
+Feature: Missing author terms can be backfilled for targeted posts
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Backfill author terms for published posts that are missing them, then find nothing on a second run
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 2 posts with missing author terms.
+		Processing post {POST_A} (1/2 or 50.00%)
+		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
+		Processing post {POST_B} (2/2 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
+		2 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp term list author --slug=cap-admin --field=count`
+		Then STDOUT should be:
+		"""
+		2
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 0 posts with missing author terms.
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+
+	Scenario: Each post gets a term for its own author and every author term is updated
+		When I run `wp user create alpha alpha@example.com --role=author --porcelain`
+		And save STDOUT as {USER_A}
+		And I run `wp user create beta beta@example.com --role=author --porcelain`
+		And save STDOUT as {USER_B}
+		And I run `wp post create --post_title="Alpha post" --post_status=publish --post_author={USER_A} --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Beta post" --post_status=publish --post_author={USER_B} --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 2 posts with missing author terms.
+		Processing post {POST_A} (1/2 or 50.00%)
+		Success: Inserted term relationship for post {POST_A} and author {USER_A} (alpha).
+		Processing post {POST_B} (2/2 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author {USER_B} (beta).
+		2 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author {USER_A} (alpha) (50.00%).
+		Success: Updated author term for author {USER_B} (beta) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-alpha
+		"""
+		When I run `wp term list author --object_ids={POST_B} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-beta
+		"""
+
+	Scenario: Draft posts are only processed when --post-statuses includes draft
+		When I run `wp post create --post_title="Draft post" --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 0 posts with missing author terms.
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts --post-statuses=draft`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_ID} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_ID} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: Several statuses can be targeted at once with a comma separated --post-statuses
+		When I run `wp post create --post_title="Published post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Draft post" --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --post-statuses=publish,draft`
+		Then STDOUT should be:
+		"""
+		Found 2 posts with missing author terms.
+		Processing post {POST_A} (1/2 or 50.00%)
+		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
+		Processing post {POST_B} (2/2 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
+		2 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+
+	Scenario: Pages are only processed when --post-types includes page
+		When I run `wp post create --post_type=page --post_title="About page" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {PAGE_ID}
+		And I run `wp post term remove {PAGE_ID} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 0 posts with missing author terms.
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts --post-types=page`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {PAGE_ID} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {PAGE_ID} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+
+	Scenario: Only the posts named in --specific-post-ids are processed
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --specific-post-ids={POST_A}`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_A} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp term list author --object_ids={POST_B} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts --specific-post-ids={POST_A},{POST_B} --above-post-id=10 --below-post-id=5`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_B} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_B} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: Only posts strictly between --above-post-id and --below-post-id are processed
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post create --post_title="Third post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_C}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp post term remove {POST_C} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --above-post-id={POST_A} --below-post-id={POST_C}`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_B} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_A} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp term list author --object_ids={POST_C} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Only posts above --above-post-id are processed when no upper bound is given
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --above-post-id={POST_A}`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_B} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_A} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Only posts below --below-post-id are processed when no lower bound is given
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --below-post-id={POST_B}`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_A} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp term list author --object_ids={POST_B} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: An uncaught exception is thrown when --above-post-id is not less than --below-post-id
+		When I try `wp co-authors-plus create-author-terms-for-posts --above-post-id=10 --below-post-id=5`
+		Then the return code should be 1
+		And STDOUT should contain:
+		"""
+		Fatal error: Uncaught Exception: The $above_post_id param must be less than the $below_post_id param.
+		"""
+		And STDERR should not be empty
+		When I try `wp co-authors-plus create-author-terms-for-posts --above-post-id=5 --below-post-id=5`
+		Then the return code should be 1
+		And STDOUT should contain:
+		"""
+		Fatal error: Uncaught Exception: The $above_post_id param must be less than the $below_post_id param.
+		"""
+
+	Scenario: A post whose author does not exist gets skip postmeta instead of a term
+		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_ID} (1/1 or 100.00%)
+		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+		When I run `wp post meta get {POST_ID} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 0 posts with missing author terms.
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+
+	Scenario: Posts with a post_author of zero are never seen as missing terms
+		When I run `wp post create --post_title="Nobody post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 0 posts with missing author terms.
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+
+	Scenario: Batches are re-queried when --records-per-batch is smaller than the total, and a skipped post does not stall progress
+		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
+		And save STDOUT as {ORPHAN_ID}
+		And I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --records-per-batch=1`
+		Then STDOUT should be:
+		"""
+		Found 3 posts with missing author terms.
+		Processing post {ORPHAN_ID} (1/3 or 33.33%)
+		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
+		Processing page 2.
+		Processing post {POST_A} (2/3 or 66.67%)
+		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
+		Processing page 3.
+		Processing post {POST_B} (3/3 or 100.00%)
+		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
+		2 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp post meta get {ORPHAN_ID} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
+		"""
+
+	Scenario: Process everything in a single pass with --unbatched
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		And I run `wp co-authors-plus create-author-terms-for-posts --unbatched`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_ID} (1/1 or 100.00%)
+		Success: Inserted term relationship for post {POST_ID} and author 1 (admin).
+		1 records affected
+		Updating author terms with new counts
+		Success: Updated author term for author 1 (admin) (100.00%).
+		Success: Done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: Skip postmeta can be deleted so posts are backfilled again
+		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		And I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
+		Then STDOUT should be:
+		"""
+		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		Success: 👍
+		"""
+		When I run `wp post meta list {POST_ID} --keys=_cap_skip_backfill --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 1 posts with missing author terms.
+		Processing post {POST_ID} (1/1 or 100.00%)
+		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
+		0 records affected
+		Updating author terms with new counts
+		Success: Done!
+		"""
+
+	Scenario: Error when deleting skip postmeta from a post that does not have it
+		When I run `wp post create --post_title="Regular post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		When I try `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids={POST_ID}`
+		Then STDOUT should be:
+		"""
+		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		"""
+		And STDERR should be:
+		"""
+		Error: 👎
+		"""
+		And the return code should be 1
+
+	Scenario: Deleting skip postmeta stops at the first post that does not have it
+		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
+		And save STDOUT as {ORPHAN_ID}
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		And I run `wp post create --post_title="Regular post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		When I try `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids={POST_ID},{ORPHAN_ID}`
+		Then STDOUT should be:
+		"""
+		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		"""
+		And STDERR should be:
+		"""
+		Error: 👎
+		"""
+		And the return code should be 1
+		When I run `wp post meta get {ORPHAN_ID} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
+		"""
+
+	Scenario: Deleting skip postmeta with nothing to delete produces no output
+		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
+		Then STDOUT should be empty
+		And the return code should be 0
+		And STDERR should be empty
+
+	Scenario: The bare delete never sees skip postmeta on unpublished posts
+		When I run `wp post create --post_title="Orphan draft" --post_author=999 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus create-author-terms-for-posts --post-statuses=draft`
+		Then STDOUT should contain:
+		"""
+		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
+		"""
+		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
+		Then STDOUT should be empty
+		And the return code should be 0
+		And STDERR should be empty
+		When I run `wp post meta get {POST_ID} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
+		"""
+
+	Scenario: The bare delete only handles the first page of posts carrying skip postmeta
+		When I run `wp eval 'for ( $i = 0; $i < 11; $i++ ) { $id = wp_insert_post( array( "post_title" => "Skipped $i", "post_status" => "publish", "post_author" => 1 ) ); add_post_meta( $id, "_cap_skip_backfill", "nonexistent_post_author_id", true ); }'`
+		And I run `wp post list --meta_key=_cap_skip_backfill --post_status=any --format=count`
+		Then STDOUT should be:
+		"""
+		11
+		"""
+		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
+		Then the return code should be 0
+		And STDOUT should match #(Deleting postmeta key[\s\S]*?){10}#
+		And STDOUT should not match #(Deleting postmeta key[\s\S]*?){11}#
+		When I run `wp post list --meta_key=_cap_skip_backfill --post_status=any --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""

--- a/features/create-author.feature
+++ b/features/create-author.feature
@@ -1,0 +1,308 @@
+Feature: A single guest author can be created
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		# Author terms survive the Behat reset, so wipe them: a leftover `cap-*` term
+		# would otherwise satisfy the term assertions below without the command
+		# creating anything, and would be silently reused by CoAuthors_Plus::get_author_term().
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Create a guest author with every supported field
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com --first_name=Jane --last_name=Doe --website=https://example.com/jane --description="Jane writes about testing"`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "avatar"
+		"""
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+		When I run `wp post list --post_type=guest-author --field=post_name`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+		When I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {GUEST_AUTHOR_ID}
+		And I run `wp post meta list {GUEST_AUTHOR_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{GUEST_AUTHOR_ID},cap-display_name,"Jane Doe"
+		{GUEST_AUTHOR_ID},cap-first_name,Jane
+		{GUEST_AUTHOR_ID},cap-last_name,Doe
+		{GUEST_AUTHOR_ID},cap-user_login,jane-doe
+		{GUEST_AUTHOR_ID},cap-user_email,jane@example.com
+		{GUEST_AUTHOR_ID},cap-website,https://example.com/jane
+		{GUEST_AUTHOR_ID},cap-description,"Jane writes about testing"
+		{GUEST_AUTHOR_ID},_original_author_login,jane-doe
+		"""
+		# Stated explicitly as well as implied by the block above: this command never
+		# writes `_original_author_id` (the guard reads an `author_id` key it never sets).
+		When I run `wp post meta list {GUEST_AUTHOR_ID} --keys=_original_author_id --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		# Scoped to the profile just created, not to the slug: a term-slug lookup would
+		# pass on residue from an earlier feature or an earlier run.
+		When I run `wp term list author --object_ids={GUEST_AUTHOR_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+
+	Scenario: Omitted optional fields raise undefined array key warnings but still create the profile
+		When I run `wp co-authors-plus create-author --display_name=Minimal --user_login=minimal`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "user_email"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "first_name"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "last_name"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "website"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "description"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "avatar"
+		"""
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+		When I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {GUEST_AUTHOR_ID}
+		And I run `wp post meta get {GUEST_AUTHOR_ID} cap-user_login`
+		Then STDOUT should be:
+		"""
+		minimal
+		"""
+		When I run `wp post meta list {GUEST_AUTHOR_ID} --keys=cap-user_email --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Field values are stored exactly as given, without sanitisation
+		When I run `wp co-authors-plus create-author --display_name="<b>Raw</b> Name" --user_login="Raw User!" --user_email=raw@example.com --website=example.com/raw --description="<script>x</script>bio"`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		When I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {RAW_ID}
+		And I run `wp post meta list {RAW_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{RAW_ID},cap-display_name,"<b>Raw</b> Name"
+		{RAW_ID},cap-user_login,"Raw User!"
+		{RAW_ID},cap-user_email,raw@example.com
+		{RAW_ID},cap-website,example.com/raw
+		{RAW_ID},cap-description,<script>x</script>bio
+		{RAW_ID},_original_author_login,"Raw User!"
+		"""
+		When I run `wp post get {RAW_ID} --field=post_title`
+		Then STDOUT should be:
+		"""
+		<b>Raw</b> Name
+		"""
+		# Only the post_name (and hence the term slug) is sanitised, by
+		# CoAuthors_Guest_Authors::create() itself. Contrast
+		# create-guest-authors-from-csv, which sanitises every cell before storing it.
+		When I run `wp post get {RAW_ID} --field=post_name`
+		Then STDOUT should be:
+		"""
+		cap-raw-user
+		"""
+		When I run `wp term list author --object_ids={RAW_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-raw-user
+		"""
+
+	Scenario: A user_login that collides with an existing user reuses that user's author term
+		Given I run `wp user create jane-doe jane-user@example.com --display_name="Jane Doe" --role=author --porcelain`
+		And save STDOUT as {USER_ID}
+		And I run `wp post create --post_title="Post by Jane" --post_author={USER_ID} --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp term list author --object_ids={POST_ID} --field=term_id`
+		And save STDOUT as {USER_TERM_ID}
+		And STDOUT should not be empty
+		When I run `wp co-authors-plus create-author --display_name="Jane Guest" --user_login=jane-doe --user_email=jane-guest@example.com`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		# The duplicate guards only look at guest authors, and get_author_term() matches
+		# on the `cap-<nicename>` slug alone, so the new profile ADOPTS the existing
+		# user's term rather than getting one of its own.
+		When I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {GUEST_AUTHOR_ID}
+		And I run `wp term list author --object_ids={GUEST_AUTHOR_ID} --field=term_id`
+		Then STDOUT should be:
+		"""
+		{USER_TERM_ID}
+		"""
+		# The shared term's description (what CAP searches on) is rewritten with the
+		# guest author's values, so the real user's post now points at the guest author.
+		When I run `wp term list author --object_ids={POST_ID} --field=description`
+		Then STDOUT should contain:
+		"""
+		Jane Guest
+		"""
+
+	Scenario: The avatar field used when creating a profile is not exposed as a parameter
+		When I try `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --avatar=5`
+		Then the return code should be 1
+		And STDERR should contain:
+		"""
+		unknown --avatar parameter
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: A guest author is not created without a display_name
+		When I run `wp co-authors-plus create-author --user_login=no-display-name`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "display_name"
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: -- Failed to create guest author: display_name is a required field
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: A guest author is not created without a user_login
+		When I run `wp co-authors-plus create-author --display_name="No Login"`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "user_login"
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: -- Failed to create guest author: user_login is a required field
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Running without any parameters still attempts creation and warns
+		When I run `wp co-authors-plus create-author`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: -- Failed to create guest author: display_name is a required field
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Creating the same author twice skips the existing profile
+		Given I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
+		And I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {GUEST_AUTHOR_ID}
+		And STDOUT should not be empty
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}); skipping.
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+
+	Scenario: An existing user_email is matched even when the user_login differs
+		Given I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
+		And I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {GUEST_AUTHOR_ID}
+		And STDOUT should not be empty
+		When I run `wp co-authors-plus create-author --display_name="Janet Other" --user_login=janet-other --user_email=jane@example.com`
+		Then STDOUT should be:
+		"""
+		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}); skipping.
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+
+	Scenario: An existing user_login is matched even when the user_email differs
+		Given I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
+		And I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {GUEST_AUTHOR_ID}
+		And STDOUT should not be empty
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=different@example.com`
+		Then STDOUT should be:
+		"""
+		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}); skipping.
+		"""
+		When I run `wp post meta get {GUEST_AUTHOR_ID} cap-user_email`
+		Then STDOUT should be:
+		"""
+		jane@example.com
+		"""

--- a/features/create-guest-authors-from-csv.feature
+++ b/features/create-guest-authors-from-csv.feature
@@ -1,0 +1,313 @@
+Feature: Guest authors can be created from a CSV file
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		# Author terms survive the Behat reset, so wipe them: a leftover `cap-*` term
+		# would otherwise satisfy the term assertions below without the command
+		# creating anything, and would be silently reused by CoAuthors_Plus::get_author_term().
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Error on a missing required --file parameter
+		When I try `wp co-authors-plus create-guest-authors-from-csv`
+		Then the return code should be 1
+		And STDERR should contain:
+		"""
+		missing --file parameter
+		"""
+
+	Scenario: Error on a file that cannot be read
+		When I try `wp co-authors-plus create-guest-authors-from-csv --file=no-such-file.csv`
+		Then the return code should be 1
+		And STDERR should be:
+		"""
+		Error: Please specify a valid CSV file with the --file arg.
+		"""
+
+	Scenario: Create guest authors from a CSV file
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors.csv`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 2 authors in CSV
+		Processing author jane-doe (jane@example.com)
+		-- Not found; creating profile.
+		Success: -- Created as guest author #
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author bob-builder (bob@example.com)
+		-- Not found; creating profile.
+		Success: -- Created as guest author #
+		"""
+		And STDOUT should contain:
+		"""
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		2
+		"""
+		When I run `wp post list --post_type=guest-author --field=post_name --order=asc --orderby=ID`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		cap-bob-builder
+		"""
+		# Scoped to the profile just created, not to the slug: a term-slug lookup would
+		# pass on residue from an earlier feature or an earlier run.
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=jane-doe --format=ids`
+		And save STDOUT as {JANE_ID}
+		And STDOUT should not be empty
+		And I run `wp term list author --object_ids={JANE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+
+	Scenario: First and last names are split from the display name when both name columns are empty
+		Given I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors.csv`
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=jane-doe --format=ids`
+		And save STDOUT as {JANE_ID}
+		And I run `wp post meta list {JANE_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{JANE_ID},cap-display_name,"Jane Doe"
+		{JANE_ID},cap-first_name,Jane
+		{JANE_ID},cap-last_name,Doe
+		{JANE_ID},cap-user_login,jane-doe
+		{JANE_ID},cap-user_email,jane@example.com
+		{JANE_ID},cap-website,https://example.com/jane
+		{JANE_ID},cap-description,"Jane writes about testing"
+		{JANE_ID},_original_author_login,jane-doe
+		"""
+		# Stated explicitly as well as implied by the block above: this command never
+		# writes `_original_author_id` (the guard reads an `author_id` key it never sets).
+		When I run `wp post meta list {JANE_ID} --keys=_original_author_id --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=bob-builder --format=ids`
+		And save STDOUT as {BOB_ID}
+		And I run `wp post meta get {BOB_ID} cap-first_name`
+		Then STDOUT should be:
+		"""
+		Robert
+		"""
+		When I run `wp post meta get {BOB_ID} cap-last_name`
+		Then STDOUT should be:
+		"""
+		Builder
+		"""
+
+	Scenario: Name columns are dropped when neither splitting branch matches
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-single-name.csv`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 1 authors in CSV
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "first_name"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "last_name"
+		"""
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=prince --format=ids`
+		And save STDOUT as {PRINCE_ID}
+		And I run `wp post meta list {PRINCE_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{PRINCE_ID},cap-display_name,Prince
+		{PRINCE_ID},cap-user_login,prince
+		{PRINCE_ID},cap-user_email,prince@example.com
+		{PRINCE_ID},cap-website,https://example.com/prince
+		{PRINCE_ID},cap-description,"Single name artist"
+		{PRINCE_ID},_original_author_login,prince
+		"""
+		# A row with exactly ONE of first_name/last_name filled matches neither branch
+		# either, so the supplied "Halfy" is silently discarded even though the display
+		# name does contain a space.
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-half-named.csv`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Undefined array key "first_name"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "last_name"
+		"""
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=half-named --format=ids`
+		And save STDOUT as {HALF_ID}
+		And I run `wp post meta list {HALF_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{HALF_ID},cap-display_name,"Half Named"
+		{HALF_ID},cap-user_login,half-named
+		{HALF_ID},cap-user_email,half@example.com
+		{HALF_ID},_original_author_login,half-named
+		"""
+
+	Scenario: Every cell is sanitised before the profile is written
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-dirty.csv`
+		Then the return code should be 0
+		# The log line echoes the raw cells, before any sanitisation.
+		And STDOUT should contain:
+		"""
+		Processing author Dirty Login! (DIRTY@Example.com)
+		"""
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		When I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {DIRTY_ID}
+		And I run `wp post meta list {DIRTY_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{DIRTY_ID},cap-display_name,"Dirty Name"
+		{DIRTY_ID},cap-first_name,Dirty
+		{DIRTY_ID},cap-last_name,Name
+		{DIRTY_ID},cap-user_login,"Dirty Login!"
+		{DIRTY_ID},cap-user_email,DIRTY@Example.com
+		{DIRTY_ID},cap-website,http://example.com/x?a=1&b=2
+		{DIRTY_ID},cap-description,alert(1)<em>Bio</em>
+		{DIRTY_ID},_original_author_login,"Dirty Login!"
+		"""
+		When I run `wp post get {DIRTY_ID} --field=post_name`
+		Then STDOUT should be:
+		"""
+		cap-dirty-login
+		"""
+
+	Scenario: A CSV header that omits columns warns for every missing key but still imports
+		# The fixture's header also ends in a nameless column whose row cell holds a
+		# value; the exact meta block below shows that cell is dropped rather than
+		# stored under an empty key.
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-missing-columns.csv`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 1 authors in CSV
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "user_email"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "website"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "description"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "avatar"
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author casey-missing ()
+		"""
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		When I run `wp post list --post_type=guest-author --format=ids`
+		And save STDOUT as {CASEY_ID}
+		And I run `wp post meta list {CASEY_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{CASEY_ID},cap-display_name,"Casey Missing"
+		{CASEY_ID},cap-first_name,Casey
+		{CASEY_ID},cap-last_name,Missing
+		{CASEY_ID},cap-user_login,casey-missing
+		{CASEY_ID},_original_author_login,casey-missing
+		"""
+
+	Scenario: A row that fails validation is warned about and the import carries on
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-invalid-row.csv`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 2 authors in CSV
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author no-display-name (nodisplay@example.com)
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: -- Failed to create guest author: display_name is a required field
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author valid-person (valid@example.com)
+		"""
+		And STDOUT should contain:
+		"""
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+		When I run `wp post list --post_type=guest-author --field=post_name`
+		Then STDOUT should be:
+		"""
+		cap-valid-person
+		"""
+
+	Scenario: A CSV file with only a header row creates nothing
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-header-only.csv`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Found 0 authors in CSV
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Importing the same CSV file twice skips the existing guest authors
+		Given I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors.csv`
+		And I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=jane-doe --format=ids`
+		And save STDOUT as {JANE_ID}
+		And STDOUT should not be empty
+		And I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=bob-builder --format=ids`
+		And save STDOUT as {BOB_ID}
+		And STDOUT should not be empty
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors.csv`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Found 2 authors in CSV
+		Processing author jane-doe (jane@example.com)
+		Warning: -- Author already exists (ID #{JANE_ID}); skipping.
+		Processing author bob-builder (bob@example.com)
+		Warning: -- Author already exists (ID #{BOB_ID}); skipping.
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		2
+		"""

--- a/features/create-guest-authors-from-wxr.feature
+++ b/features/create-guest-authors-from-wxr.feature
@@ -1,0 +1,204 @@
+Feature: Guest authors can be created from the author nodes of a WXR file
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		# Author terms survive the Behat reset, so wipe them: a leftover `cap-*` term
+		# would otherwise satisfy the term assertions below without the command
+		# creating anything, and would be silently reused by CoAuthors_Plus::get_author_term().
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+		# The command `require_once`s wordpress-importer's parsers.php directly, so that
+		# plugin is a hard dependency of every scenario below. It is pinned to 0.9.6
+		# because the crash characterised further down belongs to that release's parser
+		# fallback chain; the assertion makes a failed download fail here, legibly,
+		# rather than as a confusing fatal inside the command under test.
+		And I run `wp plugin install wordpress-importer --version=0.9.6`
+		And I run `wp plugin get wordpress-importer --field=version`
+		And STDOUT should be:
+		"""
+		0.9.6
+		"""
+
+	Scenario: Error on a missing required --file parameter
+		When I try `wp co-authors-plus create-guest-authors-from-wxr`
+		Then the return code should be 1
+		And STDERR should contain:
+		"""
+		missing --file parameter
+		"""
+
+	Scenario: Error on a file that cannot be read
+		When I try `wp co-authors-plus create-guest-authors-from-wxr --file=no-such-file.wxr`
+		Then the return code should be 1
+		And STDERR should be:
+		"""
+		Error: Please specify a valid WXR file with the --file arg.
+		"""
+
+	Scenario: Fatal error when the wordpress-importer plugin is not installed
+		Given I run `wp plugin uninstall wordpress-importer --deactivate`
+		When I try `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`
+		Then the return code should be 1
+		# The container path and PHP's exact wording belong to the runtime, not to CAP,
+		# so only the require_once of the importer's parsers.php is pinned.
+		And STDERR should match #require_once\(.*/wordpress-importer/parsers\.php\)#
+		And STDOUT should match #Failed opening required '.*/wordpress-importer/parsers\.php'#
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		# Put the pinned importer back so that scenario order in this file is not
+		# load-bearing: the reset between scenarios does not restore plugins.
+		When I run `wp plugin install wordpress-importer --version=0.9.6`
+		And I run `wp plugin get wordpress-importer --field=version`
+		Then STDOUT should be:
+		"""
+		0.9.6
+		"""
+
+	Scenario: Create guest authors from the author nodes of a WXR file
+		When I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Processing author wxr-jane (wxr-jane@example.com)
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "website"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "description"
+		"""
+		And STDOUT should contain:
+		"""
+		Undefined array key "avatar"
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author wxr-bob (wxr-bob@example.com)
+		-- Not found; creating profile.
+		"""
+		And STDOUT should contain:
+		"""
+		Success: -- Created as guest author #
+		"""
+		And STDOUT should contain:
+		"""
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		2
+		"""
+		When I run `wp post list --post_type=guest-author --field=post_name --order=asc --orderby=ID`
+		Then STDOUT should be:
+		"""
+		cap-wxr-jane
+		cap-wxr-bob
+		"""
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=wxr-jane --format=ids`
+		And save STDOUT as {JANE_ID}
+		And STDOUT should not be empty
+		And I run `wp post meta list {JANE_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{JANE_ID},cap-display_name,"WXR Jane"
+		{JANE_ID},cap-first_name,WXR
+		{JANE_ID},cap-last_name,Jane
+		{JANE_ID},cap-user_login,wxr-jane
+		{JANE_ID},cap-user_email,wxr-jane@example.com
+		{JANE_ID},_original_author_login,wxr-jane
+		"""
+		# Stated explicitly as well as implied by the block above: the `_original_author_id`
+		# guard tests `isset( $author['author_id'] )` while this flow passes the WXR
+		# author ID under the key `ID`, so the meta is never written.
+		When I run `wp post meta list {JANE_ID} --keys=_original_author_id --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		# Scoped to the profile just created, not to the slug: a term-slug lookup would
+		# pass on residue from an earlier feature or an earlier run.
+		When I run `wp term list author --object_ids={JANE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-wxr-jane
+		"""
+		# The second author gets exactly the same treatment.
+		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=wxr-bob --format=ids`
+		And save STDOUT as {BOB_ID}
+		And STDOUT should not be empty
+		And I run `wp post meta list {BOB_ID} --format=csv`
+		Then STDOUT should be:
+		"""
+		post_id,meta_key,meta_value
+		{BOB_ID},cap-display_name,"WXR Bob"
+		{BOB_ID},cap-first_name,WXR
+		{BOB_ID},cap-last_name,Bob
+		{BOB_ID},cap-user_login,wxr-bob
+		{BOB_ID},cap-user_email,wxr-bob@example.com
+		{BOB_ID},_original_author_login,wxr-bob
+		"""
+		When I run `wp term list author --object_ids={BOB_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-wxr-bob
+		"""
+
+	Scenario: A WXR file with no author nodes creates nothing
+		When I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/no-authors.wxr`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Importing the same WXR file twice skips the existing guest authors
+		Given I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`
+		And I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=wxr-jane --format=ids`
+		And save STDOUT as {JANE_ID}
+		And STDOUT should not be empty
+		And I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=wxr-bob --format=ids`
+		And save STDOUT as {BOB_ID}
+		And STDOUT should not be empty
+		When I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Processing author wxr-jane (wxr-jane@example.com)
+		Warning: -- Author already exists (ID #{JANE_ID}); skipping.
+		Processing author wxr-bob (wxr-bob@example.com)
+		Warning: -- Author already exists (ID #{BOB_ID}); skipping.
+		All done!
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		2
+		"""
+
+	Scenario: Fatal error in the importer when the file is not a WXR file
+		When I try `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/not-a-wxr.xml`
+		Then the return code should be 1
+		# The crash comes from wordpress-importer 0.9.6's parser fallback chain, so only
+		# the fact that CAP dies inside that plugin is pinned, not the class or file.
+		And STDOUT should match /Fatal error/
+		And STDOUT should match /wordpress-importer/
+		# CAP's own `Failed to read WXR file.` branch is unreachable: the parser fatals
+		# rather than returning a WP_Error.
+		And STDERR should not match /Failed to read WXR file/
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""

--- a/features/create-terms-for-posts.feature
+++ b/features/create-terms-for-posts.feature
@@ -1,0 +1,223 @@
+Feature: Author terms can be created for all posts
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Succeed cleanly when there are no posts
+		When I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 0 total posts.
+		Updating author terms with new counts
+		Success: Done! Of 0 posts, 0 now have author terms.
+		"""
+
+	Scenario: Add author terms to posts that are missing them, then skip them on a second run
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 2 total posts.
+		No co-authors found for post #{POST_A}.
+		1/2) Added - Post #{POST_A} 'First post' now has an author term for: admin
+		No co-authors found for post #{POST_B}.
+		2/2) Added - Post #{POST_B} 'Second post' now has an author term for: admin
+		Updating author terms with new counts
+		Success: Done! Of 2 posts, 2 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 2 total posts.
+		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: admin
+		2/2) Skipping - Post #{POST_B} 'Second post' already has these terms: admin
+		Updating author terms with new counts
+		Success: Done! Of 2 posts, 0 now have author terms.
+		"""
+
+	Scenario: Skip posts that already have author terms while fixing those without
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 2 total posts.
+		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: admin
+		No co-authors found for post #{POST_B}.
+		2/2) Added - Post #{POST_B} 'Second post' now has an author term for: admin
+		Updating author terms with new counts
+		Success: Done! Of 2 posts, 1 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_B} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: Pages are inspected by default
+		When I run `wp post create --post_type=page --post_title="About page" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {PAGE_ID}
+		And I run `wp post term remove {PAGE_ID} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 1 total posts.
+		No co-authors found for post #{PAGE_ID}.
+		1/1) Added - Post #{PAGE_ID} 'About page' now has an author term for: admin
+		Updating author terms with new counts
+		Success: Done! Of 1 posts, 1 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: The author term reflects the post author rather than always being admin
+		When I run `wp user create writer writer@example.com --role=author --porcelain`
+		And save STDOUT as {USER_ID}
+		And I run `wp post create --post_title="Writer post" --post_status=publish --post_author={USER_ID} --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 1 total posts.
+		No co-authors found for post #{POST_ID}.
+		1/1) Added - Post #{POST_ID} 'Writer post' now has an author term for: writer
+		Updating author terms with new counts
+		Success: Done! Of 1 posts, 1 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-writer
+		"""
+
+	Scenario: A post whose author does not exist is reported as updated even though no term is set
+		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should contain:
+		"""
+		Now inspecting or updating 1 total posts.
+		"""
+		And STDOUT should contain:
+		"""
+		No co-authors found for post #{POST_ID}.
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: Attempt to read property "slug" on false
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: Attempt to read property "user_nicename" on false
+		"""
+		And STDOUT should match #^1/1\) Added - Post \#\d+ 'Orphan post' now has an author term for: ?$#m
+		And STDOUT should contain:
+		"""
+		Success: Done! Of 1 posts, 1 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Each post gets an author term for its own author
+		When I run `wp user create alpha alpha@example.com --role=author --porcelain`
+		And save STDOUT as {USER_A}
+		And I run `wp user create beta beta@example.com --role=author --porcelain`
+		And save STDOUT as {USER_B}
+		And I run `wp post create --post_title="Alpha post" --post_status=publish --post_author={USER_A} --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Beta post" --post_status=publish --post_author={USER_B} --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 2 total posts.
+		No co-authors found for post #{POST_A}.
+		1/2) Added - Post #{POST_A} 'Alpha post' now has an author term for: alpha
+		No co-authors found for post #{POST_B}.
+		2/2) Added - Post #{POST_B} 'Beta post' now has an author term for: beta
+		Updating author terms with new counts
+		Success: Done! Of 2 posts, 2 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-alpha
+		"""
+		When I run `wp term list author --object_ids={POST_B} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-beta
+		"""
+
+	Scenario: Draft and private posts are never inspected
+		When I run `wp post create --post_title="Draft post" --post_author=1 --porcelain`
+		And save STDOUT as {DRAFT_ID}
+		And I run `wp post create --post_title="Private post" --post_status=private --post_author=1 --porcelain`
+		And save STDOUT as {PRIVATE_ID}
+		And I run `wp post term remove {DRAFT_ID} author --all`
+		And I run `wp post term remove {PRIVATE_ID} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 0 total posts.
+		Updating author terms with new counts
+		Success: Done! Of 0 posts, 0 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={DRAFT_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp term list author --object_ids={PRIVATE_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: A post whose existing author term is not its post author is left alone
+		When I run `wp user create writer writer@example.com --role=author --porcelain`
+		And I run `wp post create --post_title="Ghostwritten post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus update-author-terms`
+		And I run `wp post term set {POST_ID} author cap-writer --by=slug`
+		And I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-writer
+		"""
+		When I run `wp co-authors-plus create-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 1 total posts.
+		1/1) Skipping - Post #{POST_ID} 'Ghostwritten post' already has these terms: writer
+		Updating author terms with new counts
+		Success: Done! Of 1 posts, 0 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-writer
+		"""

--- a/features/fixtures/guest-authors-dirty.csv
+++ b/features/fixtures/guest-authors-dirty.csv
@@ -1,0 +1,2 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name
+<b>Dirty</b> Name,Dirty Login!,DIRTY@Example.com,example.com/x?a=1&b=2,<script>alert(1)</script><em>Bio</em>,abc,,

--- a/features/fixtures/guest-authors-half-named.csv
+++ b/features/fixtures/guest-authors-half-named.csv
@@ -1,0 +1,2 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name
+Half Named,half-named,half@example.com,,,0,Halfy,

--- a/features/fixtures/guest-authors-header-only.csv
+++ b/features/fixtures/guest-authors-header-only.csv
@@ -1,0 +1,1 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name

--- a/features/fixtures/guest-authors-invalid-row.csv
+++ b/features/fixtures/guest-authors-invalid-row.csv
@@ -1,0 +1,3 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name
+,no-display-name,nodisplay@example.com,,,0,,
+Valid Person,valid-person,valid@example.com,,,0,,

--- a/features/fixtures/guest-authors-missing-columns.csv
+++ b/features/fixtures/guest-authors-missing-columns.csv
@@ -1,0 +1,2 @@
+display_name,user_login,
+Casey Missing,casey-missing,ignored

--- a/features/fixtures/guest-authors-single-name.csv
+++ b/features/fixtures/guest-authors-single-name.csv
@@ -1,0 +1,2 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name
+Prince,prince,prince@example.com,https://example.com/prince,Single name artist,0,,

--- a/features/fixtures/guest-authors.csv
+++ b/features/fixtures/guest-authors.csv
@@ -1,0 +1,3 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name
+Jane Doe,jane-doe,jane@example.com,https://example.com/jane,Jane writes about testing,0,,
+Bob Builder,bob-builder,bob@example.com,https://example.com/bob,Bob builds test fixtures,0,Robert,Builder

--- a/features/fixtures/guest-authors.wxr
+++ b/features/fixtures/guest-authors.wxr
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+	<title>Guest Author Fixture</title>
+	<link>https://example.com</link>
+	<description>Minimal WXR fixture for create-guest-authors-from-wxr</description>
+	<pubDate>Mon, 01 Sep 2025 00:00:00 +0000</pubDate>
+	<language>en-US</language>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://example.com</wp:base_site_url>
+	<wp:base_blog_url>https://example.com</wp:base_blog_url>
+	<wp:author>
+		<wp:author_id>101</wp:author_id>
+		<wp:author_login><![CDATA[wxr-jane]]></wp:author_login>
+		<wp:author_email><![CDATA[wxr-jane@example.com]]></wp:author_email>
+		<wp:author_display_name><![CDATA[WXR Jane]]></wp:author_display_name>
+		<wp:author_first_name><![CDATA[WXR]]></wp:author_first_name>
+		<wp:author_last_name><![CDATA[Jane]]></wp:author_last_name>
+	</wp:author>
+	<wp:author>
+		<wp:author_id>102</wp:author_id>
+		<wp:author_login><![CDATA[wxr-bob]]></wp:author_login>
+		<wp:author_email><![CDATA[wxr-bob@example.com]]></wp:author_email>
+		<wp:author_display_name><![CDATA[WXR Bob]]></wp:author_display_name>
+		<wp:author_first_name><![CDATA[WXR]]></wp:author_first_name>
+		<wp:author_last_name><![CDATA[Bob]]></wp:author_last_name>
+	</wp:author>
+</channel>
+</rss>

--- a/features/fixtures/no-authors.wxr
+++ b/features/fixtures/no-authors.wxr
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+	<title>Guest Author Fixture Without Authors</title>
+	<link>https://example.com</link>
+	<description>WXR fixture with no wp:author nodes</description>
+	<pubDate>Mon, 01 Sep 2025 00:00:00 +0000</pubDate>
+	<language>en-US</language>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://example.com</wp:base_site_url>
+	<wp:base_blog_url>https://example.com</wp:base_blog_url>
+</channel>
+</rss>

--- a/features/fixtures/not-a-wxr.xml
+++ b/features/fixtures/not-a-wxr.xml
@@ -1,0 +1,1 @@
+This is not a WXR file. It exists only to exercise the importer failure path.

--- a/features/fixtures/reassign-author-mapping.php
+++ b/features/fixtures/reassign-author-mapping.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Author-mapping fixture for the reassign-terms Behat characterisation scenarios.
+ *
+ * The reassign-terms subcommand documents an --author-mapping=<file> flag whose
+ * file is expected to define $cli_user_map (old user_login => new user_login).
+ * See php/class-wp-cli.php reassign_terms().
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+$cli_user_map = array(
+	'olduser' => 'newuser',
+);

--- a/features/list-posts-without-terms.feature
+++ b/features/list-posts-without-terms.feature
@@ -1,0 +1,91 @@
+Feature: Posts without author terms can be listed
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+
+	Scenario: No output when there are no posts
+		When I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should be empty
+		And the return code should be 0
+		And STDERR should be empty
+
+	Scenario: No output when every post has an author term
+		When I run `wp post create --post_title="Authored post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should be empty
+		And the return code should be 0
+		And STDERR should be empty
+
+	Scenario: A post without author terms is printed as a CSV line
+		When I run `wp post create --post_title="Alpha post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should contain:
+		"""
+		"{POST_ID}","Alpha post","
+		"""
+		And STDOUT should match #^"\d+","Alpha post","[^"]+","\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"$#m
+		When I run `wp term list author --object_ids={POST_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Every post without author terms is listed, in ascending post ID order
+		When I run `wp post create --post_title="Alpha post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Beta post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should contain:
+		"""
+		"{POST_A}","Alpha post","
+		"""
+		And STDOUT should contain:
+		"""
+		"{POST_B}","Beta post","
+		"""
+		And STDOUT should match #"Alpha post".*\n.*"Beta post"#
+		And STDOUT should not match #"Beta post".*\n.*"Alpha post"#
+		And the return code should be 0
+
+	Scenario: Pages are only listed with --post_type=page
+		When I run `wp post create --post_type=page --post_title="About page" --post_status=publish --porcelain`
+		And save STDOUT as {PAGE_ID}
+		And I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should be empty
+		And the return code should be 0
+		And STDERR should be empty
+		When I run `wp co-authors-plus list-posts-without-terms --post_type=page`
+		Then STDOUT should contain:
+		"""
+		"{PAGE_ID}","About page","
+		"""
+
+	Scenario: Post titles are passed through addslashes
+		When I run `wp post create --post_title="No Man's Sky" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should contain:
+		"""
+		"{POST_ID}","No Man\'s Sky","
+		"""
+
+	Scenario: Draft posts are not listed even though they have no author terms
+		When I run `wp post create --post_title="Draft post" --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp term list author --object_ids={POST_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should be empty
+		And the return code should be 0
+		And STDERR should be empty

--- a/features/migrate-author-terms.feature
+++ b/features/migrate-author-terms.feature
@@ -1,0 +1,158 @@
+Feature: Legacy author terms can be migrated to prefixed slugs
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Report when there are no author terms to migrate
+		When I run `wp co-authors-plus migrate-author-terms`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Now migrating up to 0 terms
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+
+	Scenario: Prefix an unprefixed author term
+		When I run `wp term create author someone --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term someone ({TERM_ID}) isn't prefixed, adding one
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-someone
+		"""
+
+	Scenario: The term name keeps its original value when the slug is prefixed
+		When I run `wp term create author "Legacy Author" --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term legacy-author ({TERM_ID}) isn't prefixed, adding one
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+		When I run `wp term list author --fields=name,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		name,slug
+		"Legacy Author",cap-legacy-author
+		"""
+
+	Scenario: Skip terms that already have the cap- prefix
+		When I run `wp term create author someone --slug=cap-someone --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term cap-someone ({TERM_ID}) is already prefixed, skipping
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-someone
+		"""
+
+	Scenario: Merge a prefixed sibling into the unprefixed term and then prefix it
+		When I run `wp term create author someone --porcelain`
+		And save STDOUT as {BARE_ID}
+		And I run `wp term create author cap-someone --porcelain`
+		And save STDOUT as {PREFIXED_ID}
+		And I run `wp post create --post_title="Merged post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term add {POST_ID} author cap-someone`
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then STDOUT should be:
+		"""
+		Now migrating up to 2 terms
+		Term cap-someone ({PREFIXED_ID}) is already prefixed, skipping
+		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
+		Term someone ({BARE_ID}) isn't prefixed, adding one
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+		When I run `wp term list author --fields=term_id,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		term_id,slug
+		{BARE_ID},cap-someone
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=term_id`
+		Then STDOUT should be:
+		"""
+		{BARE_ID}
+		"""
+
+	Scenario: Running the migration twice only skips already-prefixed terms
+		When I run `wp term create author someone --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		And I run the previous command again
+		Then STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term cap-someone ({TERM_ID}) is already prefixed, skipping
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+
+	Scenario: Same-slug terms in other taxonomies are left alone
+		When I run `wp eval 'foreach ( array( "category", "post_tag" ) as $tax ) { foreach ( array( "guardian", "cap-guardian" ) as $slug ) { $t = get_term_by( "slug", $slug, $tax ); if ( $t ) { wp_delete_term( $t->term_id, $tax ); } } }'`
+		And I run `wp term create category guardian`
+		And I run `wp term create post_tag cap-guardian`
+		And I run `wp term create author guardian --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term guardian ({TERM_ID}) isn't prefixed, adding one
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+		When I run `wp term list post_tag --slug=cap-guardian --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-guardian
+		"""
+		When I run `wp term list category --slug=guardian --field=slug`
+		Then STDOUT should be:
+		"""
+		guardian
+		"""
+		When I run `wp term list author --fields=term_id,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		term_id,slug
+		{TERM_ID},cap-guardian
+		"""
+
+	Scenario: A sibling deleted earlier in the run is still logged as already prefixed
+		When I run `wp term create author "Aaa" --slug=someone --porcelain`
+		And save STDOUT as {BARE_ID}
+		And I run `wp term create author "Zzz" --slug=cap-someone --porcelain`
+		And save STDOUT as {PREFIXED_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Now migrating up to 2 terms
+		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
+		Term someone ({BARE_ID}) isn't prefixed, adding one
+		Term cap-someone ({PREFIXED_ID}) is already prefixed, skipping
+		Success: All done! Grab a cold one (Affogatto)
+		"""
+		When I run `wp term list author --fields=term_id,name,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		term_id,name,slug
+		{BARE_ID},Aaa,cap-someone
+		"""

--- a/features/reassign-terms.feature
+++ b/features/reassign-terms.feature
@@ -1,0 +1,276 @@
+Feature: Author terms can be reassigned between co-authors
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Rename an old term when the new term does not exist yet
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Success: Converted 'olduser' term to 'newuser'
+		Reassignment complete. Here are your results:
+		- 1 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --fields=name,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		name,slug
+		admin,cap-admin
+		newuser,newuser
+		"""
+		When I run `wp post list --post_type=guest-author --orderby=ID --order=asc --field=post_name`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-olduser
+		"""
+		When I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		Then STDOUT should be:
+		"""
+		Error: Term 'olduser' doesn't exist, skipping
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 1 authors were missing old terms
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		newuser
+		"""
+
+	Scenario: Merge into an existing term and reassign its posts
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp user create newuser newuser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp post create --post_title="Shared post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term add {POST_ID} author cap-olduser`
+		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Success: There's already a 'newuser' term for 'olduser'. Reassigning 1 posts and then deleting the term
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 1 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-newuser
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-newuser
+		"""
+		When I run `wp post list --post_type=guest-author --orderby=ID --order=asc --field=post_name`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-newuser
+		cap-olduser
+		"""
+
+	Scenario: Reassigning a term to itself deletes the term and orphans its posts
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp post create --post_title="Owned post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term add {POST_ID} author cap-olduser`
+		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=olduser`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Success: There's already a 'olduser' term for 'olduser'. Reassigning 1 posts and then deleting the term
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 1 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be empty
+		And the return code should be 0
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: A numeric --new_term is resolved to that user's login
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp user create newuser newuser@example.com --role=author --porcelain`
+		And save STDOUT as {NEWUSER_ID}
+		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term={NEWUSER_ID}`
+		Then STDOUT should be:
+		"""
+		Success: Converted 'olduser' term to 'newuser'
+		Reassignment complete. Here are your results:
+		- 1 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		newuser
+		"""
+
+	Scenario: A numeric --new_term for an unknown user id is not resolved
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I try `wp co-authors-plus reassign-terms --old_term=olduser --new_term=999999`
+		Then the return code should be 0
+		And STDERR should contain:
+		"""
+		Attempt to read property "user_login" on false
+		"""
+		And STDOUT should contain:
+		"""
+		Reassignment complete. Here are your results:
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-olduser
+		"""
+
+	Scenario: A target slug already taken by another term still reports success
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp term create author newuser --porcelain`
+		And save STDOUT as {EXISTING_ID}
+		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Success: Converted 'olduser' term to 'newuser'
+		Reassignment complete. Here are your results:
+		- 1 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		newuser
+		cap-olduser
+		"""
+
+	Scenario: A missing old term is reported and skipped without an error exit
+		When I run `wp co-authors-plus reassign-terms --old_term=ghost --new_term=whatever`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Error: Term 'ghost' doesn't exist, skipping
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 1 authors were missing old terms
+		"""
+		When I run `wp term create author orphan --porcelain`
+		And save STDOUT as {ORPHAN_ID}
+		And I run `wp co-authors-plus reassign-terms --old_term=orphan --new_term=whatever`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Error: Term 'orphan' doesn't exist, skipping
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 1 authors were missing old terms
+		"""
+		When I run `wp term list author --fields=term_id,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		term_id,slug
+		{ORPHAN_ID},orphan
+		"""
+
+	Scenario: Report empty results when no reassignment arguments are given
+		When I try `wp co-authors-plus reassign-terms`
+		Then the return code should be 0
+		And STDERR should contain:
+		"""
+		Warning: Undefined variable $authors_to_migrate
+		"""
+		And STDERR should contain:
+		"""
+		Warning: foreach() argument must be of type array|object, null given
+		"""
+		And STDOUT should contain:
+		"""
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I try `wp co-authors-plus reassign-terms --old_term=olduser`
+		Then the return code should be 0
+		And STDERR should contain:
+		"""
+		Warning: Undefined variable $authors_to_migrate
+		"""
+		And STDOUT should contain:
+		"""
+		- 0 authors were successfully reassigned terms
+		"""
+
+	Scenario: The documented --author-mapping flag is silently ignored
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I try `wp co-authors-plus reassign-terms --author-mapping=features/fixtures/reassign-author-mapping.php`
+		Then the return code should be 0
+		And STDERR should contain:
+		"""
+		Warning: Undefined variable $authors_to_migrate
+		"""
+		And STDOUT should contain:
+		"""
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		And STDOUT should not match /Converted/
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-olduser
+		"""
+
+	Scenario: A nonexistent --author-mapping file does not trigger the documented error
+		When I try `wp co-authors-plus reassign-terms --author-mapping=features/fixtures/no-such-file.php`
+		Then the return code should be 0
+		And STDERR should not match /author_mapping doesn't exist/
+		And STDERR should contain:
+		"""
+		Warning: Undefined variable $authors_to_migrate
+		"""
+		And STDOUT should contain:
+		"""
+		Reassignment complete. Here are your results:
+		"""
+
+	Scenario: The underscore variant --author_mapping is rejected as an unknown parameter
+		When I try `wp co-authors-plus reassign-terms --author_mapping=features/fixtures/reassign-author-mapping.php`
+		Then the return code should be 1
+		And STDERR should contain:
+		"""
+		unknown --author_mapping parameter
+		"""

--- a/features/remove-terms-from-revisions.feature
+++ b/features/remove-terms-from-revisions.feature
@@ -1,0 +1,158 @@
+Feature: Author terms can be removed from post revisions
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+		And I run `wp co-authors-plus create-guest-authors`
+
+	Scenario: Report when there are no revisions at all
+		When I run `wp co-authors-plus remove-terms-from-revisions`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Found 0 revisions to look through
+		All done! 0 revisions had author terms removed
+		"""
+
+	Scenario: Leave a revision without author terms untouched
+		When I run `wp post create --post_title="Plain post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post update {POST_ID} --post_content="Updated content"`
+		And I run `wp co-authors-plus remove-terms-from-revisions`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Found 1 revisions to look through
+		All done! 0 revisions had author terms removed
+		"""
+
+	Scenario: Remove author terms from a revision while the parent post keeps its terms
+		When I run `wp post create --post_title="First post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term add {POST_ID} author cap-admin`
+		And I run `wp post update {POST_ID} --post_content="Updated content"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_ID} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REVISION_ID}
+		And I run `wp eval 'wp_set_post_terms( {REVISION_ID}, array( "cap-admin" ), "author" );'`
+		And I run `wp post list --post_type=revision --post_status=inherit --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+		When I run `wp co-authors-plus remove-terms-from-revisions`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Found 1 revisions to look through
+		#{REVISION_ID}: Removing cap-admin
+		All done! 1 revisions had author terms removed
+		"""
+		When I run `wp term list author --object_ids={REVISION_ID} --field=slug`
+		Then STDOUT should be empty
+		And the return code should be 0
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_ID} --field=ID`
+		Then STDOUT should be:
+		"""
+		{REVISION_ID}
+		"""
+
+	Scenario: List every removed slug for a revision with multiple author terms
+		When I run `wp term create author alice --slug=cap-alice`
+		And I run `wp post create --post_title="Multi author post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post update {POST_ID} --post_content="Updated content"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_ID} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REVISION_ID}
+		And I run `wp eval 'wp_set_post_terms( {REVISION_ID}, array( "cap-admin", "cap-alice" ), "author" );'`
+		And I run `wp co-authors-plus remove-terms-from-revisions`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 1 revisions to look through
+		"""
+		And STDOUT should match /Removing (cap-admin,cap-alice|cap-alice,cap-admin)/
+		And STDOUT should contain:
+		"""
+		All done! 1 revisions had author terms removed
+		"""
+		When I run `wp term list author --object_ids={REVISION_ID} --field=slug`
+		Then STDOUT should be empty
+		And the return code should be 0
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-alice
+		"""
+
+	Scenario: Only revisions with author terms count as affected
+		When I run `wp post create --post_title="Untouched post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post update {POST_A} --post_content="Updated content A"`
+		And I run `wp post create --post_title="Tagged post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post update {POST_B} --post_content="Updated content B"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_B} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REV_B}
+		And I run `wp eval 'wp_set_post_terms( {REV_B}, array( "cap-admin" ), "author" );'`
+		And I run `wp co-authors-plus remove-terms-from-revisions`
+		Then STDOUT should be:
+		"""
+		Found 2 revisions to look through
+		#{REV_B}: Removing cap-admin
+		All done! 1 revisions had author terms removed
+		"""
+
+	Scenario: Running the command twice reports nothing left to remove
+		When I run `wp post create --post_title="First post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post update {POST_ID} --post_content="Updated content"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_ID} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REVISION_ID}
+		And I run `wp eval 'wp_set_post_terms( {REVISION_ID}, array( "cap-admin" ), "author" );'`
+		And I run `wp co-authors-plus remove-terms-from-revisions`
+		And I run the previous command again
+		Then STDOUT should be:
+		"""
+		Found 1 revisions to look through
+		All done! 0 revisions had author terms removed
+		"""
+
+	Scenario: Every revision with author terms is counted
+		When I run `wp post create --post_title="Post A" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post update {POST_A} --post_content="Update A"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_A} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REV_A}
+		And I run `wp post create --post_title="Post B" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post update {POST_B} --post_content="Update B"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_B} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REV_B}
+		And I run `wp eval 'wp_set_post_terms( {REV_A}, array( "cap-admin" ), "author" ); wp_set_post_terms( {REV_B}, array( "cap-admin" ), "author" );'`
+		And I run `wp co-authors-plus remove-terms-from-revisions`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 2 revisions to look through
+		"""
+		And STDOUT should contain:
+		"""
+		#{REV_A}: Removing cap-admin
+		"""
+		And STDOUT should contain:
+		"""
+		#{REV_B}: Removing cap-admin
+		"""
+		And STDOUT should contain:
+		"""
+		All done! 2 revisions had author terms removed
+		"""
+		When I run `wp term list author --object_ids={REV_A},{REV_B} --field=slug`
+		Then STDOUT should be empty
+		And the return code should be 0

--- a/features/swap-coauthors.feature
+++ b/features/swap-coauthors.feature
@@ -1,0 +1,336 @@
+Feature: One co-author can be swapped with another on their posts
+
+	# WARNING: outside dry mode the command only makes progress by removing the
+	# cap-<from> term from each matched post and re-running the SAME WP_Query
+	# (php/class-wp-cli.php:770-773 increments `paged` only when `--dry` is set).
+	# Any input that leaves the cap-<from> term in place therefore loops forever:
+	# `--from` equal to `--to`, or a `--from` whose case differs from the stored
+	# user_login. Do NOT characterise those with a live run — the step would hang
+	# until the CI job times out. See .context/phase0-findings.md.
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Error on a missing required --from parameter
+		When I try `wp co-authors-plus swap-coauthors --to=admin`
+		Then STDERR should contain:
+		"""
+		missing --from parameter
+		"""
+		And the return code should be 1
+
+	Scenario: Error on a non-existent --from co-author
+		When I try `wp co-authors-plus swap-coauthors --from=not-a-user --to=also-not-a-user`
+		Then STDERR should be:
+		"""
+		Error: No co-author found for not-a-user
+		"""
+		And STDOUT should be empty
+		And the return code should be 1
+
+	Scenario: Error on a non-existent --to co-author
+		When I try `wp co-authors-plus swap-coauthors --from=admin --to=not-a-user`
+		Then STDERR should be:
+		"""
+		Error: No co-author found for not-a-user
+		"""
+		And STDOUT should be empty
+		And the return code should be 1
+
+	Scenario: Error on an empty --to value
+		When I try `wp co-authors-plus swap-coauthors --from=admin --to=`
+		Then STDERR should be:
+		"""
+		Error: --to param must not be empty
+		"""
+		And STDOUT should be empty
+		And the return code should be 1
+
+	Scenario: Validate --from before an empty --to
+		When I try `wp co-authors-plus swap-coauthors --from=not-a-user --to=`
+		Then STDERR should be:
+		"""
+		Error: No co-author found for not-a-user
+		"""
+		And STDOUT should be empty
+		And the return code should be 1
+
+	Scenario: Swap every matching post and number the log lines
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post two" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_2}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post three" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_3}
+		And I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 3 posts to update.
+		1: Post #{POST_ID_1} has been assigned "author2" as a co-author
+		2: Post #{POST_ID_2} has been assigned "author2" as a co-author
+		3: Post #{POST_ID_3} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run the previous command again
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 0 posts to update.
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1},{POST_ID_2},{POST_ID_3} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		"""
+		When I run `wp post get {POST_ID_1} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR2_ID}
+		"""
+		When I run `wp term list author --slug=cap-author1 --format=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+
+	Scenario: Preserve other co-authors when swapping
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp user create author3 author3@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR3_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Shared post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		# Deliberate cross-command dependency: assign-user-to-coauthor is the only CLI
+		# route to a second co-author that goes through add_coauthors(), which is what
+		# swap-coauthors then has to preserve. `wp post term add` would attach the term
+		# without touching post_author, so it would not exercise the same state.
+		And I run `wp co-authors-plus assign-user-to-coauthor --user_login=author1 --coauthor=author3 --append_coauthors`
+		And I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		cap-author3
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		cap-author3
+		"""
+		When I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR3_ID}
+		"""
+
+	Scenario: Preview with --dry, where only 0 and a valueless flag swap for real
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		And I run `wp term list author --slug=cap-author2 --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry=true`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID_1} will be assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry=false`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID_1} will be assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp post get {POST_ID_1} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""
+		When I run `wp term list author --slug=cap-author2 --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry`
+		Then STDOUT should contain:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID_1} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		"""
+		When I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post two" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_2}
+		And I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry=0`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID_2} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID_2} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		"""
+		When I run `wp post get {POST_ID_2} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR2_ID}
+		"""
+
+	Scenario: Swap only within the given --post_type
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="A post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post create --post_type=page --post_author={AUTHOR1_ID} --post_title="A page" --post_status=publish --porcelain`
+		And save STDOUT as {PAGE_ID}
+		And I run `wp term list author --object_ids={PAGE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --post_type=page`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{PAGE_ID} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		"""
+		When I run `wp post get {PAGE_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR2_ID}
+		"""
+
+	Scenario: Ignore posts the swap query cannot reach
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Draft post" --post_status=draft --porcelain`
+		And save STDOUT as {DRAFT_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Termless post" --post_status=publish --porcelain`
+		And save STDOUT as {TERMLESS_ID}
+		And I run `wp post term remove {TERMLESS_ID} author cap-author1 --by=slug`
+		And I run `wp term list author --object_ids={DRAFT_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp term list author --object_ids={TERMLESS_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 0 posts to update.
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={DRAFT_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+		When I run `wp post get {DRAFT_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""
+		When I run `wp term list author --object_ids={TERMLESS_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp post get {TERMLESS_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""
+
+	Scenario: Swap to a guest author with no linked account
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com --first_name=Jane --last_name=Doe --website=https://example.com/jane --description="Jane writes about testing"`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus swap-coauthors --from=author1 --to=jane-doe`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to jane-doe
+		Found 1 posts to update.
+		1: Post #{POST_ID} has been assigned "jane-doe" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+		When I run `wp post get {POST_ID} --field=post_author`
+		Then STDOUT should be:
+		"""
+		{AUTHOR1_ID}
+		"""

--- a/features/testing.feature
+++ b/features/testing.feature
@@ -8,3 +8,72 @@
       """
       Manage co-authors and guest authors.
       """
+
+  Scenario: All expected subcommands remain registered
+    Given a WP installation with the Co-Authors Plus plugin
+
+    When I run `wp co-authors-plus --help`
+    Then STDOUT should contain:
+      """
+      assign-coauthors
+      """
+    And STDOUT should contain:
+      """
+      assign-user-to-coauthor
+      """
+    And STDOUT should contain:
+      """
+      create-author
+      """
+    And STDOUT should contain:
+      """
+      create-author-terms-for-posts
+      """
+    And STDOUT should contain:
+      """
+      create-guest-authors
+      """
+    And STDOUT should contain:
+      """
+      create-guest-authors-from-csv
+      """
+    And STDOUT should contain:
+      """
+      create-guest-authors-from-wxr
+      """
+    And STDOUT should contain:
+      """
+      create-terms-for-posts
+      """
+    And STDOUT should contain:
+      """
+      delete-postmeta-that-skip-author-term-backfill
+      """
+    And STDOUT should contain:
+      """
+      list-posts-without-terms
+      """
+    And STDOUT should contain:
+      """
+      migrate-author-terms
+      """
+    And STDOUT should contain:
+      """
+      reassign-terms
+      """
+    And STDOUT should contain:
+      """
+      remove-terms-from-revisions
+      """
+    And STDOUT should contain:
+      """
+      rename-coauthor
+      """
+    And STDOUT should contain:
+      """
+      swap-coauthors
+      """
+    And STDOUT should contain:
+      """
+      update-author-terms
+      """

--- a/features/update-author-terms.feature
+++ b/features/update-author-terms.feature
@@ -1,0 +1,154 @@
+Feature: Author terms can be recounted and recreated
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: An author term is created for a user without one
+		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 0 terms
+		Created author term for admin
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+
+	Scenario: An existing term is recounted and refreshed
+		When I run `wp post create --post_title="A post" --post_status=publish --post_author=1 --porcelain`
+		And I run `wp term list author --slug=cap-admin --field=term_id`
+		And save STDOUT as {TERM_ID}
+		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 1 terms
+		Term cap-admin ({TERM_ID}) changed from 1 to 1 and the description was refreshed
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+		When I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+
+	Scenario: A stale term count is corrected in the database but the log reports the stale value
+		When I run `wp post create --post_title="A post" --post_status=publish --post_author=1 --porcelain`
+		And I run `wp term list author --slug=cap-admin --field=term_id`
+		And save STDOUT as {TERM_ID}
+		And I run `wp eval '$t = get_term_by( "slug", "cap-admin", "author" ); global $wpdb; $wpdb->update( $wpdb->term_taxonomy, array( "count" => 5 ), array( "term_taxonomy_id" => $t->term_taxonomy_id ) );'`
+		And I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		5
+		"""
+		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 1 terms
+		Term cap-admin ({TERM_ID}) changed from 5 to 5 and the description was refreshed
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+		When I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+
+	Scenario: A term without a matching co-author is still reported as refreshed
+		When I run `wp term create author ghost --slug=cap-ghost --porcelain`
+		And save STDOUT as {TERM_ID}
+		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 1 terms
+		Term cap-ghost ({TERM_ID}) changed from 0 to 0 and the description was refreshed
+		Created author term for admin
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-ghost
+		"""
+
+	Scenario: The description of an existing term is rewritten from the co-author's searchable fields
+		When I run `wp term create author admin --slug=cap-admin --description="stale description" --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 1 terms
+		Term cap-admin ({TERM_ID}) changed from 0 to 0 and the description was refreshed
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+		When I run `wp term get author {TERM_ID} --field=description`
+		Then STDOUT should match #^admin {3}admin 1 \S+@\S+$#
+		And STDOUT should not match /stale description/
+
+	Scenario: An author term is created for every user, including one who has never authored a post
+		When I run `wp user create zsub zsub@example.com --role=subscriber --porcelain`
+		And I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 0 terms
+		Created author term for admin
+		Created author term for zsub
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-zsub
+		"""
+
+	Scenario: Guest authors created via the CLI are drafts and invisible to the guest author pass
+		When I run `wp co-authors-plus create-guest-authors`
+		And I run `wp post list --post_type=guest-author --fields=post_name,post_status --format=csv`
+		Then STDOUT should be:
+		"""
+		post_name,post_status
+		cap-admin,draft
+		"""
+		When I run `wp term list author --slug=cap-admin --field=term_id`
+		And save STDOUT as {TERM_ID}
+		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 1 terms
+		Term cap-admin ({TERM_ID}) changed from 0 to 0 and the description was refreshed
+		Now inspecting or updating 0 Guest Authors.
+		Success: All done
+		"""
+
+	Scenario: An author term is created for a published guest author without one
+		When I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Guest One", "user_login" => "guest-one" ) );'`
+		And save STDOUT as {GA_ID}
+		And I run `wp post update {GA_ID} --post_status=publish`
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 0 terms
+		Created author term for admin
+		Now inspecting or updating 1 Guest Authors.
+		Created author term for Guest Author guest-one
+		Success: All done
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-guest-one
+		"""


### PR DESCRIPTION
## Summary

Every `wp co-authors-plus` subcommand lives in one `CoAuthorsPlus_Command` class
(`php/class-wp-cli.php`), and we plan to split that into one class per command with
extracted services for 4.2.0, in line with our plugin standards. The obstacle was
evidence: only three of the sixteen subcommands had any behavioural coverage, so
there was no way to demonstrate that such a refactor preserved behaviour. This PR
builds that evidence first, and changes no runtime code.

It adds Behat characterisation tests for the thirteen uncovered subcommands, taking
the suite from 21 scenarios to 140 (1568 steps). Two design choices are deliberate
and worth understanding before reviewing. The tests exercise the `wp ...` string
interface rather than the PHP class, because the class is precisely what is about to
move — a test calling the command methods directly would break on the very change it
exists to guard. For the same reason, no assertion pins a source path or line number,
since the refactor changes both. `features/testing.feature` also gains a registration
guard asserting that all sixteen subcommands remain listed in
`wp co-authors-plus --help`, which is what would fail first if the split dropped one.

Characterisation tests describe what the code does, not what it should do, and doing
this honestly surfaced a number of genuine bugs. They are pinned exactly as they
behave today, so each can be corrected later in its own PR alongside a re-pinned
scenario. The most serious is that a valueless `--dry` on `swap-coauthors` performs a
**real swap**: WP-CLI matches it against the `[--dry=<dry>]` synopsis, warns, discards
the argument, and the `false` default applies — so the most natural way to ask for a
preview mutates the site and exits 0. Relatedly, `--from` equal to `--to` loops
forever, because the query only advances when `--dry` is set; that one is documented
in a comment rather than executed, since a live scenario would hang CI until the job
timed out. Elsewhere, `reassign-terms --author-mapping` is dead code (WP-CLI supplies
the hyphenated key while the code reads `author_mapping`, so the file is never
required), `update-author-terms` never reports its corrected count because
`wp_cache_delete` passes the taxonomy name where core expects the `terms` cache group,
`remove-terms-from-revisions` hardcodes the `author` taxonomy instead of using the
configured one, and `assign-coauthors` defaults `--meta_key` to the undocumented
`_original_import_author`.

`docs/cli-behaviour-notes.md` records all 158 observed behaviours with the reasoning
behind each pinned scenario. It lives in `docs/` (excluded from distributions) and is
the backlog for those follow-up fixes.

## Test plan

- [ ] Behat is green: 140 scenarios, 1568 steps (verified locally against WordPress trunk / PHP 8.4)
- [ ] `git diff` confirms no change under `php/` — runtime code is untouched
- [ ] No assertion references a source file path or line number, so the suite survives the planned move of each command into its own class