### PR TITLE
Inline the co-author template render pipeline

### DIFF
--- a/php/blocks/block-coauthors/class-block-coauthors.php
+++ b/php/blocks/block-coauthors/class-block-coauthors.php
@@ -133,26 +133,6 @@ class Block_CoAuthors {
 	}
 
 	/**
-	 * Get Composed Map Function
-	 * Use array reduce so an unknown array of functions can be used as single array_map callback
-	 *
-	 * @since 3.6.0
-	 * @param array $fns
-	 * @return callable
-	 */
-	public static function get_composed_map_function( ...$fns ): callable {
-		return function ( $value ) use ( $fns ) {
-			return array_reduce(
-				$fns,
-				function( $v, callable $f ) {
-					return $f( $v );
-				},
-				$value
-			);
-		};
-	}
-
-	/**
 	 * Render Prefix
 	 *
 	 * @since 3.6.0
@@ -189,17 +169,20 @@ class Block_CoAuthors {
 	 * @return array
 	 */
 	public static function render_coauthors_blocks_with_template( array $template, array $authors ): array {
+		$render_template = self::get_template_render_function( $template );
+
 		return array_map(
-			self::get_composed_map_function(
-				self::get_template_render_function( $template ),
-				// To match JSX from editor, remove line-breaks between blocks.
-				function( $content ) {
-					return str_replace( "\n", '', $content );
-				},
-				// To match JSX from editor, trim whitespace around blocks.
-				'trim',
-				Templating::get_render_element_function( 'div', 'class="wp-block-co-authors-plus-coauthor"' )
-			),
+			function( array $author ) use ( $render_template ): string {
+				// To match JSX from the editor, remove line-breaks between
+				// blocks and trim the whitespace around each one.
+				$content = trim( str_replace( "\n", '', $render_template( $author ) ) );
+
+				return Templating::render_element(
+					'div',
+					'class="wp-block-co-authors-plus-coauthor"',
+					$content
+				);
+			},
 			$authors
 		);
 	}

