### PR TITLE
Replace AuthorsSelection propTypes with a render test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
 				"@wordpress/scripts": "^34.2.0",
 				"classnames": "^2.5.1",
 				"prettier": "npm:wp-prettier@^2.2.1-beta-1",
-				"prop-types": "^15.8.1",
 				"version-bump-prompt": "^6.1.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"@wordpress/scripts": "^34.2.0",
 		"classnames": "^2.5.1",
 		"prettier": "npm:wp-prettier@^2.2.1-beta-1",
-		"prop-types": "^15.8.1",
 		"version-bump-prompt": "^6.1.0"
 	},
 	"keywords": []

--- a/src/__tests__/author-selection.test.js
+++ b/src/__tests__/author-selection.test.js
@@ -1,0 +1,133 @@
+/**
+ * Tests for the selected co-authors list in the document sidebar.
+ *
+ * These cover the contract a malformed `propTypes` block used to claim to
+ * check: what `selectedAuthors` entries the component reads, and what shape it
+ * hands back through `updateAuthors`. `PropTypes.arrayOf()` takes a validator
+ * rather than an array literal, so the declaration validated nothing and named
+ * fields (`displayName`, `userNiceName`, `avatar`) this component never reads.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AuthorsSelection from '../components/author-selection';
+import { selectedAuthors } from '../__fixtures__/authors';
+
+/**
+ * The real @wordpress/components cannot be required here: it pulls in an ESM
+ * build of uuid that this Jest config will not transform. Stub the three
+ * components used, keeping Button faithful enough for role-and-name queries —
+ * it renders a real <button> whose accessible name comes from `label`, exactly
+ * as the WordPress component does.
+ */
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { label, disabled, onClick } ) => (
+		<button
+			aria-label={ label }
+			disabled={ disabled }
+			onClick={ onClick }
+		/>
+	),
+	Flex: ( { children } ) => <div>{ children }</div>,
+	FlexItem: ( { children } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	chevronUp: 'chevron-up',
+	chevronDown: 'chevron-down',
+	close: 'close',
+} ) );
+
+const renderSelection = ( authors ) => {
+	const updateAuthors = jest.fn();
+	render(
+		<AuthorsSelection
+			selectedAuthors={ authors }
+			updateAuthors={ updateAuthors }
+		/>
+	);
+	return updateAuthors;
+};
+
+describe( 'AuthorsSelection', () => {
+	it( 'renders one row per author, labelled by display', () => {
+		renderSelection( selectedAuthors );
+
+		selectedAuthors.forEach( ( author ) => {
+			expect( screen.getByText( author.display ) ).toBeTruthy();
+		} );
+	} );
+
+	it.each( [ [ undefined ], [ null ], [ [] ] ] )(
+		'renders nothing for %p',
+		( authors ) => {
+			const { container } = render(
+				<AuthorsSelection
+					selectedAuthors={ authors }
+					updateAuthors={ jest.fn() }
+				/>
+			);
+
+			expect( container.innerHTML ).toBe( '' );
+		}
+	);
+
+	it( 'disables the moves that would fall off either end', () => {
+		renderSelection( selectedAuthors );
+
+		const up = screen.getAllByRole( 'button', { name: 'Move Up' } );
+		const down = screen.getAllByRole( 'button', { name: 'Move down' } );
+
+		// First author cannot move up, last cannot move down. moveItem() would
+		// splice at -1 and wrap the author to the end of the list.
+		expect( up[ 0 ].disabled ).toBe( true );
+		expect( up[ up.length - 1 ].disabled ).toBe( false );
+		expect( down[ 0 ].disabled ).toBe( false );
+		expect( down[ down.length - 1 ].disabled ).toBe( true );
+	} );
+
+	it( 'disables every control when a single author is left', () => {
+		renderSelection( [ selectedAuthors[ 0 ] ] );
+
+		[ 'Move Up', 'Move down', 'Remove Author' ].forEach( ( name ) => {
+			expect( screen.getByRole( 'button', { name } ).disabled ).toBe(
+				true
+			);
+		} );
+	} );
+
+	it( 'reorders the list when an author is moved down', () => {
+		const updateAuthors = renderSelection( selectedAuthors );
+
+		fireEvent.click(
+			screen.getAllByRole( 'button', { name: 'Move down' } )[ 0 ]
+		);
+
+		expect( updateAuthors ).toHaveBeenCalledWith( [
+			selectedAuthors[ 1 ],
+			selectedAuthors[ 0 ],
+			selectedAuthors[ 2 ],
+			selectedAuthors[ 3 ],
+		] );
+	} );
+
+	it( 'drops the author from the list when removed', () => {
+		const updateAuthors = renderSelection( selectedAuthors );
+
+		fireEvent.click(
+			screen.getAllByRole( 'button', { name: 'Remove Author' } )[ 1 ]
+		);
+
+		expect( updateAuthors ).toHaveBeenCalledWith( [
+			selectedAuthors[ 0 ],
+			selectedAuthors[ 2 ],
+			selectedAuthors[ 3 ],
+		] );
+	} );
+} );

