### PR TITLE
Look up the added author with find(), not filter()[0]

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -95,6 +95,22 @@ describe( 'Utility - addItemByValue', () => {
 			addItemByValue( newAuthorValue, selectedAuthors, dropdownOptions )
 		).toStrictEqual( [ ...selectedAuthors, dropdownOptions[ 0 ] ] );
 	} );
+
+	it( 'should match on value rather than position', () => {
+		// The second dropdown option, to prove the lookup is not just taking
+		// the head of the list.
+		expect(
+			addItemByValue( 'claudette', selectedAuthors, dropdownOptions )
+		).toStrictEqual( [ ...selectedAuthors, dropdownOptions[ 1 ] ] );
+	} );
+
+	it( 'should append undefined when the value is not in the dropdown', () => {
+		// Characterisation, not endorsement: an unmatched value has always
+		// appended undefined, which buildCoauthorTermIds() then discards.
+		expect(
+			addItemByValue( 'nobody', selectedAuthors, dropdownOptions )
+		).toStrictEqual( [ ...selectedAuthors, undefined ] );
+	} );
 } );
 
 describe( 'Utility - buildCoauthorTermIds', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,10 +112,10 @@ export const addItemByValue = (
 	currAuthors,
 	dropDownAuthors
 ) => {
-	const newAuthorObj = dropDownAuthors.filter(
+	const newAuthorObj = dropDownAuthors.find(
 		( item ) => item.value === newAuthorValue
 	);
-	return [ ...currAuthors, newAuthorObj[ 0 ] ];
+	return [ ...currAuthors, newAuthorObj ];
 };
 
 /**


### PR DESCRIPTION
## Summary

`addItemByValue()` filtered the dropdown options into a fresh array and then read only `[ 0 ]` from it, discarding whatever else matched. `Array.prototype.find()` expresses the same intent directly and stops at the first match.

This is a pure refactor: both forms produce `undefined` when the value is not present in the dropdown, so behaviour is identical in every case. Rather than take that equivalence on trust, the suite gains two tests — one proving the lookup matches on `value` rather than simply taking the head of the list, and one characterising the unmatched case.

Worth a reviewer's eye: that unmatched case appends `undefined` to the author list. It is harmless today, because `buildCoauthorTermIds()` filters out anything without a valid `termId` before the edit reaches the entity store, and the `ComboboxControl` only emits values it has just offered. The new test labels it as characterisation rather than endorsement — tightening it would be a behaviour change, so it is deliberately left for a separate decision.

## Test plan

- [x] `npm run test:unit` passes (68 tests, up from 66)
- [x] `npx wp-scripts lint-js` clean on both changed files