### PR TITLE
Correct the documented default for coauthors_supported_post_types

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -56,7 +56,11 @@ The Open Graph tags the plugin contributes to the document head.
 
 ### `coauthors_supported_post_types`
 
-Post types that Co-Authors Plus attaches to. Defaults to the list of registered public post types.
+Post types that Co-Authors Plus attaches to. Defaults to every registered post type that supports `author`, minus `revision`, `attachment`, `customize_changeset`, `wp_template` and `wp_template_part`. Note that this is not the same as the public post types: a post type is included on its `author` support alone, whether or not it is public, and a public post type registered without `author` support (WooCommerce's `product`, for example) is not included.
+
+The `author` taxonomy is registered for this list on `init` at priority 100, so a post type must have its `author` support in place by then — `add_post_type_support()` called later leaves the post type out of the taxonomy, and the plugin's author query filters will skip it.
+
+The list is recomputed on every call until `wp_loaded`, then memoised for the remainder of the request. A callback on this filter should therefore not depend on request context that is only settled later, such as the current query or screen.
 
 - **Parameters:** `array $post_types`
 - **File:** `php/class-coauthors-plus.php`


### PR DESCRIPTION
## Summary

`docs/filters.md` describes `coauthors_supported_post_types` as defaulting to "the list of registered public post types". That is wrong in both directions. `supported_post_types()` starts from `get_post_types()` — every registered post type, public or not — and keeps those that support `author`, minus five built-ins. So a private post type with `author` support is included, and a public post type without it is not.

The distinction is not academic. It came up in #1366, where a WooCommerce site expected products to be covered: `product` is public, and is exactly the sort of post type this page implies is supported by default, but WooCommerce registers it without `author` support, so Co-Authors Plus never attaches to it unless the site adds that support itself.

While correcting the default, this also records the two things that catch people out once they do hook the filter. The `author` taxonomy is registered from this list on `init` at priority 100, so `author` support added after that point leaves the post type out of the taxonomy and the author query filters silently skip it. And since #1307 the list is memoised once `wp_loaded` has fired, so a callback that varies with the current query or screen will be frozen to whatever it returned first.

Documentation only — no behaviour change.