### PR TITLE
Register the Bulk Edit hooks unconditionally

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -144,15 +144,11 @@ class CoAuthors_Plus {
 		// REST API: Depending on user capabilities, hide author term description.
 		add_action( 'rest_prepare_author', array( $this, 'conditionally_hide_author_term_description' ) );
 
-		// Add Bulk Edit support on supported versions of WordPress.
-		global $wp_version;
-		if ( version_compare( $wp_version, '6.3', '>=' ) ) {
-			// Add Co-Author select field to the Bulk Edit actions form.
-			add_action( 'bulk_edit_custom_box', array( $this, '_action_bulk_edit_custom_box' ), 10, 2 );
+		// Add Co-Author select field to the Bulk Edit actions form.
+		add_action( 'bulk_edit_custom_box', array( $this, '_action_bulk_edit_custom_box' ), 10, 2 );
 
-			// Update Co-Authors when bulk editing posts.
-			add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
-		}
+		// Update Co-Authors when bulk editing posts.
+		add_action( 'bulk_edit_posts', array( $this, 'action_bulk_edit_update_coauthors' ), 10, 2 );
 	}
 
 	/**

--- a/tests/Integration/Admin/BulkEditHooksTest.php
+++ b/tests/Integration/Admin/BulkEditHooksTest.php
@@ -70,9 +70,13 @@ class BulkEditHooksTest extends TestCase {
 	public function test_bulk_edit_assigns_coauthors_to_each_selected_post(): void {
 		wp_set_current_user( $this->create_editor( 'bulk_editor' )->ID );
 
+		// One owner for both posts: create_post() would otherwise call
+		// create_author() twice with its default login and get a WP_Error back
+		// for the duplicate.
+		$owner    = $this->create_author( 'bulk_owner' );
 		$coauthor = $this->create_author( 'bulk_coauthor' );
-		$first    = $this->create_post();
-		$second   = $this->create_post();
+		$first    = $this->create_post( $owner );
+		$second   = $this->create_post( $owner );
 
 		$this->_cap->action_bulk_edit_update_coauthors(
 			array(),

--- a/tests/Integration/Admin/BulkEditHooksTest.php
+++ b/tests/Integration/Admin/BulkEditHooksTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Tests for the Bulk Edit co-author hooks.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\Admin;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+
+/**
+ * Bulk Edit support is registered unconditionally, and works.
+ *
+ * `bulk_edit_custom_box` and `bulk_edit_posts` both arrived in WordPress 6.3,
+ * so the hooks used to be registered behind a version_compare() against the
+ * running WordPress. The plugin now declares 6.4 as its minimum, which makes
+ * that check dead code — but only for as long as the declared minimum stays
+ * above 6.3, which is what the first test here holds.
+ *
+ * @covers \CoAuthors_Plus::register_hooks
+ * @covers \CoAuthors_Plus::action_bulk_edit_update_coauthors
+ */
+class BulkEditHooksTest extends TestCase {
+
+	/**
+	 * The WordPress version that introduced both Bulk Edit hooks.
+	 */
+	const BULK_EDIT_HOOKS_SINCE = '6.3';
+
+	/**
+	 * The plugin's declared minimum WordPress is new enough for the hooks.
+	 *
+	 * If this ever fails, the version guard was load-bearing after all and
+	 * needs to come back rather than the assertion being relaxed.
+	 */
+	public function test_declared_minimum_wordpress_provides_the_bulk_edit_hooks(): void {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$requires = get_plugin_data( COAUTHORS_PLUS_FILE, false, false )['RequiresWP'];
+
+		$this->assertNotEmpty( $requires, 'The plugin header must declare "Requires at least".' );
+		$this->assertTrue(
+			version_compare( $requires, self::BULK_EDIT_HOOKS_SINCE, '>=' ),
+			sprintf(
+				'Declared minimum WordPress %s is older than %s, which introduced the Bulk Edit hooks.',
+				$requires,
+				self::BULK_EDIT_HOOKS_SINCE
+			)
+		);
+	}
+
+	/**
+	 * Both hooks are attached.
+	 */
+	public function test_registers_both_bulk_edit_hooks(): void {
+		$this->assertNotFalse(
+			has_action( 'bulk_edit_custom_box', array( $this->_cap, '_action_bulk_edit_custom_box' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'bulk_edit_posts', array( $this->_cap, 'action_bulk_edit_update_coauthors' ) )
+		);
+	}
+
+	/**
+	 * A bulk edit assigns the submitted co-authors to every selected post.
+	 */
+	public function test_bulk_edit_assigns_coauthors_to_each_selected_post(): void {
+		wp_set_current_user( $this->create_editor( 'bulk_editor' )->ID );
+
+		$coauthor = $this->create_author( 'bulk_coauthor' );
+		$first    = $this->create_post();
+		$second   = $this->create_post();
+
+		$this->_cap->action_bulk_edit_update_coauthors(
+			array(),
+			array(
+				'post'      => array( $first->ID, $second->ID ),
+				'post_type' => 'post',
+				'coauthors' => array( $coauthor->user_nicename ),
+			)
+		);
+
+		$this->assertPostHasCoAuthors( $first->ID, array( $coauthor ) );
+		$this->assertPostHasCoAuthors( $second->ID, array( $coauthor ) );
+	}
+
+	/**
+	 * A bulk edit that submits no co-authors leaves the existing byline alone.
+	 */
+	public function test_bulk_edit_without_coauthors_leaves_the_byline_alone(): void {
+		wp_set_current_user( $this->create_editor( 'bulk_editor' )->ID );
+
+		$original = $this->create_author( 'bulk_original' );
+		$post     = $this->create_post( $original );
+		$this->_cap->add_coauthors( $post->ID, array( $original->user_nicename ) );
+
+		$this->_cap->action_bulk_edit_update_coauthors(
+			array(),
+			array(
+				'post'      => array( $post->ID ),
+				'post_type' => 'post',
+			)
+		);
+
+		$this->assertPostHasCoAuthors( $post->ID, array( $original ) );
+	}
+}


### PR DESCRIPTION
## Summary

`bulk_edit_custom_box` and `bulk_edit_posts` both arrived in WordPress 6.3, so the plugin registered its Bulk Edit hooks behind a `version_compare( $wp_version, '6.3', '>=' )`. That check has been dead for a while: the plugin header and `README.md` both declare `Requires at least: 6.4`, and the lowest leg of the integration matrix is WP 6.4 on PHP 7.4. The branch cannot be false on any supported install, so the hooks are now registered like every other one around them.

Bulk Edit turned out to have no test coverage whatsoever, which is a poor position from which to delete its only conditional. So the tests come first: the hooks are attached, a bulk edit assigns the submitted co-authors to every selected post, and a bulk edit submitting none leaves the existing byline untouched.

The first test in the file guards the premise rather than the code. It reads `Requires at least` back out of the plugin header and fails if it ever drops below 6.3 — because at that point the version guard was load-bearing after all and needs to come back, rather than the assertion being relaxed. The failure message says as much, so whoever hits it does not have to reconstruct this reasoning.

## Test plan

- [x] `composer lint` clean
- [x] `composer cs -- tests/` clean on the new test
- [ ] Integration suite in CI (WP 6.4/PHP 7.4 and WP master) — not run locally, wp-env would not start in this workspace