### PR TITLE
Honour the --author-mapping flag on reassign-terms, and settle the flag naming

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -207,32 +207,20 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 11 scenarios.)
 
-- The documented `--author-mapping=<file>` flag IS dead code: WP-CLI passes the
-  assoc arg under the hyphenated key `author-mapping`, but the method reads
-  `$this->args['author_mapping']` (underscore) after `wp_parse_args`
-  (php/class-wp-cli.php:537-546). The mapping file is never `require`d, and the
-  `author_mapping doesn't exist` error (line 553) is unreachable — even a
-  nonexistent file path is accepted silently. Confirmed: running with a valid
-  mapping fixture still emits `Warning: Undefined variable $authors_to_migrate`
-  (proof the file was not required) and reports an all-zero summary with rc 0.
-  The underscore spelling `--author_mapping` is rejected by WP-CLI synopsis
-  validation (`Error: Parameter errors:` / ` unknown --author_mapping parameter`).
-  Pinned via the three --author-mapping scenarios in features/reassign-terms.feature.
-- Re-calibrated 2026-09-02: WP-CLI's synopsis rejection also prints a third line,
-  `Did you mean '--author-mapping'?`, which the wp-env harness leaves on STDOUT
-  (it is neither `Error:`-prefixed nor indented, so the STDERR splitter stops the
-  error block before it). Now pinned exactly: STDERR is the two-line
-  `Error: Parameter errors:` block, STDOUT is the `Did you mean` suggestion.
-  Ironically WP-CLI names the working spelling of a flag that does nothing.
-- When neither a usable mapping nor `--old_term`/`--new_term` is supplied,
-  `$authors_to_migrate` is never defined, so the `foreach` at line 571 raises PHP
-  warnings on PHP 8+ — yet the command still prints the zero-count summary and
-  exits 0. Confirmed; each warning appears TWICE in combined output (once as a
-  timestamped `[date] PHP Warning:  ...` debug-log echo, once as the
-  `display_errors` copy `Warning: Undefined variable $authors_to_migrate in
-  .../php/class-wp-cli.php on line 571` and `Warning: foreach() argument must be
-  of type array|object, null given ... on line 571`). Pinned exactly (minus the
-  timestamped copies) in the no-args scenario.
+- ~~The documented `--author-mapping=<file>` flag IS dead code: WP-CLI passes
+  the assoc arg under the hyphenated key `author-mapping`, but the method reads
+  `$this->args['author_mapping']` (underscore) after `wp_parse_args`. The
+  mapping file is never `require`d, the `author_mapping doesn't exist` error is
+  unreachable, and even a nonexistent path is accepted silently.~~ **FIXED.**
+  The defaults and the read now use the hyphenated key WP-CLI actually
+  supplies, so the file is loaded, and a missing file reports an error and
+  exits non-zero.
+- ~~When neither a usable mapping nor `--old_term`/`--new_term` is supplied,
+  `$authors_to_migrate` is never defined, so the `foreach` raises PHP warnings
+  on PHP 8+ — yet the command still prints a zero-count summary and exits
+  0.~~ **FIXED.** The variable is initialised, a mapping file that does not
+  define `$cli_user_map` is reported, and the command now errors when it has
+  nothing to reassign rather than pretending to succeed.
 - The rename path (target term absent) sets the surviving term's slug AND name to
   the raw `--new_term` value with NO `cap-` prefix (lines 598-603), inconsistent
   with the plugin's `cap-<nicename>` slug convention. The old guest author profile

--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -215,6 +215,10 @@ PHP 8.4) rather than inferred from reading the source.
   The defaults and the read now use the hyphenated key WP-CLI actually
   supplies, so the file is loaded, and a missing file reports an error and
   exits non-zero.
+- The flag naming in this command was mixed: `--author-mapping` hyphenated
+  alongside `--old_term`/`--new_term` underscored, which is what invited the
+  key-mismatch bug above. `--old-term` and `--new-term` are now the documented
+  spellings; the underscored forms still work but report a deprecation notice.
 - ~~When neither a usable mapping nor `--old_term`/`--new_term` is supplied,
   `$authors_to_migrate` is never defined, so the `foreach` raises PHP warnings
   on PHP 8+ — yet the command still prints a zero-count summary and exits

