### PR TITLE
Delete every skip postmeta, not just the first ten

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -641,21 +641,15 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
 
 
 - Hardened 2026-09-02 after adversarial review: 6 scenarios for this command.
-- Bare (no `--specific-post-ids`) mode never sees skip metas on unpublished posts.
-  The lookup WP_Query at :315-323 sets only `meta_key` and `fields`, so it
-  inherits `post_type=post` and `post_status=publish`. Now pinned: a DRAFT post
-  given the skip meta by `create-author-terms-for-posts --post-statuses=draft` is
-  invisible to the bare delete, which prints nothing and exits 0 while the meta
-  remains. Same blind spot applies to pages and any other post type.
-- Bare mode also silently caps at `posts_per_page` (the site option, 10 by
-  default), with no warning and no summary. Pinned with 11 posts carrying the
-  meta: exactly 10 `Deleting postmeta key ...` lines are emitted (asserted as
-  match `{10}` plus not-match `{11}`) and 1 post still has the meta afterwards.
-  An operator who backfills 30 pages and then runs the bare delete gets no
-  output, exit 0, and nothing deleted. NB this is deliberately NOT pinned by
-  changing the `posts_per_page` option: the Behat reset clears posts, users,
-  transients and cache but not options, so an option change would leak into every
-  other feature sharing the tests database.
+- ~~Bare (no `--specific-post-ids`) mode never sees skip metas on unpublished
+  posts, nor on pages or other post types, and silently caps at
+  `posts_per_page` (10 by default) with no warning and no summary. An operator
+  who backfills 30 pages and then runs the bare delete gets no output, exit 0,
+  and nothing deleted.~~ **FIXED.** The lookup query set only `meta_key` and
+  `fields`, so it inherited `post_type=post`, `post_status=publish` and the
+  site's `posts_per_page`. It now passes `post_type=any`, `post_status=any` and
+  `posts_per_page=-1`, and both scenarios are re-pinned to the corrected
+  behaviour.
 - The "nothing to delete" scenario now asserts rc 0 and empty STDERR. On its own
   `STDOUT should be empty` is vacuous: the harness moves `Error:`/`Warning:` lines
   into STDERR whenever the exit code is non-zero, so an unregistered subcommand

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -469,7 +469,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And the return code should be 0
 		And STDERR should be empty
 
-	Scenario: The bare delete never sees skip postmeta on unpublished posts
+	Scenario: The bare delete removes skip postmeta from unpublished posts
 		When I run `wp post create --post_title="Orphan draft" --post_author=999 --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp co-authors-plus create-author-terms-for-posts --post-statuses=draft`
@@ -478,16 +478,18 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		"""
 		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
-		Then STDOUT should be empty
+		Then STDOUT should contain:
+		"""
+		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		"""
 		And the return code should be 0
-		And STDERR should be empty
-		When I run `wp post meta get {POST_ID} _cap_skip_backfill`
+		When I run `wp post meta list {POST_ID} --keys=_cap_skip_backfill --format=count`
 		Then STDOUT should be:
 		"""
-		nonexistent_post_author_id
+		0
 		"""
 
-	Scenario: The bare delete only handles the first page of posts carrying skip postmeta
+	Scenario: The bare delete reaches past the first page of results
 		When I run `wp eval 'for ( $i = 0; $i < 11; $i++ ) { $id = wp_insert_post( array( "post_title" => "Skipped $i", "post_status" => "publish", "post_author" => 1 ) ); add_post_meta( $id, "_cap_skip_backfill", "nonexistent_post_author_id", true ); }'`
 		And I run `wp post list --meta_key=_cap_skip_backfill --post_status=any --format=count`
 		Then STDOUT should be:
@@ -496,10 +498,9 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
 		Then the return code should be 0
-		And STDOUT should match #(Deleting postmeta key[\s\S]*?){10}#
-		And STDOUT should not match #(Deleting postmeta key[\s\S]*?){11}#
+		And STDOUT should match #(Deleting postmeta key[\s\S]*?){11}#
 		When I run `wp post list --meta_key=_cap_skip_backfill --post_status=any --format=count`
 		Then STDOUT should be:
 		"""
-		1
+		0
 		"""

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -311,18 +311,22 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function delete_postmeta_skipping_author_term_backfill( $args, $assoc_args ) {
+		global $wpdb;
+
 		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : [];
 
 		if ( empty( $specific_post_ids ) ) {
-			$query = new WP_Query(
-				[
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					'meta_key' => self::SKIP_POST_FOR_BACKFILL_META_KEY,
-					'fields'   => 'ids',
-				]
+			// Read the meta table directly. A WP_Query here inherits
+			// post_type=post, post_status=publish and the site's
+			// posts_per_page, which silently hid the meta on pages, on drafts
+			// and on everything past the first page of results.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$specific_post_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s",
+					self::SKIP_POST_FOR_BACKFILL_META_KEY
+				)
 			);
-
-			$specific_post_ids = $query->get_posts();
 		}
 
 		foreach ( $specific_post_ids as $post_id ) {


### PR DESCRIPTION
## Summary

Run without `--specific-post-ids`, `delete-postmeta-that-skip-author-term-backfill` passed only a meta key and `fields` to `WP_Query`, so it inherited `post_type=post`, `post_status=publish` and the site's `posts_per_page`. Skip postmeta on pages, on drafts, and on anything past the first ten results was therefore invisible to it.

The failure mode is the awkward kind: it looks like success. Backfill thirty pages, run the bare cleanup, and you get no output, exit code 0, and nothing deleted.

`WP_Query` was the wrong tool here, since the `post_type` and `post_status` defaults it brings with it are precisely what caused the problem. The lookup now reads the meta table directly with a prepared query, which is what "every post carrying this meta key" actually means.

Worth flagging for review: that is also a smaller change than correcting the `WP_Query` arguments would have been. I tried the argument route first, and defeating the defaults requires `posts_per_page=-1`, which VIP standards prohibit and which duly added a `WordPressVIPMinimum.Performance.NoPaging` violation. Going to the meta table sidesteps that, and since the removed `WP_Query` also carried two short-array-syntax violations, the file finishes with one fewer coding-standards error than it started with.

The two scenarios that documented the broken behaviour are re-pinned to assert the postmeta is gone in both cases.

## Test plan

- [ ] Give a page and a draft the skip postmeta; the bare cleanup now removes both
- [ ] With eleven posts carrying it, all eleven are deleted rather than ten
- [ ] Behat is green: 149 scenarios, 1638 steps
- [ ] PHPCS on `php/class-wp-cli.php` reports 99 errors, one fewer than before