### PR TITLE
Use WP-CLI's own cache flush between batches

### DIFF
--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -134,7 +134,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			if ( $count && 0 === $count % 500 ) {
-				$this->stop_the_insanity();
+				\WP_CLI\Utils\wp_clear_object_cache();
 				sleep( 1 );
 			}
 
@@ -412,7 +412,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			}
 
 			$this->args['paged']++;
-			$this->stop_the_insanity();
+			\WP_CLI\Utils\wp_clear_object_cache();
 			$posts = new WP_Query( $this->args );
 		}
 
@@ -821,7 +821,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				$query_args['paged']++;
 			}
 
-			$this->stop_the_insanity();
+			\WP_CLI\Utils\wp_clear_object_cache();
 
 			$posts = new WP_Query( $query_args );
 		}
@@ -869,7 +869,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 				}
 			}
 
-			$this->stop_the_insanity();
+			\WP_CLI\Utils\wp_clear_object_cache();
 
 			$this->args['paged']++;
 			$posts = new WP_Query( $this->args );
@@ -1072,7 +1072,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 					}
 				}
 
-				$this->stop_the_insanity();
+				\WP_CLI\Utils\wp_clear_object_cache();
 
 				$args['paged']++;
 				$posts = new WP_Query( $args );
@@ -1308,28 +1308,6 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 		/* translators: Guest Author ID. */
 		WP_CLI::success( sprintf( esc_html__( '-- Created as guest author #%s', 'co-authors-plus' ), $guest_author_id ) );
-	}
-
-	/**
-	 * Clear all the caches for memory management.
-	 */
-	private function stop_the_insanity(): void {
-		global $wpdb, $wp_object_cache;
-
-		$wpdb->queries = array(); // or define( 'WP_IMPORTING', true );
-
-		if ( ! is_object( $wp_object_cache ) ) {
-			return;
-		}
-
-		$wp_object_cache->group_ops      = array();
-		$wp_object_cache->stats          = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache          = array();
-
-		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
-			$wp_object_cache->__remoteset(); // important
-		}
 	}
 
 	/**

--- a/tests/Unit/Cli/ClearObjectCacheTest.php
+++ b/tests/Unit/Cli/ClearObjectCacheTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Guards for the WP-CLI cache-clearing utility the commands rely on.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Cli;
+
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+
+/**
+ * The long-running CLI commands flush caches between batches.
+ *
+ * They used to do it through a private stop_the_insanity() that reached into
+ * $wp_object_cache's internals directly. They now call WP_CLI\Utils
+ * \wp_clear_object_cache(), which prefers wp_cache_flush_runtime() when the
+ * object cache supports it and only touches the Memcached-specific properties
+ * that are actually set.
+ *
+ * That utility ships with WP-CLI itself, and the call sites only run under
+ * WP-CLI over large batches, so nothing in the PHP suites would notice it
+ * disappearing until a command fatalled on a real site. Checking the copy in
+ * vendor/ is a proxy for the WP-CLI a user runs rather than proof about it,
+ * but it is the cheapest standing signal that the function has not been
+ * renamed or moved out from under us.
+ *
+ * @coversNothing
+ */
+final class ClearObjectCacheTest extends TestCase {
+
+	/**
+	 * Absolute path to a file in the plugin root.
+	 *
+	 * @param string $relative Path relative to the repository root.
+	 * @return string
+	 */
+	private function path( string $relative ): string {
+		return dirname( __DIR__, 3 ) . '/' . $relative;
+	}
+
+	/**
+	 * WP-CLI still ships the utility the commands delegate to.
+	 */
+	public function test_wp_cli_provides_the_cache_clearing_utility(): void {
+		$utils = $this->path( 'vendor/wp-cli/wp-cli/php/utils-wp.php' );
+
+		$this->assertFileExists(
+			$utils,
+			'wp-cli/wp-cli must be installed so this check has something to read.'
+		);
+
+		$this->assertStringContainsString(
+			'function wp_clear_object_cache()',
+			(string) file_get_contents( $utils ),
+			'WP_CLI\Utils\wp_clear_object_cache() has moved or been renamed. The CLI '
+			. 'commands call it between batches and would fatal on a long run.'
+		);
+	}
+
+	/**
+	 * The plugin no longer carries its own copy of the cache flush.
+	 *
+	 * The hand-rolled version blanked $wp_object_cache->cache and friends
+	 * unconditionally, which creates dynamic properties on any drop-in whose
+	 * class does not allow them, and never reached wp_cache_flush_runtime().
+	 */
+	public function test_the_plugin_does_not_reimplement_the_cache_flush(): void {
+		$source = (string) file_get_contents( $this->path( 'php/class-wp-cli.php' ) );
+
+		$this->assertStringNotContainsString( 'stop_the_insanity', $source );
+		$this->assertStringNotContainsString( 'memcache_debug', $source );
+		$this->assertStringContainsString( '\WP_CLI\Utils\wp_clear_object_cache();', $source );
+	}
+}


### PR DESCRIPTION
## Summary

`stop_the_insanity()` hand-rolled a cache flush by reaching into `$wp_object_cache` and blanking `group_ops`, `stats`, `memcache_debug` and `cache` directly. WP-CLI ships `WP_CLI\Utils\wp_clear_object_cache()` for exactly this job, and it is better than our copy in three separate ways.

It calls `wp_cache_flush_runtime()` when the object cache advertises support for it. That is the supported API since WordPress 6.0, and it is the only flush a persistent drop-in can implement correctly — blanking `->cache` from outside assumes an internal layout the drop-in never promised.

It guards each of the legacy Memcached properties with `isset()` before assigning. Ours assigned unconditionally, which creates dynamic properties on any drop-in class not marked `#[AllowDynamicProperties]`, and that is a deprecation on PHP 8.2 and up.

And the last three lines of ours were dead. `is_callable( $wp_object_cache, '__remoteset' )` passes a method name where `is_callable()` expects `$syntax_only`, a boolean. The string coerces to `true`, and under syntax-only checking `is_callable()` returns `false` for a plain object — so `__remoteset()` has never been called, on any site, since the code was written.

**On coverage.** The five call sites are already exercised by the Behat suite: `assign-coauthors`, `create-terms-for-posts`, `list-posts-without-terms` and `create-author-terms-for-posts` all reach the swapped line on every run, so a fatal from an unresolvable call would surface there immediately. I did not add a Behat scenario for the batch-crossing path, because reaching it needs 100 to 500 generated posts and the flush leaves no observable output to assert on.

What nothing covered, before or after, is the utility itself going away. It lives in a dependency, and the call sites only fire under WP-CLI over large batches, so a rename upstream would show up as a fatal on a customer's site rather than as a red build. The unit test is that standing check, plus an assertion that we have not quietly grown a second copy of the flush. Checking `vendor/` is a proxy for the WP-CLI a user actually runs rather than proof about it, and the docblock says so.

## Test plan

- [x] `composer test:unit` passes (45 tests, 70 assertions — up from 68)
- [x] The new test's second assertion confirmed failing against `develop`, where `stop_the_insanity` still exists
- [x] `composer lint` and `composer cs -- tests/` clean
- [ ] Behat suite in CI, which drives four of the five affected commands