--- a/features/reassign-terms.feature
+++ b/features/reassign-terms.feature
@@ -7,7 +7,7 @@ Feature: Author terms can be reassigned between co-authors
 	Scenario: Rename an old term when the new term does not exist yet
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
-		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=newuser`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
@@ -30,7 +30,7 @@ Feature: Author terms can be reassigned between co-authors
 		cap-admin
 		cap-olduser
 		"""
-		When I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		When I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=newuser`
 		Then STDOUT should be:
 		"""
 		Error: Term 'olduser' doesn't exist, skipping
@@ -53,7 +53,7 @@ Feature: Author terms can be reassigned between co-authors
 		And I run `wp post create --post_title="Shared post" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp post term add {POST_ID} author cap-olduser`
-		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=newuser`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
@@ -88,7 +88,7 @@ Feature: Author terms can be reassigned between co-authors
 		And I run `wp post create --post_title="Owned post" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp post term add {POST_ID} author cap-olduser`
-		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=olduser`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=olduser`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
@@ -107,12 +107,12 @@ Feature: Author terms can be reassigned between co-authors
 		cap-admin
 		"""
 
-	Scenario: A numeric --new_term is resolved to that user's login
+	Scenario: A numeric --new-term is resolved to that user's login
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
 		And I run `wp user create newuser newuser@example.com --role=author --porcelain`
 		And save STDOUT as {NEWUSER_ID}
-		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term={NEWUSER_ID}`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term={NEWUSER_ID}`
 		Then STDOUT should be:
 		"""
 		Success: Converted 'olduser' term to 'newuser'
@@ -128,10 +128,10 @@ Feature: Author terms can be reassigned between co-authors
 		newuser
 		"""
 
-	Scenario: A numeric --new_term for an unknown user id is not resolved
+	Scenario: A numeric --new-term for an unknown user id is not resolved
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
-		And I try `wp co-authors-plus reassign-terms --old_term=olduser --new_term=999999`
+		And I try `wp co-authors-plus reassign-terms --old-term=olduser --new-term=999999`
 		Then the return code should be 0
 		And STDERR should contain:
 		"""
@@ -153,7 +153,7 @@ Feature: Author terms can be reassigned between co-authors
 		And I run `wp co-authors-plus create-guest-authors`
 		And I run `wp term create author newuser --porcelain`
 		And save STDOUT as {EXISTING_ID}
-		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=newuser`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
@@ -172,7 +172,7 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 
 	Scenario: A missing old term is reported and skipped without an error exit
-		When I run `wp co-authors-plus reassign-terms --old_term=ghost --new_term=whatever`
+		When I run `wp co-authors-plus reassign-terms --old-term=ghost --new-term=whatever`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
@@ -184,7 +184,7 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 		When I run `wp term create author orphan --porcelain`
 		And save STDOUT as {ORPHAN_ID}
-		And I run `wp co-authors-plus reassign-terms --old_term=orphan --new_term=whatever`
+		And I run `wp co-authors-plus reassign-terms --old-term=orphan --new-term=whatever`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
@@ -205,14 +205,14 @@ Feature: Author terms can be reassigned between co-authors
 		When I try `wp co-authors-plus reassign-terms`
 		Then STDERR should be:
 		"""
-		Error: Please specify either --author-mapping, or both --old_term and --new_term.
+		Error: Please specify either --author-mapping, or both --old-term and --new-term.
 		"""
 		And STDOUT should be empty
 		And the return code should be 1
-		When I try `wp co-authors-plus reassign-terms --old_term=olduser`
+		When I try `wp co-authors-plus reassign-terms --old-term=olduser`
 		Then STDERR should be:
 		"""
