### PR TITLE
Move an author with one splice, and stop at the ends

### DIFF
--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -75,6 +75,31 @@ describe( 'Utility - moveItem', () => {
 			selectedAuthors[ 3 ],
 		] );
 	} );
+
+	it( 'should not mutate the array it was given', () => {
+		const original = [ ...selectedAuthors ];
+
+		moveItem( selectedAuthors[ 0 ], selectedAuthors, 'down' );
+
+		expect( selectedAuthors ).toStrictEqual( original );
+	} );
+
+	it.each( [
+		[ 'the first item up', 0, 'up' ],
+		[ 'the last item down', 3, 'down' ],
+	] )( 'should leave the order alone when moving %s', ( _label, i, dir ) => {
+		// Moving off either end has no meaningful answer. Splicing at -1 used
+		// to wrap the first item round to second-from-last instead.
+		expect(
+			moveItem( selectedAuthors[ i ], selectedAuthors, dir )
+		).toStrictEqual( selectedAuthors );
+	} );
+
+	it( 'should leave the order alone for an item that is not in the list', () => {
+		expect(
+			moveItem( { value: 'nobody' }, selectedAuthors, 'down' )
+		).toStrictEqual( selectedAuthors );
+	} );
 } );
 
 describe( 'Utility - removeItem', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,32 +57,28 @@ export const needsPostIdFallback = ( coauthors ) => {
 /**
  * Move an item up or down in an array.
  *
- * @param {string} targetItem Item to move.
+ * The array is returned unchanged when the move would leave it — moving the
+ * first item up or the last item down — or when the item is not in the list at
+ * all. Without that guard, moving the first item up splices at index -1, which
+ * wraps it to second-from-last instead of doing nothing.
+ *
+ * @param {Object} targetItem Item to move.
  * @param {Array}  itemsArr   Array in which to move the item.
  * @param {string} direction  'up' or 'down'
  * @return {Array} Array with reordered items.
  */
 export const moveItem = ( targetItem, itemsArr, direction ) => {
-	const currIndex = itemsArr
-		.map( ( item ) => item.value )
-		.indexOf( targetItem.value );
-	const indexUpdate = direction === 'up' ? -1 : 1;
-	const newIndex = currIndex + indexUpdate;
+	const currIndex = itemsArr.findIndex(
+		( item ) => item.value === targetItem.value
+	);
+	const newIndex = currIndex + ( 'up' === direction ? -1 : 1 );
 
-	const arrCopy = itemsArr.map( ( item ) => Object.assign( {}, item ) );
-	const targetCopy = arrCopy[ currIndex ];
+	if ( currIndex < 0 || newIndex < 0 || newIndex >= itemsArr.length ) {
+		return itemsArr;
+	}
 
-	const newItems = ( () => {
-		return arrCopy.filter( ( item ) => {
-			if ( item.value ) {
-				return item.value !== targetCopy.value;
-			}
-			return item !== targetCopy;
-		} );
-	} )();
-	const sortedArr = [ ...newItems ];
-
-	sortedArr.splice( newIndex, 0, targetCopy );
+	const sortedArr = [ ...itemsArr ];
+	sortedArr.splice( newIndex, 0, sortedArr.splice( currIndex, 1 )[ 0 ] );
 
 	return sortedArr;
 };


### PR DESCRIPTION
## Summary

`moveItem()` took five steps to reorder one element: clone every item with `Object.assign`, filter the target out inside an immediately-invoked closure, spread that result into a further array, then splice the target back in at the new index. Two splices against a single copy do the same work, and dropping the per-element clone means React sees unchanged authors as genuinely unchanged rather than as new objects on every reorder.

While rewriting it, the boundary arithmetic turned out to be wrong in a way worth fixing rather than faithfully reproducing. Moving the *first* author up computed `newIndex = -1`, and `Array.prototype.splice()` counts a negative index back from the end — so rather than doing nothing, it wrapped that author round to second-from-last. Separately, calling it with an author who is not in the list threw a `TypeError`, because the filter dereferenced a target that `arrCopy[ -1 ]` had left undefined. Both cases now return the list untouched.

Neither is reachable from the sidebar today: `AuthorsSelection` disables Move Up on the first row and Move Down on the last, and only ever passes an author drawn from the list it renders. But `moveItem()` is exported and shouldn't rely on its caller to keep it in range, so the guard lives in the function.

The three new tests are the evidence rather than the argument. Against the previous implementation, "first item up" and "not in the list" both fail; "last item down" passes, because splicing past the end already appended in place and produced the original order by accident.

## Test plan

- [x] `npm run test:unit` passes (70 tests, up from 66)
- [x] The two new boundary tests confirmed failing against the previous implementation
- [x] `npx wp-scripts lint-js` clean on both changed files