### PR TITLE
Pin the byline ordering contract, and stop losing an author on term error

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -267,6 +267,15 @@ class CoAuthors_Plus {
 			'query_var'    => false,
 			'rewrite'      => false,
 			'public'       => false,
+
+			/*
+			 * 'sort' and the 'term_order' args are what make byline order work, so
+			 * do not drop them. 'sort' => true makes wp_set_object_terms() write
+			 * wp_term_relationships.term_order in the order the slugs are passed,
+			 * and 'args' forces every wp_get_object_terms() call for this taxonomy
+			 * to read back in that order. Without the pair, bylines come back in an
+			 * arbitrary order. See AddCoauthorsTest for the round-trip coverage.
+			 */
 			'sort'         => true,
 			'args'         => array( 'orderby' => 'term_order' ),
 			'show_ui'      => false,
@@ -1686,6 +1695,13 @@ class CoAuthors_Plus {
 		// Break the reference, so later writes cannot alias the last element.
 		unset( $author_name );
 
+		/*
+		 * The author taxonomy is registered with 'sort' => true (see
+		 * action_init_late()), and this is a non-append call, so
+		 * wp_set_object_terms() writes wp_term_relationships.term_order in the
+		 * order the slugs are passed here. That is what makes the byline order
+		 * round-trip: the read path orders by term_order ASC.
+		 */
 		wp_set_post_terms( $post_id, $coauthors, $this->coauthor_taxonomy );
 
 		// If the original post_author is no longer assigned,

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -1676,10 +1676,16 @@ class CoAuthors_Plus {
 			$author             = $this->get_coauthor_by( $field, $author_name );
 			$coauthor_objects[] = $author;
 			$term               = $this->update_author_term( $author );
-			if ( is_object( $term ) ) {
+
+			// A WP_Error is an object too, and its ->slug would blank the author.
+			if ( is_object( $term ) && ! is_wp_error( $term ) ) {
 				$author_name = $term->slug;
 			}
 		}
+
+		// Break the reference, so later writes cannot alias the last element.
+		unset( $author_name );
+
 		wp_set_post_terms( $post_id, $coauthors, $this->coauthor_taxonomy );
 
 		// If the original post_author is no longer assigned,

--- a/tests/Integration/Bylines/AddCoauthorsTest.php
+++ b/tests/Integration/Bylines/AddCoauthorsTest.php
@@ -873,6 +873,99 @@ class AddCoauthorsTest extends TestCase {
 	}
 
 	/**
+	 * Confirms that the byline order a caller passes to add_coauthors() survives
+	 * a round-trip through get_coauthors().
+	 *
+	 * The ordering is not implemented in add_coauthors() itself. The author
+	 * taxonomy is registered with 'sort' => true, so wp_set_object_terms()
+	 * writes wp_term_relationships.term_order in the order the slugs are
+	 * passed, and the taxonomy's 'args' force the read path to order by
+	 * term_order ASC. This test pins that contract, because both halves of it
+	 * live in easily-removed registration args (see action_init_late()).
+	 *
+	 * The second assignment deliberately uses a different, non-alphabetic order
+	 * so a passing first assertion cannot be explained by the read path falling
+	 * back to term_taxonomy_id order.
+	 *
+	 * @covers ::add_coauthors
+	 */
+	public function test_add_coauthors_preserves_input_order(): void {
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_author' => $this->editor1->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$first_order = array( $this->author1->user_login, $this->author2->user_login, $this->author3->user_login );
+		$this->assertTrue( $this->_cap->add_coauthors( $post_id, $first_order ) );
+		$this->assertSame( $first_order, $this->get_coauthor_logins( $post_id ) );
+
+		$second_order = array( $this->author3->user_login, $this->author1->user_login, $this->author2->user_login );
+		$this->assertTrue( $this->_cap->add_coauthors( $post_id, $second_order ) );
+		$this->assertSame( $second_order, $this->get_coauthor_logins( $post_id ) );
+	}
+
+	/**
+	 * Confirms that appending co-authors keeps the existing bylines in place and
+	 * adds the new ones after them, even when the appended list repeats an
+	 * author who is already assigned.
+	 *
+	 * Note that add_coauthors() merges the existing and incoming lists itself
+	 * and always calls wp_set_post_terms() in non-append mode, so every
+	 * term_order value is rewritten on each save. The repeated author matters because array_unique()
+	 * preserves keys, so the merged list is left with a gap in its numeric keys.
+	 * Anything that assumes those keys are sequential will mis-order the tail.
+	 *
+	 * @covers ::add_coauthors
+	 */
+	public function test_add_coauthors_appends_after_existing_bylines(): void {
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_author' => $this->editor1->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// Create the three author terms in ascending order first, so that the
+		// byline order asserted below runs counter to term_taxonomy_id order. A
+		// post left with every term_order at 0 sorts by term_taxonomy_id, so
+		// without this the assertion would pass either way.
+		$this->_cap->add_coauthors(
+			$post_id,
+			array( $this->author1->user_login, $this->author2->user_login, $this->author3->user_login )
+		);
+
+		$this->_cap->add_coauthors( $post_id, array( $this->author3->user_login, $this->author2->user_login ) );
+
+		// author2 is already assigned, so array_unique() drops the middle entry
+		// of the merged list and leaves the keys as 0, 1, 3.
+		$this->_cap->add_coauthors( $post_id, array( $this->author2->user_login, $this->author1->user_login ), true );
+
+		$this->assertSame(
+			array( $this->author3->user_login, $this->author2->user_login, $this->author1->user_login ),
+			$this->get_coauthor_logins( $post_id )
+		);
+	}
+
+	/**
+	 * Returns the user_login of each of a post's co-authors, in byline order.
+	 *
+	 * @param int $post_id Post to read.
+	 * @return string[]
+	 */
+	private function get_coauthor_logins( int $post_id ): array {
+		return array_map(
+			function ( $coauthor ) {
+				return $coauthor->user_login;
+			},
+			get_coauthors( $post_id )
+		);
+	}
+
+	/**
 	 * Tests that deleting a user without a co-author term doesn't cause PHP warnings.
 	 *
 	 * @covers ::delete_user_action


### PR DESCRIPTION
## Summary

This came out of reviewing #1346, which set out to fix [#1052](https://github.com/Automattic/co-authors-plus/issues/1052) by writing `wp_term_relationships.term_order` inside `add_coauthors()`. That turned out to be unnecessary: the `author` taxonomy is registered with `'sort' => true`, so `wp_set_object_terms()` already writes `term_order` in the order the slugs are passed, and the taxonomy's `'args' => array( 'orderby' => 'term_order' )` forces every `wp_get_object_terms()` call for the taxonomy to read back in that order. `add_coauthors()` always calls `wp_set_post_terms()` in non-append mode, so core's `! $append` guard is always satisfied. That behaviour has been in core since well before our minimum supported version, WP 6.4.

The uncomfortable part is that nothing in the plugin implements the ordering, and nothing tested it. Both halves of the guarantee live in registration arguments that look inert. `'sort' => true` in particular reads like a stray boolean, and deleting it would break every byline on the site without a single test going red. So rather than adding code core already runs, this pins the contract: two integration tests that fail if either argument is dropped, and comments at both sites explaining why they are load-bearing.

The append case gets its own test because `array_unique()` preserves keys, so the merged co-authors list is left with a gap in its numeric keys. Anything that assumes those keys are sequential will mis-order the tail, which is exactly the trap #1346 fell into. Both tests deliberately assert an order that runs counter to `term_taxonomy_id` order, so a pass cannot be explained by the read path's incidental fallback ordering.

The one genuine fix salvaged from #1346 is the `is_wp_error()` guard. `update_author_term()` returns a `WP_Error` when `wp_insert_term()` fails, and a `WP_Error` is an object, so the existing `is_object()` check happily read `->slug` off it. That yielded `null`, which `wp_set_post_terms()` then dropped, silently losing the author from the byline rather than falling back to the name originally supplied.

Note that this does not close #1052. That report is from June 2024, well after `'sort' => true` landed, so the reported random ordering has some other cause and the write path has been ruled out.

## Test plan

- [ ] `composer test:integration` passes (271 tests).
- [ ] Temporarily set `'sort' => false` in `action_init_late()` and confirm both new tests fail. This is what proves they are not vacuous.
- [ ] Temporarily remove the `'args' => array( 'orderby' => 'term_order' )` entry and confirm the same.