### PR TITLE
Stop swap-coauthors running forever on certain inputs

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -122,24 +122,15 @@ PHP 8.4) rather than inferred from reading the source.
   rendering belongs to WP-CLI, not to CAP (and CI installs wp-env, hence WP-CLI,
   unpinned), so a one-class-per-command split that swaps `@synopsis` for a
   `## OPTIONS` docblock must not fail this file.
-- **Unbounded loop — do NOT characterise with a live run.** Outside dry mode the
-  command never advances `paged` (php/class-wp-cli.php:770-773 increments it only
-  `if ( $dry )`); it relies on `add_coauthors()` removing the `cap-<from>` term so the
-  identical `WP_Query` shrinks to zero. Two reachable inputs never remove that term:
-  (a) `--from` === `--to`, where the login is `unset()` from `$coauthors` and
-  immediately re-appended (:751-761) so the same term is rewritten unchanged; and
-  (b) a `--from` whose case differs from the stored `user_login` (e.g. `--from=Author1`)
-  — `get_coauthor_by()` and the slug tax_query both match case-insensitively, but the
-  removal loop compares with `===` at :753. Either way `while ( $posts->post_count )`
-  runs forever, emitting `N: Post #X has been assigned ...` until the process is
-  killed; on CI the job would burn its whole runner allowance (the workflow sets no
-  `timeout-minutes`). A third trigger is the `continue` at :741-743 for a post whose
-  `get_coauthors()` is empty. `rename-coauthor` has an equivalent guard ("New
-  user_login value conflicts with existing co-author"); `swap-coauthors` has none.
-  Candidate fix: error when `$from_userlogin === $to_userlogin`, compare logins
-  case-insensitively, and/or break out when a page yields no removals. A Gherkin
-  comment at the top of features/swap-coauthors.feature warns authors off adding such
-  a scenario.
+- ~~**Unbounded loop.** Outside preview mode the drain loop advances `paged`
+  only when previewing, relying on `add_coauthors()` removing the `cap-<from>`
+  term to make progress; `--from` equal to `--to`, or a `--from` whose case
+  differed from the stored `user_login`, left the term in place and the command
+  ran forever.~~ **FIXED.** The command now works from the resolved co-author
+  logins rather than the raw input, which removes the case-mismatch cause
+  entirely, rejects `--from` equal to `--to` up front, and aborts with a clear
+  error if a page of posts ever comes back unprocessed. Both former triggers are
+  now pinned by scenarios, which are safe to run.
 - ~~`--dry` truthiness: `--dry=true` and `--dry=false` are BOTH previews, but
   `--dry=0` and the valueless `--dry` perform a REAL swap — WP-CLI matches the
   bare flag against the `[--dry=<dry>]` synopsis, warns `--dry parameter needs a

--- a/features/swap-coauthors.feature
+++ b/features/swap-coauthors.feature
@@ -1,12 +1,11 @@
 Feature: One co-author can be swapped with another on their posts
 
-	# WARNING: outside preview mode the command only makes progress by removing
-	# the cap-<from> term from each matched post and re-running the SAME
-	# WP_Query, as it advances `paged` only when previewing. Any input that
-	# leaves the cap-<from> term in place therefore loops forever: `--from`
-	# equal to `--to`, or a `--from` whose case differs from the stored
-	# user_login. Do NOT characterise those with a live run — the step would
-	# hang until the CI job times out. See docs/cli-behaviour-notes.md.
+	# Outside preview mode the command makes progress only by removing the
+	# cap-<from> term from each matched post and re-running the SAME WP_Query,
+	# as it advances `paged` only when previewing. Any input leaving that term
+	# in place would once loop forever; the two known causes are now rejected up
+	# front and a no-progress guard aborts anything else, so the scenarios below
+	# are safe to run. See docs/cli-behaviour-notes.md.
 
 	Background:
 		Given a WP installation with the Co-Authors Plus plugin
@@ -225,6 +224,44 @@ Feature: One co-author can be swapped with another on their posts
 		Success: All done!
 		"""
 		When I run `wp term list author --object_ids={POST_ID_2} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
+		"""
+
+	Scenario: Refuse to swap a co-author with themselves
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		When I try `wp co-authors-plus swap-coauthors --from=author1 --to=author1`
+		Then STDERR should be:
+		"""
+		Error: --from and --to must be different co-authors
+		"""
+		And STDOUT should be empty
+		And the return code should be 1
+		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+
+	Scenario: Resolve a --from whose case differs from the stored user_login
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Post one" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID_1}
+		When I run `wp co-authors-plus swap-coauthors --from=AUTHOR1 --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID_1} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
 		Then STDOUT should be:
 		"""
 		cap-author2

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -701,9 +701,6 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$from_userlogin = $assoc_args['from'];
 		$to_userlogin   = $assoc_args['to'];
 
-		$from_userlogin_prefixed = 'cap-' . $from_userlogin;
-		$to_userlogin_prefixed   = 'cap-' . $to_userlogin;
-
 		$orig_coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $from_userlogin );
 
 		if ( ! $orig_coauthor ) {
@@ -718,6 +715,22 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		if ( ! $to_coauthor ) {
 			WP_CLI::error( "No co-author found for $to_userlogin" );
+		}
+
+		// Work from the resolved logins rather than the raw input. Co-author
+		// lookups are not case sensitive, so "--from=Alice" can resolve to the
+		// co-author stored as "alice"; comparing the raw value against the
+		// stored one would then never match, the term would never be removed,
+		// and the drain loop below would never end.
+		$from_userlogin = $orig_coauthor->user_login;
+		$to_userlogin   = $to_coauthor->user_login;
+
+		$from_userlogin_prefixed = 'cap-' . $from_userlogin;
+
+		// Swapping a co-author with themselves would remove the term and add it
+		// straight back, so the loop below would never drain.
+		if ( $from_userlogin === $to_userlogin ) {
+			WP_CLI::error( '--from and --to must be different co-authors' );
 		}
 
 		WP_CLI::log( "Swapping authorship from {$from_userlogin} to {$to_userlogin}" );
@@ -743,7 +756,27 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		WP_CLI::log( "Found $posts->found_posts posts to update." );
 
+		$previous_first_post_id = null;
+
 		while ( $posts->post_count ) {
+			// Outside preview mode this loop re-runs the same query and relies
+			// on each post losing the "from" term to make progress. If a page
+			// comes back unchanged, that has not happened, so stop rather than
+			// spin forever.
+			$first_post_id = $posts->posts[0]->ID;
+
+			if ( ! $dry && $first_post_id === $previous_first_post_id ) {
+				WP_CLI::error(
+					sprintf(
+						'Post #%d still has the "%s" term after being processed, so the swap cannot make progress. Aborting.',
+						$first_post_id,
+						$from_userlogin_prefixed
+					)
+				);
+			}
+
+			$previous_first_post_id = $first_post_id;
+
 			foreach ( $posts->posts as $post ) {
 				$coauthors = get_coauthors( $post->ID );
 


### PR DESCRIPTION
## Summary

`swap-coauthors` could run forever. Outside preview mode it advances its query only as a side effect: it re-runs the same `WP_Query` and finishes when the matched posts no longer carry the `cap-<from>` author term. Two inputs left that term in place, so the command spun indefinitely, logging as it went, until someone killed it.

Passing the same co-author to `--from` and `--to` removed the login and appended it straight back. A `--from` whose case differed from the stored `user_login` never matched either, because `get_coauthor_by()` resolves a co-author case-insensitively while the removal compared the raw input using `===`. That second case is the more insidious of the two: the `tax_query` still matched, since term slugs are sanitised before the query runs, so the command happily reported how many posts it had found and then collected the same work forever without ever being able to complete it.

The fix works in three layers. Both logins are now taken from the resolved co-author objects rather than the raw input, which removes the case-mismatch cause outright and, incidentally, makes the `Swapping authorship from X to Y` line report what will actually happen. Swapping a co-author with themselves is rejected up front; that check sits after both lookups so the existing order of validation errors is unchanged. Finally, because termination still depends on a side effect, the loop stops with an actionable error if a page of posts comes back unprocessed, so any future cause of this becomes a clear failure rather than a hang.

A dead `$to_userlogin_prefixed` assignment in this method is also removed. The identically named variable in `rename_coauthor` is a separate thing and is untouched.

The feature file previously carried a comment warning contributors *not* to cover these inputs, because a live run would have hung CI until the job timed out. Both are now safe to execute and have scenarios, which felt like the clearest possible confirmation that the fix does what it claims.

**Stacked PR:** this is based on #1372 rather than `develop`, because it changes the same method and the same feature file and would otherwise conflict. GitHub will retarget it to `develop` once #1372 merges, and the diff shown here is only this change.

## Test plan

- [ ] `--from` equal to `--to` fails immediately with a clear error rather than hanging
- [ ] A case-mismatched `--from` resolves to the stored co-author and completes the swap
- [ ] Behat is green: 144 scenarios, 1603 steps
- [ ] PHPCS on `php/class-wp-cli.php` is unchanged at its 100 pre-existing errors