-		Error: Please specify either --author-mapping, or both --old_term and --new_term.
+		Error: Please specify either --author-mapping, or both --old-term and --new-term.
 		"""
 		And the return code should be 1
 
@@ -250,6 +250,28 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 		And STDOUT should be empty
 		And the return code should be 1
+
+	Scenario: Accept the deprecated --old_term and --new_term flags with a notice
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp co-authors-plus reassign-terms --old_term=olduser --new_term=newuser`
+		Then STDOUT should be:
+		"""
+		Warning: The --old_term flag is deprecated; use --old-term instead.
+		Warning: The --new_term flag is deprecated; use --new-term instead.
+		Success: Converted 'olduser' term to 'newuser'
+		Reassignment complete. Here are your results:
+		- 1 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		And the return code should be 0
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		newuser
+		"""
 
 	Scenario: The underscore variant --author_mapping is rejected as an unknown parameter
 		When I try `wp co-authors-plus reassign-terms --author_mapping=features/fixtures/reassign-author-mapping.php`

--- a/features/reassign-terms.feature
+++ b/features/reassign-terms.feature
@@ -201,71 +201,55 @@ Feature: Author terms can be reassigned between co-authors
 		{ORPHAN_ID},orphan
 		"""
 
-	Scenario: Report empty results when no reassignment arguments are given
+	Scenario: Require either a mapping file or both term arguments
 		When I try `wp co-authors-plus reassign-terms`
-		Then the return code should be 0
-		And STDERR should contain:
+		Then STDERR should be:
 		"""
-		Warning: Undefined variable $authors_to_migrate
+		Error: Please specify either --author-mapping, or both --old_term and --new_term.
 		"""
-		And STDERR should contain:
-		"""
-		Warning: foreach() argument must be of type array|object, null given
-		"""
-		And STDOUT should contain:
-		"""
-		Reassignment complete. Here are your results:
-		- 0 authors were successfully reassigned terms
-		- 0 authors had their old term merged to their new term
-		- 0 authors were missing old terms
-		"""
+		And STDOUT should be empty
+		And the return code should be 1
 		When I try `wp co-authors-plus reassign-terms --old_term=olduser`
-		Then the return code should be 0
-		And STDERR should contain:
+		Then STDERR should be:
 		"""
-		Warning: Undefined variable $authors_to_migrate
+		Error: Please specify either --author-mapping, or both --old_term and --new_term.
 		"""
-		And STDOUT should contain:
-		"""
-		- 0 authors were successfully reassigned terms
-		"""
+		And the return code should be 1
 
-	Scenario: The documented --author-mapping flag is silently ignored
+	Scenario: Reassign terms from an --author-mapping file
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
-		And I try `wp co-authors-plus reassign-terms --author-mapping=features/fixtures/reassign-author-mapping.php`
-		Then the return code should be 0
-		And STDERR should contain:
-		"""
-		Warning: Undefined variable $authors_to_migrate
-		"""
-		And STDOUT should contain:
-		"""
-		Reassignment complete. Here are your results:
-		- 0 authors were successfully reassigned terms
-		- 0 authors had their old term merged to their new term
-		- 0 authors were missing old terms
-		"""
-		And STDOUT should not match /Converted/
-		When I run `wp term list author --field=slug`
+		And I run `wp term list author --field=slug`
 		Then STDOUT should be:
 		"""
 		cap-admin
 		cap-olduser
 		"""
-
-	Scenario: A nonexistent --author-mapping file does not trigger the documented error
-		When I try `wp co-authors-plus reassign-terms --author-mapping=features/fixtures/no-such-file.php`
-		Then the return code should be 0
-		And STDERR should not match /author_mapping doesn't exist/
-		And STDERR should contain:
+		When I run `wp co-authors-plus reassign-terms --author-mapping=features/fixtures/reassign-author-mapping.php`
+		Then STDOUT should be:
 		"""
-		Warning: Undefined variable $authors_to_migrate
-		"""
-		And STDOUT should contain:
-		"""
+		Success: Converted 'olduser' term to 'newuser'
 		Reassignment complete. Here are your results:
+		- 1 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
 		"""
