### PR TITLE
Write the avatar img tag where it is used

### DIFF
--- a/php/blocks/block-coauthor-avatar/class-block-coauthor-avatar.php
+++ b/php/blocks/block-coauthor-avatar/class-block-coauthor-avatar.php
@@ -103,10 +103,7 @@ class Block_CoAuthor_Avatar {
 
 		$image_attributes['style'] .= implode( '', $styles );
 
-		$image = Templating::render_self_closing_element(
-			'img',
-			Templating::render_attributes( $image_attributes )
-		);
+		$image = '<img ' . Templating::render_attributes( $image_attributes ) . '/>';
 
 		if ( $is_link ) {
 			$link_attributes = Templating::render_attributes(

--- a/php/blocks/templating/class-templating.php
+++ b/php/blocks/templating/class-templating.php
@@ -28,18 +28,6 @@ class Templating {
 	}
 
 	/**
-	 * Render Self Closing Element
-	 *
-	 * @since 3.6.0
-	 * @param string      $name
-	 * @param null|string $attributes
-	 * @return string
-	 */
-	public static function render_self_closing_element( string $name, ?string $attributes = '' ): string {
-		return "<{$name} $attributes/>";
-	}
-
-	/**
 	 * Render Attribute String
 	 *
 	 * @since 3.6.0

--- a/tests/Integration/Blocks/BlockCoAuthorAvatarTest.php
+++ b/tests/Integration/Blocks/BlockCoAuthorAvatarTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for the Co-Author Avatar block rendering.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\Blocks;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+use CoAuthors\Blocks\Block_CoAuthor_Avatar;
+use WP_Block;
+use WP_Block_Type_Registry;
+
+/**
+ * Covers the markup the avatar block emits for the image itself.
+ *
+ * The <img> used to be built through a Templating::render_self_closing_element
+ * helper. Nothing else called it, so the tag is now written where it is used;
+ * these assertions hold the emitted markup steady across that change.
+ *
+ * @covers \CoAuthors\Blocks\Block_CoAuthor_Avatar::render_block
+ */
+class BlockCoAuthorAvatarTest extends TestCase {
+
+	const BLOCK_NAME = 'co-authors-plus/avatar';
+
+	public function set_up() {
+		parent::set_up();
+
+		// WP_Block only maps available_context onto $block->context for a
+		// registered block type, so register a minimal one when the plugin's
+		// build directory is absent (dev checkouts without a JS build).
+		$registry = WP_Block_Type_Registry::get_instance();
+		if ( ! $registry->is_registered( self::BLOCK_NAME ) ) {
+			register_block_type(
+				self::BLOCK_NAME,
+				array(
+					'uses_context'    => array( 'co-authors-plus/author', 'co-authors-plus/layout' ),
+					'render_callback' => array( Block_CoAuthor_Avatar::class, 'render_block' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Render the block for an author with two avatar sizes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 */
+	private function render( array $attributes = array() ): string {
+		// isLink is always supplied: the block reads it as
+		// `'' !== $link && $attributes['isLink'] ?? false`, and ?? binds
+		// looser than &&, so a missing key warns rather than defaulting.
+		$block = new WP_Block(
+			array(
+				'blockName'    => self::BLOCK_NAME,
+				'attrs'        => array_merge( array( 'isLink' => false ), $attributes ),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			),
+			array(
+				'co-authors-plus/author' => array(
+					'display_name' => 'Ada Lovelace',
+					'link'         => 'https://example.org/author/ada/',
+					'avatar_urls'  => array(
+						24 => 'https://example.org/avatar-24.png',
+						48 => 'https://example.org/avatar-48.png',
+					),
+				),
+				'co-authors-plus/layout' => 'default',
+			)
+		);
+
+		return $block->render();
+	}
+
+	/**
+	 * The image is emitted as a self-closing tag carrying its attributes.
+	 */
+	public function test_renders_a_self_closing_img_tag(): void {
+		$output = $this->render( array( 'size' => 48 ) );
+
+		$this->assertStringContainsString( '<img ', $output );
+		$this->assertStringContainsString( '/>', $output );
+		$this->assertStringContainsString( 'src="https://example.org/avatar-48.png"', $output );
+		$this->assertStringContainsString( 'width="48"', $output );
+		$this->assertStringContainsString( 'height="48"', $output );
+	}
+
+	/**
+	 * Every registered avatar size is offered in the srcset.
+	 */
+	public function test_builds_a_srcset_from_every_avatar_size(): void {
+		$output = $this->render( array( 'size' => 24 ) );
+
+		$this->assertStringContainsString(
+			'srcset="https://example.org/avatar-24.png 24w, https://example.org/avatar-48.png 48w"',
+			$output
+		);
+	}
+
+	/**
+	 * With isLink set, the image is wrapped in an anchor to the author archive.
+	 */
+	public function test_wraps_the_image_in_a_link_when_asked(): void {
+		$output = $this->render(
+			array(
+				'size'   => 48,
+				'isLink' => true,
+			)
+		);
+
+		$this->assertMatchesRegularExpression(
+			'#<a [^>]*href="https://example\.org/author/ada/"[^>]*><img [^>]*/></a>#',
+			$output
+		);
+	}
+
+	/**
+	 * Without isLink there is no anchor at all.
+	 */
+	public function test_renders_a_bare_image_without_a_link(): void {
+		$output = $this->render(
+			array(
+				'size'   => 48,
+				'isLink' => false,
+			)
+		);
+
+		$this->assertStringNotContainsString( '<a ', $output );
+	}
+
+	/**
+	 * An author with no avatars renders nothing.
+	 */
+	public function test_renders_nothing_without_avatar_urls(): void {
+		$block = new WP_Block(
+			array(
+				'blockName'    => self::BLOCK_NAME,
+				'attrs'        => array( 'isLink' => false ),
+				'innerBlocks'  => array(),
+				'innerHTML'    => '',
+				'innerContent' => array(),
+			),
+			array(
+				'co-authors-plus/author' => array( 'display_name' => 'Ada Lovelace' ),
+			)
+		);
+
+		$this->assertSame( '', $block->render() );
+	}
+}


### PR DESCRIPTION
## Summary

`Templating::render_self_closing_element()` existed to wrap a single string interpolation — `"<{$name} $attributes/>"` — and had exactly one caller in the whole plugin: the `<img>` in the avatar block. Reading that block meant jumping to another file to discover it emits an img tag. The line now says so directly, and the helper is gone.

The avatar block had no test coverage at all, so rather than delete on the strength of the argument, `BlockCoAuthorAvatarTest` pins the markup first: a self-closing `<img>` carrying `src`, `width` and `height` for the requested size, a `srcset` built from every registered avatar size, the optional anchor wrapper when `isLink` is set, no anchor when it is not, and an empty string for an author with no avatars.

One thing a reviewer may wonder about: the test always passes `isLink` explicitly, even where the value is irrelevant. That is deliberate. The block computes it as `'' !== $link && $attributes['isLink'] ?? false`, and `??` binds looser than `&&`, so the coalesce operand is the entire conjunction rather than the array access. A missing `isLink` key therefore warns instead of defaulting to `false`. Block registration always supplies the attribute in production, so this is invisible there, but hand-built attributes in a test would trip it. Worth a separate look at some point; it is not something this change should quietly alter.

## Test plan

- [x] `composer lint` clean
- [x] `composer cs -- tests/` clean on the new test
- [ ] Integration suite in CI (WP 6.4/PHP 7.4 and WP master) — not run locally, wp-env would not start in this workspace