### PR TITLE
Guard list-authors registration too

### DIFF
--- a/features/testing.feature
+++ b/features/testing.feature
@@ -9,6 +9,8 @@
       Manage co-authors and guest authors.
       """
 
+  # Add every new subcommand here. This guard is what fails first if one stops
+  # being registered, so a command missing from the list is silently unguarded.
   Scenario: All expected subcommands remain registered
     Given a WP installation with the Co-Authors Plus plugin
 
@@ -48,6 +50,10 @@
     And STDOUT should contain:
       """
       delete-postmeta-that-skip-author-term-backfill
+      """
+    And STDOUT should contain:
+      """
+      list-authors
       """
     And STDOUT should contain:
       """


### PR DESCRIPTION
## Summary

The registration guard in `features/testing.feature` asserts that every `wp co-authors-plus` subcommand still appears in `wp co-authors-plus --help`. It exists because that is the check which fails first if the coming split of `CoAuthorsPlus_Command` into one class per command accidentally stops registering something.

It listed sixteen subcommands. The plugin now has seventeen, `list-authors` having arrived after the guard was written, so that command was not guarded at all.

The failure mode is what makes this worth a PR rather than a quiet amend. A guard falling out of date does not go red; it keeps passing while covering less, which is precisely the opposite of what it is for. A comment above the scenario now asks that new subcommands be added to it, since nothing else will notice.

To be clear about the blast radius: the behavioural coverage was never missing, as `list-authors` arrived with its own feature file. Only the registration guard was stale.

## Test plan

- [ ] `features/testing.feature` passes, and all seventeen subcommands are listed in the guard