+		And the return code should be 0
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		newuser
+		"""
+
+	Scenario: Report a missing --author-mapping file
+		When I try `wp co-authors-plus reassign-terms --author-mapping=features/fixtures/no-such-file.php`
+		Then STDERR should be:
+		"""
+		Error: --author-mapping file doesn't exist: features/fixtures/no-such-file.php
+		"""
+		And STDOUT should be empty
+		And the return code should be 1
 
 	Scenario: The underscore variant --author_mapping is rejected as an unknown parameter
 		When I try `wp co-authors-plus reassign-terms --author_mapping=features/fixtures/reassign-author-mapping.php`

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -539,23 +539,31 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		global $coauthors_plus;
 
 		$defaults   = array(
-			'author_mapping' => null,
+			// WP-CLI supplies this under the hyphenated name given in the
+			// synopsis, so reading 'author_mapping' silently found nothing.
+			'author-mapping' => null,
 			'old_term'       => null,
 			'new_term'       => null,
 		);
 		$this->args = wp_parse_args( $assoc_args, $defaults );
 
-		$author_mapping = $this->args['author_mapping'];
+		$author_mapping = $this->args['author-mapping'];
 		$old_term       = $this->args['old_term'];
 		$new_term       = $this->args['new_term'];
+
+		$authors_to_migrate = array();
 
 		// Get the reassignment data
 		if ( $author_mapping && is_file( $author_mapping ) ) {
 			require_once $author_mapping;
+
+			if ( ! isset( $cli_user_map ) ) {
+				WP_CLI::error( 'Mapping file does not define $cli_user_map: ' . $author_mapping );
+			}
+
 			$authors_to_migrate = $cli_user_map;
 		} elseif ( $author_mapping ) {
-			WP_CLI::error( "author_mapping doesn't exist: " . $author_mapping );
-			exit;
+			WP_CLI::error( "--author-mapping file doesn't exist: " . $author_mapping );
 		}
 
 		// Alternate reassigment approach
@@ -563,6 +571,10 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			$authors_to_migrate = array(
 				$old_term => $new_term,
 			);
+		}
+
+		if ( empty( $authors_to_migrate ) ) {
+			WP_CLI::error( 'Please specify either --author-mapping, or both --old_term and --new_term.' );
 		}
 
 		// For each author to migrate, check whether the term exists,

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -528,28 +528,46 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * for authors have changed. During the import process, 'author' terms will be
 	 * created with the old user_login value. We can use this to migrate to the new user_login
 	 *
+	 * Supply either --author-mapping, or both --old-term and --new-term. The
+	 * underscored --old_term and --new_term are deprecated aliases, still
+	 * accepted but reporting a notice.
+	 *
 	 * @todo support reassigning by CSV
 	 *
 	 * @since 3.0
 	 *
 	 * @subcommand reassign-terms
-	 * @synopsis [--author-mapping=<file>] [--old_term=<slug>] [--new_term=<slug>]
+	 * @synopsis [--author-mapping=<file>] [--old-term=<slug>] [--new-term=<slug>] [--old_term=<slug>] [--new_term=<slug>]
 	 */
 	public function reassign_terms( $args, $assoc_args ): void {
 		global $coauthors_plus;
 
 		$defaults   = array(
-			// WP-CLI supplies this under the hyphenated name given in the
-			// synopsis, so reading 'author_mapping' silently found nothing.
+			// WP-CLI supplies these under the hyphenated names given in the
+			// synopsis, so reading underscored keys silently found nothing.
 			'author-mapping' => null,
+			'old-term'       => null,
+			'new-term'       => null,
 			'old_term'       => null,
 			'new_term'       => null,
 		);
 		$this->args = wp_parse_args( $assoc_args, $defaults );
 
 		$author_mapping = $this->args['author-mapping'];
-		$old_term       = $this->args['old_term'];
-		$new_term       = $this->args['new_term'];
+		$old_term       = $this->args['old-term'];
+		$new_term       = $this->args['new-term'];
+
+		// --old_term and --new_term predate the hyphenated spellings and are
+		// kept working for existing scripts.
+		if ( null !== $this->args['old_term'] ) {
+			WP_CLI::warning( 'The --old_term flag is deprecated; use --old-term instead.' );
+			$old_term = $old_term ?? $this->args['old_term'];
+		}
+
+		if ( null !== $this->args['new_term'] ) {
+			WP_CLI::warning( 'The --new_term flag is deprecated; use --new-term instead.' );
+			$new_term = $new_term ?? $this->args['new_term'];
+		}
 
 		$authors_to_migrate = array();
 
@@ -574,7 +592,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		}
 
 		if ( empty( $authors_to_migrate ) ) {
-			WP_CLI::error( 'Please specify either --author-mapping, or both --old_term and --new_term.' );
+			WP_CLI::error( 'Please specify either --author-mapping, or both --old-term and --new-term.' );
 		}
 
 		// For each author to migrate, check whether the term exists,
@@ -688,7 +706,8 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 	 * Swap one co-author with another on all posts for which they are a co-author. Unlike rename-coauthor,
 	 * this leaves the original co-author term intact and works when the 'to' user already has a co-author term.
 	 *
-	 * Pass --dry-run to preview the swap without writing anything.
+	 * Pass --dry-run to preview the swap without writing anything. --dry is a
+	 * deprecated alias for it, still accepted but reporting a notice.
 	 *
 	 * @subcommand swap-coauthors
 	 * @synopsis --from=<user-login> --to=<user-login> [--post_type=<ptype>] [--dry-run] [--dry]


### PR DESCRIPTION
## Summary

`reassign-terms` declares `--author-mapping` in its synopsis, so WP-CLI supplies the value under a hyphenated key, but the defaults and the read both spelled it with an underscore. That key therefore always held its null default, and the mapping file was never loaded.

The documented flag consequently did nothing whatsoever. Its "file doesn't exist" guard was unreachable too, so a mistyped path was accepted in silence, and with no usable input the reassignment array was never defined at all: the command raised PHP warnings, printed a zero-count summary and exited 0. Every route through it reported success while doing nothing, which is a poor way for any command to fail and a particularly poor one for a bulk author migration, where the operator is told the reassignment worked.

Reading the key WP-CLI actually supplies fixes the flag. The command now also initialises that array, reports a mapping file that does not define `$cli_user_map`, and refuses to run when it has nothing to reassign rather than warning and claiming success. A dead `exit` after `WP_CLI::error`, which already exits, is removed, and the error text now names the flag as `--author-mapping`.

The second commit removes the condition that invited the bug. Mixed conventions in one command — `--author-mapping` hyphenated, `--old_term` and `--new_term` not — make it easy to reach for the wrong spelling when reading a value back. `--old-term` and `--new-term` are now the documented forms. The underscored spellings still work and report a deprecation notice, since removing them would break existing scripts; that mirrors the treatment `--dry` already has on `swap-coauthors`.

Both commands now mention their deprecated aliases in the docblock, so `wp help` says which spelling to prefer. That was a gap worth closing on its own: help listed the aliases alongside the current flags with nothing to separate them, and the runtime notice only appeared once someone had already chosen wrongly. `swap-coauthors` had the same problem, so its one-line fix rides along here rather than becoming a separate trivial PR.

The scenarios that documented the broken behaviour are re-pinned — no arguments now gives a clear error and a non-zero exit, a valid mapping file actually converts a term, and a missing file reports the documented error — and the feature file moves to the documented spellings throughout, with one scenario covering the deprecated forms.

## Test plan

- [ ] A valid `--author-mapping` file reassigns the terms it maps
- [ ] A mistyped `--author-mapping` path reports an error and exits non-zero
- [ ] Running with no arguments errors rather than reporting a zero-count success
- [ ] `--old-term`/`--new-term` work, and `--old_term`/`--new_term` still work with a notice
- [ ] `wp help co-authors-plus reassign-terms` and `... swap-coauthors` name the deprecated aliases