### PR TITLE
Cover the prop contract that propTypes did enforce

### DIFF
--- a/src/__tests__/co-authors.test.js
+++ b/src/__tests__/co-authors.test.js
@@ -36,9 +36,23 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn(),
 } ) );
 
+/**
+ * Capture the props handed to AuthorsSelection.
+ *
+ * AuthorsSelection used to declare propTypes marking both props required and
+ * updateAuthors a function. Those two checks did fire, unlike the malformed
+ * arrayOf() element check beside them, and were removed with the rest of the
+ * block in #1387. They only ever guarded this one call site, so asserting the
+ * wiring here covers the same ground as a real test rather than a dev-only
+ * console warning.
+ */
+let selectionProps;
 jest.mock( '../components/author-selection', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: ( props ) => {
+		selectionProps = props;
+		return null;
+	},
 } ) );
 
 jest.mock( '../hooks/use-coauthor-details', () => ( {
@@ -63,6 +77,7 @@ describe( 'CoAuthors author search', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
 		comboboxProps = undefined;
+		selectionProps = undefined;
 
 		apiFetch.mockResolvedValue( [] );
 		useDispatch.mockReturnValue( { editPost: jest.fn() } );
@@ -181,5 +196,46 @@ describe( 'CoAuthors author search', () => {
 		} );
 
 		expect( comboboxProps.options ).toStrictEqual( [] );
+	} );
+} );
+
+describe( 'CoAuthors selection wiring', () => {
+	beforeEach( () => {
+		selectionProps = undefined;
+		apiFetch.mockResolvedValue( [] );
+		useDispatch.mockReturnValue( { editPost: jest.fn() } );
+		// No co-authors in the store, so the assertion below is about the
+		// wiring alone. buildCoauthorTermIds() has its own tests for
+		// preserving term IDs the REST endpoint could not resolve.
+		useSelect.mockReturnValue( {
+			coauthorTermIdsKey: '',
+			hasResolvedPost: true,
+		} );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'hands AuthorsSelection both props it requires', async () => {
+		render( <CoAuthors /> );
+		await act( async () => {} );
+
+		expect( Array.isArray( selectionProps.selectedAuthors ) ).toBe( true );
+		expect( typeof selectionProps.updateAuthors ).toBe( 'function' );
+	} );
+
+	it( 'writes the edited byline through updateAuthors', async () => {
+		const editPost = jest.fn();
+		useDispatch.mockReturnValue( { editPost } );
+
+		render( <CoAuthors /> );
+		await act( async () => {} );
+
+		act( () => {
+			selectionProps.updateAuthors( [ { termId: 7 }, { termId: 8 } ] );
+		} );
+
+		expect( editPost ).toHaveBeenCalledWith( { coauthors: [ 7, 8 ] } );
 	} );
 } );


### PR DESCRIPTION
## Summary

Follow-up to #1387, prompted by a fair challenge: a test-like thing and some production code were removed, and it was not clear what covers that behaviour now.

**I overclaimed in #1387.** That PR said the `propTypes` block "validates nothing at all". Running the exact removed declaration against `prop-types` shows that is only true of part of it:

| Scenario | Removed declaration |
|---|---|
| `selectedAuthors` elements are numbers | **missed** |
| `selectedAuthors` elements missing fields | **missed** |
| `selectedAuthors` not an array | **missed** |
| `selectedAuthors` absent | **caught** (`isRequired`) |
| `updateAuthors` absent | **caught** (`isRequired`) |
| `updateAuthors` wrong type | **caught** (`PropTypes.func`) |

The malformed `arrayOf( [ … ] )` meant no element check ever ran — that part was inert, and it also logged `invalid PropType notation inside arrayOf` on *every* render in dev builds, which removal usefully silences. But the two `isRequired` flags and the `func` type check were live, and three of the six scenarios above were genuinely being caught.

Of those three, the render test added in #1387 already covers `selectedAuthors` being absent, and covers it better than the warning did — it asserts the component renders nothing rather than logging to the console. The two `updateAuthors` checks had nothing replacing them. That is the real gap.

**Where the cover belongs.** `AuthorsSelection` has exactly one consumer and is not exported from the plugin's entry point, so a dev-only warning about a wrong prop was only ever going to fire for that one call site. Testing the component in isolation for a missing `updateAuthors` would amount to asserting that it throws, which is not worth writing. Asserting the *caller* wires it up is.

So `co-authors.test.js` now captures the props `CoAuthors` hands down, asserts `selectedAuthors` is an array and `updateAuthors` is a function, and asserts an edit made through `updateAuthors` reaches `editPost`. I checked both fail if the wiring drops the prop — which is precisely the case `PropTypes.func.isRequired` used to warn about, now caught in CI instead of in someone's console.

One incidental find: my first draft of the second test expected `editPost` to receive `[ 7, 8 ]` and got `[ 42, 7, 8 ]`. That was my assumption being wrong, not the code — `buildCoauthorTermIds()` correctly preserved an unresolved term ID from the store. The test now starts from an empty store so it stays about the wiring, since that preservation behaviour has its own tests.

## Test plan

- [x] `npm run test:unit` passes (85 tests, up from 83)
- [x] Both new tests confirmed failing when `<AuthorsSelection>` is given only `selectedAuthors`
- [x] `npx wp-scripts lint-js` clean