--- a/src/components/author-selection/index.jsx
+++ b/src/components/author-selection/index.jsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies.
- */
-import PropTypes from 'prop-types';
-
-/**
  * WordPress dependencies.
  */
 import { chevronUp, chevronDown, close } from '@wordpress/icons';
@@ -115,20 +110,6 @@ const AuthorsSelection = ( { selectedAuthors, updateAuthors } ) => {
 			</div>
 		);
 	} );
-};
-
-AuthorsSelection.propTypes = {
-	selectedAuthors: PropTypes.arrayOf( [
-		PropTypes.shape( {
-			id: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
-			userNiceName: PropTypes.string,
-			login: PropTypes.string,
-			email: PropTypes.string,
-			displayName: PropTypes.string,
-			avatar: PropTypes.string,
-		} ),
-	] ).isRequired,
-	updateAuthors: PropTypes.func.isRequired,
 };
 
 export default AuthorsSelection;


### PR DESCRIPTION
## Summary

The `AuthorsSelection.propTypes` block looked like documentation and validation, and was neither.

`PropTypes.arrayOf()` expects a single validator; it was handed an array literal containing one. React rejects that notation outright — logging `Property 'selectedAuthors' of component 'AuthorsSelection' has invalid PropType notation inside arrayOf` in development — and then validates nothing at all. The shape it described was wrong too: it named `displayName`, `userNiceName`, `login`, `email` and `avatar`, none of which this component reads. What actually arrives, from `formatAuthorData()`, is `{ id, termId, label, display, value, userType }`, and the component uses only `display` and `value`. So the block was both inert and actively misleading about the contract.

Rather than repair a declaration whose entire job can be done properly by a test, this removes it and adds real coverage of the same contract: which fields each row reads, when the move and remove controls are disabled, and the reordered or shortened list handed back through `updateAuthors`. That last part matters more than the type check ever did — the "move up" disabled state on the first row is what stops `moveItem()` splicing at index `-1` and wrapping the author to the end of the list.

With the only import gone, `prop-types` also drops out of `devDependencies`. It remains in the lockfile as a transitive dependency of `@wordpress/components`, which is expected.

One note on the test setup: `@wordpress/components` is stubbed rather than imported. Its published build pulls in an ESM copy of `uuid` that this Jest configuration will not transform, which is the same reason `co-authors.test.js` already stubs it. The `Button` stub renders a real `<button>` whose accessible name comes from `label`, matching the WordPress component, so the `getByRole( 'button', { name } )` queries stay honest.

## Test plan

- [x] `npm run test:unit` passes (74 tests, up from 66)
- [x] `npm run build` succeeds with `prop-types` removed
- [x] `npx wp-scripts lint-js` clean on the new test