### PR TITLE
Make swap-coauthors --dry-run actually preview the swap

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -93,9 +93,11 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env 2026-09-01; all scenarios green.)
 
-- `--dry` uses the raw string value in a boolean context (php/class-wp-cli.php:690,
-  749), so ANY non-empty value — including `--dry=false` — enables dry-run mode.
-  Pinned in the "Treat --dry=false as a dry run" scenario. Confirmed.
+- ~~`--dry` uses the raw string value in a boolean context, so ANY non-empty
+  value — including `--dry=false` — enables dry-run mode.~~ **FIXED.** The
+  command now declares `[--dry-run]` as a boolean flag per WP-CLI convention and
+  reads it with `Utils\get_flag_value()`. `--dry` remains accepted as a
+  deprecated alias, emitting a notice.
 - When a post has multiple co-authors, the swap rewrites `post_author` to the FIRST
   remaining co-author with a WP user (term-name order from `get_coauthors()`), not
   necessarily the `--to` author, even though the log claims the `--to` author "has
@@ -138,16 +140,16 @@ PHP 8.4) rather than inferred from reading the source.
   case-insensitively, and/or break out when a page yields no removals. A Gherkin
   comment at the top of features/swap-coauthors.feature warns authors off adding such
   a scenario.
-- `--dry` truthiness, now calibrated end to end in "Preview with --dry, where only 0
-  and a valueless flag swap for real": `--dry=true` and `--dry=false` are BOTH
-  previews (any non-empty string is truthy), but `--dry=0` performs a REAL,
-  irreversible swap because PHP treats the string "0" as falsy at :749. Worse, the
-  valueless flag form `--dry` also swaps for real: WP-CLI matches it against the
-  `[--dry=<dry>]` synopsis, prints `Warning: --dry parameter needs a value`, DISCARDS
-  the argument, and the `false` default then applies — so the most natural way to ask
-  for a preview is the one that mutates the site, and it still exits 0. That warning
-  text is WP-CLI's, so the scenario pins only CAP's own lines, via
-  `STDOUT should contain:`.
+- ~~`--dry` truthiness: `--dry=true` and `--dry=false` are BOTH previews, but
+  `--dry=0` and the valueless `--dry` perform a REAL swap — WP-CLI matches the
+  bare flag against the `[--dry=<dry>]` synopsis, warns `--dry parameter needs a
+  value`, DISCARDS it, and the `false` default applies.~~ **FIXED.** This was the
+  worst defect the characterisation pass found: the two most natural ways to ask
+  for a preview both mutated the site and exited 0. `--dry-run` (and the
+  deprecated `--dry`) now preview correctly in their bare form. Following WP-CLI
+  convention, `--dry-run=0` and `--no-dry-run` remain real swaps, since flag
+  values use PHP truthiness and `--no-<flag>` is the documented negation; both
+  are pinned in "Treat --dry-run=0 and --no-dry-run as a real swap".
 - The command is TERM-driven, not `post_author`-driven. A post whose only link to the
   `from` author is `wp_posts.post_author` (its `cap-<from>` term removed) is reported
   as `Found 0 posts to update.` / `Success: All done!` and left untouched — unlike

--- a/features/swap-coauthors.feature
+++ b/features/swap-coauthors.feature
@@ -1,12 +1,12 @@
 Feature: One co-author can be swapped with another on their posts
 
-	# WARNING: outside dry mode the command only makes progress by removing the
-	# cap-<from> term from each matched post and re-running the SAME WP_Query
-	# (php/class-wp-cli.php:770-773 increments `paged` only when `--dry` is set).
-	# Any input that leaves the cap-<from> term in place therefore loops forever:
-	# `--from` equal to `--to`, or a `--from` whose case differs from the stored
-	# user_login. Do NOT characterise those with a live run — the step would hang
-	# until the CI job times out. See .context/phase0-findings.md.
+	# WARNING: outside preview mode the command only makes progress by removing
+	# the cap-<from> term from each matched post and re-running the SAME
+	# WP_Query, as it advances `paged` only when previewing. Any input that
+	# leaves the cap-<from> term in place therefore loops forever: `--from`
+	# equal to `--to`, or a `--from` whose case differs from the stored
+	# user_login. Do NOT characterise those with a live run — the step would
+	# hang until the CI job times out. See docs/cli-behaviour-notes.md.
 
 	Background:
 		Given a WP installation with the Co-Authors Plus plugin