--- a/php/blocks/templating/class-templating.php
+++ b/php/blocks/templating/class-templating.php
@@ -28,21 +28,6 @@ class Templating {
 	}
 
 	/**
-	 * Get Render Element Function
-	 * Dependency inject render_element so you can use in array_map or add_filter.
-	 * 
-	 * @since 3.6.0
-	 * @param string      $name
-	 * @param null|string $attributes
-	 * @return callable
-	 */
-	public static function get_render_element_function( string $name, ?string $attributes = '' ): callable {
-		return function( string $content ) use ( $name, $attributes ) : string {
-			return self::render_element( $name, $attributes, $content );
-		};
-	}
-
-	/**
 	 * Render Self Closing Element
 	 *
 	 * @since 3.6.0

--- a/tests/Integration/Blocks/BlockCoAuthorsTemplateTest.php
+++ b/tests/Integration/Blocks/BlockCoAuthorsTemplateTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for the per-author template rendering in the Co-Authors block.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\Blocks;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+use CoAuthors\Blocks\Block_CoAuthors;
+
+/**
+ * Covers the three transformations applied to each rendered author.
+ *
+ * The block renders its inner template once per co-author, then has to make
+ * the server output match the JSX the editor produces: line breaks between
+ * blocks removed, surrounding whitespace trimmed, and the result wrapped in a
+ * per-author div. Those steps used to run through a variadic function
+ * composition helper; they are asserted here directly on the output.
+ *
+ * @covers \CoAuthors\Blocks\Block_CoAuthors::render_coauthors_blocks_with_template
+ */
+class BlockCoAuthorsTemplateTest extends TestCase {
+
+	/**
+	 * A block registered only by this test, to observe the context it receives.
+	 */
+	const PROBE_BLOCK = 'cap-test/context-probe';
+
+	public function tear_down() {
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( self::PROBE_BLOCK ) ) {
+			unregister_block_type( self::PROBE_BLOCK );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A parsed block whose inner content carries the line breaks and padding
+	 * the render pipeline is expected to strip.
+	 *
+	 * `core/null` is what get_block_as_template() substitutes for the real
+	 * block name, so rendering concatenates the inner content rather than
+	 * dispatching to a render callback.
+	 *
+	 * @return array
+	 */
+	private function template(): array {
+		return array(
+			'blockName'    => 'core/null',
+			'attrs'        => array(),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '',
+			'innerContent' => array( "\n\t<span>Byline</span>\n" ),
+		);
+	}
+
+	/**
+	 * Each author is wrapped, its line breaks removed and its edges trimmed.
+	 */
+	public function test_renders_each_author_trimmed_and_wrapped(): void {
+		$blocks = Block_CoAuthors::render_coauthors_blocks_with_template(
+			$this->template(),
+			array( array( 'display_name' => 'Ada Lovelace' ) )
+		);
+
+		$this->assertSame(
+			array( '<div class="wp-block-co-authors-plus-coauthor"><span>Byline</span></div>' ),
+			$blocks
+		);
+	}
+
+	/**
+	 * One rendered block comes back per author, in the order given.
+	 */
+	public function test_renders_one_block_per_author(): void {
+		$blocks = Block_CoAuthors::render_coauthors_blocks_with_template(
+			$this->template(),
+			array(
+				array( 'display_name' => 'Ada Lovelace' ),
+				array( 'display_name' => 'Grace Hopper' ),
+			)
+		);
+
+		$this->assertCount( 2, $blocks );
+		$this->assertSame( $blocks[0], $blocks[1] );
+	}
+
+	/**
+	 * No authors means no blocks, rather than one empty wrapper.
+	 */
+	public function test_renders_nothing_without_authors(): void {
+		$this->assertSame(
+			array(),
+			Block_CoAuthors::render_coauthors_blocks_with_template( $this->template(), array() )
+		);
+	}
+
+	/**
+	 * The author payload reaches the template as block context.
+	 *
+	 * This is the first step of the pipeline, and the only part of it that
+	 * asserting on the wrapper markup alone would not catch.
+	 */
+	public function test_passes_the_author_through_as_block_context(): void {
+		$seen = array();
+
+		register_block_type(
+			self::PROBE_BLOCK,
+			array(
+				'uses_context'    => array( 'co-authors-plus/author' ),
+				'render_callback' => static function ( $attributes, $content, $block ) use ( &$seen ) {
+					$seen[] = $block->context['co-authors-plus/author'] ?? null;
+					return '';
+				},
+			)
+		);
+
+		$template                 = $this->template();
+		$template['innerContent'] = array( null );
+		$template['innerBlocks']  = array(
+			array(
+				'blockName'    => self::PROBE_BLOCK,
+				'attrs'        => array(),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			),
+		);
+
+		Block_CoAuthors::render_coauthors_blocks_with_template(
+			$template,
+			array( array( 'display_name' => 'Ada Lovelace' ) )
+		);
+
+		$this->assertSame(
+			array( array( 'display_name' => 'Ada Lovelace' ) ),
+			$seen
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`render_coauthors_blocks_with_template()` built its `array_map` callback out of `get_composed_map_function()`, a variadic combinator that `array_reduce`d an arbitrary list of callables into one. The list was never arbitrary — four fixed steps, at the combinator's only call site. One of those steps came from `Templating::get_render_element_function()`, a closure factory that existed solely to make `render_element()` usable inside the composition, and which likewise had exactly one caller.

Both are removed. A single named closure now runs the same four steps in the same order: render the template for this author, strip line breaks, trim the edges, wrap in the per-author div. It reads top to bottom rather than asking the reader to unroll a `reduce` over an implicit pipeline to work out what happens to the content and in what order.

The block had no direct test coverage, so the behaviour is now asserted rather than argued. `BlockCoAuthorsTemplateTest` checks each of the four steps: that line breaks and surrounding whitespace are removed, that each author comes back wrapped in `wp-block-co-authors-plus-coauthor`, that the output is one block per author in order, and that the author payload reaches the template as `co-authors-plus/author` block context. That last one uses a block registered by the test with a `uses_context` declaration, which is the only way to observe the context the real inner blocks receive.

Incidentally this drops the two files from 34 PHPCS violations to 24, since both deleted methods carried non-compliant docblocks.

## Test plan

- [x] `composer lint` clean
- [x] `composer cs -- tests/` clean on the new test
- [ ] Integration suite in CI (WP 6.4/PHP 7.4 and WP master) — not run locally, wp-env would not start in this workspace