### PR TITLE
Drop the no-op de-duplication in getSizeKeysIntersection

### DIFF
--- a/src/__tests__/block-coauthor-image-utils.test.js
+++ b/src/__tests__/block-coauthor-image-utils.test.js
@@ -187,6 +187,27 @@ describe( 'Utility - getSizeKeysIntersection', () => {
 	it( 'returns an empty array when imageDimensions is empty', () => {
 		expect( getSizeKeysIntersection( media, {} ) ).toStrictEqual( [] );
 	} );
+
+	it( 'keeps the media size order and yields no duplicates', () => {
+		// getAvailableSizeSlug() falls back to the first key, so the media's
+		// own ordering has to survive. Object.keys() is already unique, which
+		// is why no de-duplication step is needed here.
+		const orderedMedia = {
+			media_details: {
+				sizes: { tall: {}, thumbnail: {}, wide: {}, medium: {} },
+			},
+		};
+
+		const keys = getSizeKeysIntersection( orderedMedia, imageDimensions );
+
+		expect( keys ).toStrictEqual( [
+			'tall',
+			'thumbnail',
+			'wide',
+			'medium',
+		] );
+		expect( keys ).toHaveLength( new Set( keys ).size );
+	} );
 } );
 
 describe( 'Utility - getAvailableSizeSlug', () => {

--- a/src/blocks/block-coauthor-image/utils.js
+++ b/src/blocks/block-coauthor-image/utils.js
@@ -100,11 +100,7 @@ export function getSizeKeysIntersection( media, imageDimensions ) {
 	const mediaKeys = Object.keys( media.media_details.sizes );
 	const sizeKeys = Object.keys( imageDimensions );
 
-	return Array.from(
-		new Set( [
-			...mediaKeys.filter( ( key ) => sizeKeys.includes( key ) ),
-		] )
-	);
+	return mediaKeys.filter( ( key ) => sizeKeys.includes( key ) );
 }
 
 /**


### PR DESCRIPTION
## Summary

`getSizeKeysIntersection()` wrapped its result in `Array.from( new Set( [ ...keys.filter( … ) ] ) )`. The input to that filter is `Object.keys( media.media_details.sizes )`, and object keys are unique by definition — so the spread, the `Set` and the `Array.from` could never change the result. Three layers of ceremony around a plain `filter`, which is now all that remains.

The wrapper looked as though it might be guarding an ordering or uniqueness property, so rather than delete it on the strength of an argument alone, the existing suite gains a test that pins both. `getAvailableSizeSlug()` falls back to the first key of the intersection when the requested size slug is unavailable, which makes the media's own key ordering load-bearing — the new test asserts that ordering survives, and that the output contains no duplicates.

## Test plan

- [x] `npm run test:unit` passes (67 tests, up from 66)
- [x] `npx wp-scripts lint-js` clean on both changed files