@@ -140,27 +140,13 @@ Feature: One co-author can be swapped with another on their posts
 		{AUTHOR3_ID}
 		"""
 
-	Scenario: Preview with --dry, where only 0 and a valueless flag swap for real
+	Scenario: Preview a swap with --dry-run and change nothing
 		When I run `wp user create author1 author1@example.com --role=author --porcelain`
 		And save STDOUT as {AUTHOR1_ID}
 		And I run `wp user create author2 author2@example.com --role=author --porcelain`
-		And save STDOUT as {AUTHOR2_ID}
 		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID_1}
-		And I run `wp term list author --slug=cap-author2 --format=count`
-		Then STDOUT should be:
-		"""
-		0
-		"""
-		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry=true`
-		Then STDOUT should be:
-		"""
-		Swapping authorship from author1 to author2
-		Found 1 posts to update.
-		1: Post #{POST_ID_1} will be assigned "author2" as a co-author
-		Success: All done!
-		"""
-		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry=false`
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry-run`
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
@@ -183,8 +169,40 @@ Feature: One co-author can be swapped with another on their posts
 		"""
 		0
 		"""
+
+	Scenario: Accept the deprecated --dry flag as a preview, with a notice
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
 		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry`
-		Then STDOUT should contain:
+		Then STDOUT should be:
+		"""
+		Warning: The --dry flag is deprecated; use --dry-run instead.
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID_1} will be assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+
+	# WP-CLI treats a flag's value with PHP truthiness and documents --no-<flag>
+	# as the way to switch one off, so both forms below are real swaps. Pinned so
+	# the distinction stays deliberate rather than becoming a surprise.
+	Scenario: Treat --dry-run=0 and --no-dry-run as a real swap
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR2_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		When I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry-run=0`
+		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
 		Found 1 posts to update.
@@ -198,7 +216,7 @@ Feature: One co-author can be swapped with another on their posts
 		"""
 		When I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post two" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID_2}
-		And I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --dry=0`
+		And I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2 --no-dry-run`
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
@@ -210,11 +228,6 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		cap-author2
-		"""
-		When I run `wp post get {POST_ID_2} --field=post_author`
-		Then STDOUT should be:
-		"""
-		{AUTHOR2_ID}
 		"""
 
 	Scenario: Swap only within the given --post_type

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -672,8 +672,10 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * Swap one co-author with another on all posts for which they are a co-author. Unlike rename-coauthor,
 	 * this leaves the original co-author term intact and works when the 'to' user already has a co-author term.
 	 *
+	 * Pass --dry-run to preview the swap without writing anything.
+	 *
 	 * @subcommand swap-coauthors
-	 * @synopsis --from=<user-login> --to=<user-login> [--post_type=<ptype>] [--dry=<dry>]
+	 * @synopsis --from=<user-login> --to=<user-login> [--post_type=<ptype>] [--dry-run] [--dry]
 	 */
 	public function swap_coauthors( $args, $assoc_args ): void {
 		global $coauthors_plus, $wpdb;
@@ -682,12 +684,19 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			'from'      => null,
 			'to'        => null,
 			'post_type' => 'post',
-			'dry'       => false,
 		);
 
-		$assoc_args = array_merge( $defaults, $assoc_args );
+		// Read the preview flags before defaults are merged in, so that an
+		// absent flag stays absent and can be told apart from an explicit one.
+		$dry = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
 
-		$dry = $assoc_args['dry'];
+		// --dry predates --dry-run and is kept working for existing scripts.
+		if ( null !== \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry', null ) ) {
+			WP_CLI::warning( 'The --dry flag is deprecated; use --dry-run instead.' );
+			$dry = $dry || (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry', false );
+		}
+
+		$assoc_args = array_merge( $defaults, $assoc_args );
 
 		$from_userlogin = $assoc_args['from'];
 		$to_userlogin   = $assoc_args['to'];


### PR DESCRIPTION
## Summary

`swap-coauthors` declared its preview flag as a value parameter, `[--dry=<dry>]`. WP-CLI therefore rejected the bare form: it printed `Warning: --dry parameter needs a value`, discarded the argument, and fell back to the `false` default. So this rewrote bylines across the site and exited 0:

```
wp co-authors-plus swap-coauthors --from=alice --to=bob --dry
```

Truthiness compounded it, because any non-empty string is truthy, so `--dry=true` and `--dry=false` were both previews while `--dry=0` swapped for real. The two most natural ways to ask for a preview were the two that modified data, and anyone who reached for the obvious invocation against a production site made changes they believed they were previewing.

The flag is now declared as a boolean, which is how WP-CLI's own commands express one, and read with `get_flag_value()`. It is spelled `--dry-run` to match that convention, as used by `wp plugin update` and `wp theme update`. `--dry` is kept as a deprecated alias, so existing scripts keep working and, more to the point, start behaving correctly, with a notice pointing at the new name. Removing it outright would be a breaking change to a documented flag, so it stays until the next major. The flags are read before defaults are merged in, which is what lets an absent flag be told apart from an explicit one.

`--dry-run=0` and `--no-dry-run` still perform real swaps. That falls out of flag values using PHP truthiness and `--no-<flag>` being WP-CLI's documented negation, so it is the least surprising behaviour for anyone used to the tool, but both forms are now covered by scenarios so the distinction stays deliberate rather than becoming the next surprise. Reviewers may reasonably disagree here: this command is more destructive than a plugin update, and an argument exists for treating any `--dry*` as a preview. I have followed the convention rather than inventing a local one, and it is easy to change if you would rather fail safe.

This is a behaviour change to a documented flag, but an unambiguous bug fix, and it is backward compatible, so it suits the 4.2.0 minor.

## Test plan

- [ ] `--dry-run` and the deprecated `--dry` both preview, leaving the `cap-<from>` term in place
- [ ] `--dry-run=0`, `--no-dry-run` and no flag at all perform a real swap
- [ ] Behat is green: 142 scenarios, 1580 steps
- [ ] PHPCS on `php/class-wp-cli.php` is unchanged at its 100 pre-existing errors