### PR TITLE
Map search results without the wrapping IIFE

### DIFF
--- a/src/__tests__/co-authors.test.js
+++ b/src/__tests__/co-authors.test.js
@@ -134,4 +134,52 @@ describe( 'CoAuthors author search', () => {
 			method: 'GET',
 		} );
 	} );
+
+	it( 'offers the search results as formatted dropdown options', async () => {
+		await renderPanel();
+
+		apiFetch.mockResolvedValue( [
+			{
+				id: 5,
+				termId: 42,
+				displayName: 'Ada Lovelace',
+				userNicename: 'ada',
+				email: 'ada@example.com',
+				userType: 'wpuser',
+			},
+		] );
+
+		act( () => {
+			comboboxProps.onFilterValueChange( 'ada' );
+		} );
+
+		await act( async () => {
+			jest.advanceTimersByTime( 500 );
+		} );
+
+		expect( comboboxProps.options ).toStrictEqual( [
+			{
+				id: 5,
+				termId: 42,
+				label: 'Ada Lovelace | ada@example.com',
+				display: 'Ada Lovelace',
+				value: 'ada',
+				userType: 'wpuser',
+			},
+		] );
+	} );
+
+	it( 'empties the dropdown when the search matches nobody', async () => {
+		await renderPanel();
+
+		act( () => {
+			comboboxProps.onFilterValueChange( 'nobody' );
+		} );
+
+		await act( async () => {
+			jest.advanceTimersByTime( 500 );
+		} );
+
+		expect( comboboxProps.options ).toStrictEqual( [] );
+	} );
 } );

--- a/src/components/co-authors/index.jsx
+++ b/src/components/co-authors/index.jsx
@@ -138,14 +138,9 @@ const CoAuthors = () => {
 				path: `/coauthors/v1/search/?q=${ query }&existing_authors=${ existingAuthors }`,
 				method: 'GET',
 			} );
-			const formattedAuthors = ( ( items ) => {
-				if ( items.length > 0 ) {
-					return items.map( ( item ) => formatAuthorData( item ) );
-				}
-				return [];
-			} )( response );
-
-			setDropdownOptions( formattedAuthors );
+			setDropdownOptions(
+				response.map( ( item ) => formatAuthorData( item ) )
+			);
 		} catch ( error ) {
 			console.log( error ); // eslint-disable-line no-console
 		}


### PR DESCRIPTION
## Summary

`fetchAuthors()` assembled its dropdown options through an immediately-invoked arrow function that checked `items.length > 0` before mapping, and returned `[]` otherwise. `Array.prototype.map()` already returns an empty array when given one, so the guard, the closure and the intermediate variable bought five lines and no behaviour. The mapping now happens inline at the point of use.

The equivalence argument is easy to state but worth pinning down, so `co-authors.test.js` gains coverage of both branches the IIFE distinguished. The test file already stubs `ComboboxControl` and captures its props, which makes the options list the component actually renders directly observable: one test asserts a matching author arrives formatted into the option shape, the other that a search matching nobody leaves the dropdown empty.

The callback is kept as an explicit `( item ) => formatAuthorData( item )` rather than passing `formatAuthorData` point-free. `map()` supplies an index and the source array as second and third arguments, and while `formatAuthorData` ignores them today, point-free style would quietly start feeding the index into any parameter added later.

## Test plan

- [x] `npm run test:unit` passes (68 tests, up from 66)
- [x] `npx prettier --check` clean on the changed component