### PR TITLE
Express the 'cap-' prefix checks with str_starts_with

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1236,11 +1236,14 @@ class CoAuthors_Guest_Authors {
 	 * Gets a postmeta key by prefixing it with 'cap-'
 	 * if not yet prefixed
 	 *
+	 * The comparison is case-insensitive, so a key that already arrives as
+	 * 'CAP-foo' is left alone rather than becoming 'cap-CAP-foo'.
+	 *
 	 * @since 3.0
 	 */
 	public function get_post_meta_key( $key ) {
 
-		if ( 0 !== stripos( $key, 'cap-' ) ) {
+		if ( ! str_starts_with( strtolower( $key ), 'cap-' ) ) {
 			$key = 'cap-' . $key;
 		}
 
@@ -1261,7 +1264,7 @@ class CoAuthors_Guest_Authors {
 			case 'post_name':
 				$key = 'user_nicename';
 
-				if ( 0 === strpos( $value, 'cap-' ) ) {
+				if ( str_starts_with( $value, 'cap-' ) ) {
 					$value = substr( $value, 4 );
 				}
 

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2155,7 +2155,7 @@ class CoAuthors_Plus {
 		$found_users = array();
 		foreach ( $found_terms as $found_term ) {
 			$found_user = $this->get_coauthor_by( 'user_nicename', $found_term->slug );
-			if ( ! $found_user && 0 === strpos( $found_term->slug, 'cap-cap-' ) ) {
+			if ( ! $found_user && str_starts_with( $found_term->slug, 'cap-cap-' ) ) {
 				// Account for guest author terms that start with 'cap-'.
 				// e.g. "Cap Ri" -> "cap-cap-ri".
 				$cap_slug   = substr( $found_term->slug, 4, strlen( $found_term->slug ) );

--- a/tests/Integration/GuestAuthors/GuestAuthorKeyPrefixTest.php
+++ b/tests/Integration/GuestAuthors/GuestAuthorKeyPrefixTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for the 'cap-' prefix handling on guest author keys.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\GuestAuthors;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+
+/**
+ * Guest author postmeta keys and cache keys both hinge on a 'cap-' prefix.
+ *
+ * The get_post_meta_key() method adds the prefix unless it is already there,
+ * matching case-insensitively; get_cache_key() strips it from a post_name
+ * before hashing, matching case-sensitively. Those two are deliberately different,
+ * and the difference had no test, which made rewriting either check a
+ * guessing game.
+ *
+ * @covers \CoAuthors_Guest_Authors::get_post_meta_key
+ * @covers \CoAuthors_Guest_Authors::get_cache_key
+ */
+class GuestAuthorKeyPrefixTest extends TestCase {
+
+	/**
+	 * @var \CoAuthors_Guest_Authors
+	 */
+	private $guest_authors;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->guest_authors = $this->_cap->guest_authors;
+	}
+
+	/**
+	 * Keys and the prefixed form each is expected to produce.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function data_meta_keys(): array {
+		return array(
+			'unprefixed key gains the prefix'      => array( 'first_name', 'cap-first_name' ),
+			'prefixed key is left alone'           => array( 'cap-first_name', 'cap-first_name' ),
+			'upper-case prefix is left alone'      => array( 'CAP-first_name', 'CAP-first_name' ),
+			'mixed-case prefix is left alone'      => array( 'Cap-first_name', 'Cap-first_name' ),
+			'prefix elsewhere still gains one'     => array( 'linked_cap-account', 'cap-linked_cap-account' ),
+			'a key that merely starts with "cap"'  => array( 'capital', 'cap-capital' ),
+			'empty key gains the bare prefix'      => array( '', 'cap-' ),
+		);
+	}
+
+	/**
+	 * The prefix is added exactly once, whatever case it arrives in.
+	 *
+	 * The case-insensitivity is the point: 'CAP-first_name' must not become
+	 * 'cap-CAP-first_name' and start reading a postmeta key nothing writes.
+	 *
+	 * @dataProvider data_meta_keys
+	 *
+	 * @param string $key      Key as supplied.
+	 * @param string $expected Key as it should come back.
+	 */
+	public function test_prefixes_a_meta_key_once( string $key, string $expected ): void {
+		$this->assertSame( $expected, $this->guest_authors->get_post_meta_key( $key ) );
+	}
+
+	/**
+	 * Prefixing is idempotent.
+	 *
+	 * @dataProvider data_meta_keys
+	 *
+	 * @param string $key      Key as supplied.
+	 * @param string $expected Key as it should come back.
+	 */
+	public function test_prefixing_a_meta_key_twice_changes_nothing( string $key, string $expected ): void {
+		$once = $this->guest_authors->get_post_meta_key( $key );
+
+		$this->assertSame( $once, $this->guest_authors->get_post_meta_key( $once ) );
+		$this->assertSame( $expected, $once );
+	}
+
+	/**
+	 * A post_name loses its 'cap-' prefix before the cache key is hashed.
+	 */
+	public function test_cache_key_strips_the_prefix_from_a_post_name(): void {
+		$this->assertSame(
+			$this->guest_authors->get_cache_key( 'user_nicename', 'ada' ),
+			$this->guest_authors->get_cache_key( 'post_name', 'cap-ada' )
+		);
+	}
+
+	/**
+	 * That strip is case-sensitive, unlike the meta key prefix.
+	 *
+	 * 'CAP-ada' is not a slug WordPress would produce, so it is treated as an
+	 * ordinary nicename rather than a prefixed one.
+	 */
+	public function test_cache_key_prefix_strip_is_case_sensitive(): void {
+		$this->assertSame(
+			$this->guest_authors->get_cache_key( 'user_nicename', 'CAP-ada' ),
+			$this->guest_authors->get_cache_key( 'post_name', 'CAP-ada' )
+		);
+	}
+
+	/**
+	 * An unprefixed post_name is hashed as-is.
+	 */
+	public function test_cache_key_leaves_an_unprefixed_post_name_alone(): void {
+		$this->assertSame(
+			$this->guest_authors->get_cache_key( 'user_nicename', 'ada' ),
+			$this->guest_authors->get_cache_key( 'post_name', 'ada' )
+		);
+	}
+
+	/**
+	 * Only post_name is treated as possibly prefixed.
+	 */
+	public function test_cache_key_does_not_strip_the_prefix_from_other_keys(): void {
+		$this->assertNotSame(
+			$this->guest_authors->get_cache_key( 'login', 'ada' ),
+			$this->guest_authors->get_cache_key( 'login', 'cap-ada' )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Three places tested for a `cap-` prefix by comparing a `strpos()` or `stripos()` result against `0`. That idiom costs the reader a moment every time — is `0` "found at position zero" or "not found", and why `!==` here but `===` there? `str_starts_with()` simply says what is meant. The plugin already uses `str_contains()` for the same reason at `class-coauthors-plus.php:960`, and WordPress has polyfilled both since 5.9, comfortably below the declared minimum of 6.4.

The two `strpos()` sites swap over exactly. **`get_post_meta_key()` does not**, and that is the part worth a reviewer's attention: it used `stripos()`, which is case-**insensitive**. A naive `! str_starts_with( $key, 'cap-' )` would change behaviour — a key already arriving as `CAP-foo` would be prefixed a second time, becoming `cap-CAP-foo` and reading a postmeta key nothing ever writes. The replacement is `! str_starts_with( strtolower( $key ), 'cap-' )`, and the docblock now records that the case-insensitivity is deliberate rather than incidental, which was not previously written down anywhere.

None of these prefix rules had any test coverage, which made rewriting either check guesswork. The new test pins both, including the difference between them that is easy to mistake for an inconsistency: the meta key prefix match is case-insensitive, the cache key strip is case-sensitive. It also covers the cases that distinguish "starts with the prefix" from "contains it" (`linked_cap-account`) and from "merely starts with those letters" (`capital`).

I also checked the equivalence directly rather than reasoning about it alone — old and new expressions produce identical output for all seven cases in the data provider, including the empty string.

## Test plan

- [x] `composer lint` clean
- [x] `composer cs -- tests/` clean on the new test
- [x] Old and new expressions confirmed to agree on every case in the data provider
- [ ] Integration suite in CI (WP 6.4/PHP 7.4 and WP master) — not run locally, wp-env would not start in this workspace