### PR TITLE
Give the 'cap-' prefix one owner and two honest rules

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -30,6 +30,7 @@ const COAUTHORS_PLUS_FILE = __FILE__;
 
 require_once __DIR__ . '/template-tags.php';
 
+require_once __DIR__ . '/php/class-prefix.php';
 require_once __DIR__ . '/php/class-coauthors-template-filters.php';
 require_once __DIR__ . '/php/class-coauthors-endpoint.php';
 require_once __DIR__ . '/php/integrations/amp.php';

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -6,6 +6,8 @@
  * to give them access to the dashboard through a WP_User account
  */
 
+use CoAuthors\Prefix;
+
 class CoAuthors_Guest_Authors {
 
 	public $labels;
@@ -927,10 +929,18 @@ class CoAuthors_Guest_Authors {
 		if ( ! $slug ) {
 			wp_die( esc_html__( 'Guest authors cannot be created without display names.', 'co-authors-plus' ) );
 		}
+		/*
+		 * Deliberately the meta key rule, not the slug rule: this has always
+		 * prefixed case-insensitively, so a user_login of 'Cap Ri' yields the
+		 * post_name 'cap-cap-ri' while 'CAP-ri' yields 'cap-ri'. Changing that
+		 * would change the byline of guest authors created afterwards, so it
+		 * needs a decision and an upgrade path rather than a quiet fix.
+		 * See https://github.com/Automattic/co-authors-plus/issues/1397.
+		 */
 		$post_data['post_name'] = $this->get_post_meta_key( $slug );
 
 		// Guest authors can't be created with the same user_login as a user
-		$user_nicename = str_replace( 'cap-', '', $slug );
+		$user_nicename = Prefix::strip_slug_prefix( $slug );
 		$user          = get_user_by( 'slug', $user_nicename );
 		if ( $user
 			&& is_user_member_of_blog( $user->ID, get_current_blog_id() )
@@ -1243,11 +1253,7 @@ class CoAuthors_Guest_Authors {
 	 */
 	public function get_post_meta_key( $key ) {
 
-		if ( ! str_starts_with( strtolower( $key ), 'cap-' ) ) {
-			$key = 'cap-' . $key;
-		}
-
-		return $key;
+		return Prefix::ensure_meta_key_prefix( $key );
 	}
 
 	/**
@@ -1264,9 +1270,7 @@ class CoAuthors_Guest_Authors {
 			case 'post_name':
 				$key = 'user_nicename';
 
-				if ( str_starts_with( $value, 'cap-' ) ) {
-					$value = substr( $value, 4 );
-				}
+				$value = Prefix::strip_slug_prefix( $value );
 
 				break;
 
@@ -1331,7 +1335,7 @@ class CoAuthors_Guest_Authors {
 		}
 
 		// If one of the guest author meta values has changed, we'll need to invalidate all keys
-		if ( false !== strpos( $meta_key, 'cap-' ) && get_post_meta( $object_id, $meta_key, true ) !== $meta_value ) {
+		if ( Prefix::meta_key_has_prefix( $meta_key ) && get_post_meta( $object_id, $meta_key, true ) !== $meta_value ) {
 			$this->delete_guest_author_cache( $object_id );
 		}
 
@@ -1410,6 +1414,7 @@ class CoAuthors_Guest_Authors {
 		// Create the primary post object
 		$new_post = array(
 			'post_title' => $args['display_name'],
+			// The meta key rule, deliberately. See manage_guest_author_filter_post_data().
 			'post_name'  => sanitize_title( $this->get_post_meta_key( $args['user_login'] ) ),
 			'post_type'  => $this->post_type,
 		);

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -3,6 +3,8 @@
  * @package Automattic\CoAuthorsPlus
  */
 
+use CoAuthors\Prefix;
+
 class CoAuthors_Plus {
 
 	// Name for the taxonomy we're using to store relationships
@@ -2151,11 +2153,11 @@ class CoAuthors_Plus {
 		$found_users = array();
 		foreach ( $found_terms as $found_term ) {
 			$found_user = $this->get_coauthor_by( 'user_nicename', $found_term->slug );
-			if ( ! $found_user && str_starts_with( $found_term->slug, 'cap-cap-' ) ) {
-				// Account for guest author terms that start with 'cap-'.
-				// e.g. "Cap Ri" -> "cap-cap-ri".
-				$cap_slug   = substr( $found_term->slug, 4, strlen( $found_term->slug ) );
-				$found_user = $this->get_coauthor_by( 'user_nicename', $cap_slug );
+			$unprefixed = Prefix::strip_slug_prefix( $found_term->slug );
+			if ( ! $found_user && Prefix::slug_has_prefix( $unprefixed ) ) {
+				// A doubled prefix means the guest author's own user_nicename
+				// starts with 'cap-'. e.g. "Cap Ri" -> "cap-cap-ri".
+				$found_user = $this->get_coauthor_by( 'user_nicename', $unprefixed );
 			}
 			if ( ! empty( $found_user ) ) {
 				$found_users[ $found_user->user_login ] = $found_user;
@@ -2420,7 +2422,7 @@ class CoAuthors_Plus {
 		}
 
 		// See if the prefixed term is available, otherwise default to just the nicename
-		$term = get_term_by( 'slug', 'cap-' . $coauthor->user_nicename, $this->coauthor_taxonomy );
+		$term = get_term_by( 'slug', Prefix::prefix_slug( $coauthor->user_nicename ), $this->coauthor_taxonomy );
 		if ( ! $term ) {
 			$term = get_term_by( 'slug', $coauthor->user_nicename, $this->coauthor_taxonomy );
 		}
@@ -2454,7 +2456,7 @@ class CoAuthors_Plus {
 				wp_update_term( $term->term_id, $this->coauthor_taxonomy, array( 'description' => $term_description ) );
 			}
 		} else {
-			$coauthor_slug = 'cap-' . $coauthor->user_nicename;
+			$coauthor_slug = Prefix::prefix_slug( $coauthor->user_nicename );
 			$args          = array(
 				'slug'        => $coauthor_slug,
 				'description' => $term_description,
@@ -2705,7 +2707,7 @@ class CoAuthors_Plus {
 		}
 
 		$term       = $this->get_author_term( $guest_author );
-		$guest_term = get_term_by( 'slug', 'cap-' . $guest_author->user_nicename, $this->coauthor_taxonomy );
+		$guest_term = get_term_by( 'slug', Prefix::prefix_slug( $guest_author->user_nicename ), $this->coauthor_taxonomy );
 
 		if ( is_object( $guest_term )
 			&& ! empty( $guest_author->linked_account )

--- a/php/class-prefix.php
+++ b/php/class-prefix.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * The 'cap-' prefix, and the two different jobs it does.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+namespace CoAuthors;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds, strips and detects the 'cap-' prefix.
+ *
+ * The plugin puts the same four characters in front of two unrelated kinds of
+ * string, and the rules differ because the strings do.
+ *
+ * **Slugs** — author term slugs and guest author `post_name` values. Both pass
+ * through `sanitize_title()`, which ends in `strtolower()`, so a slug can never
+ * arrive upper-cased and matching is case-sensitive. Prefixing is
+ * *unconditional*: see prefix_slug() for why that matters.
+ *
+ * **Postmeta keys** — `cap-first_name` and friends. WordPress does not sanitise
+ * meta keys, so a `coauthors_guest_author_fields` filter can supply
+ * `CAP-first_name`; matching is case-insensitive and prefixing is idempotent,
+ * because prefixing such a key again would read a key nothing ever writes.
+ *
+ * The method names carry that difference deliberately: prefix_slug() always
+ * prefixes, ensure_meta_key_prefix() only prefixes what is not prefixed
+ * already. Before this class those rules had to be inferred from a strpos(),
+ * a stripos(), a preg_match() and a str_replace() scattered across three
+ * files, and two of them were wrong.
+ *
+ * @since 4.2.0
+ */
+final class Prefix {
+
+	/**
+	 * The prefix itself.
+	 */
+	public const VALUE = 'cap-';
+
+	/**
+	 * Prefix a user_nicename to get its author term slug or post_name.
+	 *
+	 * Deliberately unconditional, rather than "prefix unless already
+	 * prefixed". A guest author named "Cap Ri" has the user_nicename `cap-ri`
+	 * and the term slug `cap-cap-ri`; skipping the prefix for a nicename that
+	 * happens to start with `cap-` would point it at a different author's
+	 * term. CoAuthors_Plus::search_authors() carries the matching special case
+	 * for reading those doubled slugs back.
+	 *
+	 * @param string $user_nicename Co-author user_nicename or user_login.
+	 * @return string
+	 */
+	public static function prefix_slug( string $user_nicename ): string {
+		return self::VALUE . $user_nicename;
+	}
+
+	/**
+	 * Whether a slug starts with the prefix.
+	 *
+	 * Case-sensitive: slugs are lower-cased by sanitize_title().
+	 *
+	 * @param string $slug Term slug or guest author post_name.
+	 * @return bool
+	 */
+	public static function slug_has_prefix( string $slug ): bool {
+		return str_starts_with( $slug, self::VALUE );
+	}
+
+	/**
+	 * Remove one leading prefix from a slug, if it has one.
+	 *
+	 * Only the leading occurrence, and only one: a guest author called
+	 * "Recap Caption" has the slug `recap-caption`, which must come back
+	 * untouched, and `cap-cap-ri` must yield `cap-ri` rather than `ri`.
+	 *
+	 * @param string $slug Term slug or guest author post_name.
+	 * @return string
+	 */
+	public static function strip_slug_prefix( string $slug ): string {
+		return self::slug_has_prefix( $slug )
+			? substr( $slug, strlen( self::VALUE ) )
+			: $slug;
+	}
+
+	/**
+	 * Prefix a postmeta key, unless it already carries the prefix.
+	 *
+	 * @param string $key Guest author field name.
+	 * @return string
+	 */
+	public static function ensure_meta_key_prefix( string $key ): string {
+		return self::meta_key_has_prefix( $key ) ? $key : self::VALUE . $key;
+	}
+
+	/**
+	 * Whether a postmeta key starts with the prefix, in any case.
+	 *
+	 * Case-insensitive: meta keys are not sanitised, so a filter may supply
+	 * `CAP-first_name`.
+	 *
+	 * @param string $key Postmeta key.
+	 * @return bool
+	 */
+	public static function meta_key_has_prefix( string $key ): bool {
+		return str_starts_with( strtolower( $key ), self::VALUE );
+	}
+}

--- a/php/class-wp-cli.php
+++ b/php/class-wp-cli.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 WP_CLI::add_command( 'co-authors-plus', 'CoAuthorsPlus_Command' );
 
+use CoAuthors\Prefix;
+
 class CoAuthorsPlus_Command extends WP_CLI_Command {
 
 	const SKIP_POST_FOR_BACKFILL_META_KEY = '_cap_skip_backfill';
@@ -667,7 +669,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
 		$to_userlogin          = $assoc_args['to'];
-		$to_userlogin_prefixed = 'cap-' . $to_userlogin;
+		$to_userlogin_prefixed = Prefix::prefix_slug( $to_userlogin );
 
 		$orig_coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $assoc_args['from'] );
 		if ( ! $orig_coauthor ) {
@@ -694,7 +696,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		if ( 'guest-author' == $orig_coauthor->type ) {
 			$wpdb->update( $wpdb->posts, array( 'post_name' => $to_userlogin_prefixed ), array( 'ID' => $orig_coauthor->ID ) );
 			clean_post_cache( $orig_coauthor->ID );
-			update_post_meta( $orig_coauthor->ID, 'cap-user_login', $to_userlogin );
+			update_post_meta( $orig_coauthor->ID, Prefix::ensure_meta_key_prefix( 'user_login' ), $to_userlogin );
 			$coauthors_plus->guest_authors->delete_guest_author_cache( $orig_coauthor->ID );
 			WP_CLI::log( 'Updated guest author profile value too' );
 		}
@@ -760,7 +762,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		$from_userlogin = $orig_coauthor->user_login;
 		$to_userlogin   = $to_coauthor->user_login;
 
-		$from_userlogin_prefixed = 'cap-' . $from_userlogin;
+		$from_userlogin_prefixed = Prefix::prefix_slug( $from_userlogin );
 
 		// Swapping a co-author with themselves would remove the term and add it
 		// straight back, so the loop below would never drain.
@@ -1011,12 +1013,12 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 		WP_CLI::log( 'Now migrating up to ' . count( $author_terms ) . ' terms' );
 		foreach ( $author_terms as $author_term ) {
 			// Term is already prefixed. We're good.
-			if ( preg_match( '#^cap\-#', $author_term->slug, $matches ) ) {
+			if ( Prefix::slug_has_prefix( $author_term->slug ) ) {
 				WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) is already prefixed, skipping" );
 				continue;
 			}
 			// A prefixed term was accidentally created, and the old term needs to be merged into the new (WordPress.com VIP)
-			if ( $prefixed_term = get_term_by( 'slug', 'cap-' . $author_term->slug, $coauthors_plus->coauthor_taxonomy ) ) {
+			if ( $prefixed_term = get_term_by( 'slug', Prefix::prefix_slug( $author_term->slug ), $coauthors_plus->coauthor_taxonomy ) ) {
 				WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) has a new term too: $prefixed_term->slug ($prefixed_term->term_id). Merging" );
 				$args = array(
 					'default'       => $author_term->term_id,
@@ -1028,7 +1030,7 @@ class CoAuthorsPlus_Command extends WP_CLI_Command {
 			// Term isn't prefixed, doesn't have a sibling, and should be updated
 			WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) isn't prefixed, adding one" );
 			$args = array(
-				'slug' => 'cap-' . $author_term->slug,
+				'slug' => Prefix::prefix_slug( $author_term->slug ),
 			);
 			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
 		}

--- a/tests/Integration/GuestAuthors/GuestAuthorPrefixHandlingTest.php
+++ b/tests/Integration/GuestAuthors/GuestAuthorPrefixHandlingTest.php
@@ -32,10 +32,7 @@ class GuestAuthorPrefixHandlingTest extends TestCase {
 
 		$this->guest_authors = $this->_cap->guest_authors;
 
-		// The filter bails without an editing user and a valid nonce, both of
-		// which the guest author edit screen would have supplied.
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
-		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
 	}
 
 	public function tear_down() {
@@ -52,15 +49,25 @@ class GuestAuthorPrefixHandlingTest extends TestCase {
 	 * @return array The filtered post data.
 	 */
 	private function filter_post_data( int $guest_author_id, string $display_name ): array {
-		$_POST['cap-display_name'] = $display_name;
+		/*
+		 * Populate $_POST only for the duration of this call. The filter is
+		 * also reached through wp_insert_post() during create(), where a nonce
+		 * left lying around would make it engage with no form data behind it.
+		 */
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-display_name']   = $display_name;
 
-		return $this->guest_authors->manage_guest_author_filter_post_data(
-			array( 'post_type' => $this->guest_authors->post_type ),
-			array(
-				'ID'        => $guest_author_id,
-				'post_type' => $this->guest_authors->post_type,
-			)
-		);
+		try {
+			return $this->guest_authors->manage_guest_author_filter_post_data(
+				array( 'post_type' => $this->guest_authors->post_type ),
+				array(
+					'ID'        => $guest_author_id,
+					'post_type' => $this->guest_authors->post_type,
+				)
+			);
+		} finally {
+			unset( $_POST['guest-author-nonce'], $_POST['cap-display_name'] );
+		}
 	}
 
 	/**

--- a/tests/Integration/GuestAuthors/GuestAuthorPrefixHandlingTest.php
+++ b/tests/Integration/GuestAuthors/GuestAuthorPrefixHandlingTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Tests for the two prefix bugs fixed alongside the Prefix helper.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Integration\GuestAuthors;
+
+use Automattic\CoAuthorsPlus\Tests\Integration\TestCase;
+
+/**
+ * Two places treated "contains cap-" as if it meant "starts with cap-".
+ *
+ * Both are exercised here through the hooks that reach them, rather than by
+ * calling the methods directly, so the tests describe what a site sees.
+ *
+ * @covers \CoAuthors_Guest_Authors::manage_guest_author_filter_post_data
+ * @covers \CoAuthors_Guest_Authors::filter_update_post_metadata
+ */
+class GuestAuthorPrefixHandlingTest extends TestCase {
+
+	/**
+	 * @var \CoAuthors_Guest_Authors
+	 */
+	private $guest_authors;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->guest_authors = $this->_cap->guest_authors;
+
+		// The filter bails without an editing user and a valid nonce, both of
+		// which the guest author edit screen would have supplied.
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+	}
+
+	public function tear_down() {
+		unset( $_POST['guest-author-nonce'], $_POST['cap-display_name'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Run the post-data filter for a guest author as the edit screen would.
+	 *
+	 * @param int    $guest_author_id Guest author post ID.
+	 * @param string $display_name    Display name submitted with the form.
+	 * @return array The filtered post data.
+	 */
+	private function filter_post_data( int $guest_author_id, string $display_name ): array {
+		$_POST['cap-display_name'] = $display_name;
+
+		return $this->guest_authors->manage_guest_author_filter_post_data(
+			array( 'post_type' => $this->guest_authors->post_type ),
+			array(
+				'ID'        => $guest_author_id,
+				'post_type' => $this->guest_authors->post_type,
+			)
+		);
+	}
+
+	/**
+	 * A name containing "cap-" is not mistaken for a prefixed one.
+	 *
+	 * The filter strips the prefix from the slug to check whether a WordPress
+	 * user already owns that nicename. It used
+	 * str_replace(), which removes every occurrence, so "Recap Caption" became
+	 * `recaption` and the guard compared against the wrong user entirely.
+	 *
+	 * Here a real user owns `recaption`. The guest author being saved is
+	 * `recap-caption`, a different nicename, so the save must go through. The
+	 * old code matched them and called wp_die().
+	 */
+	public function test_a_name_containing_the_prefix_is_not_treated_as_prefixed(): void {
+		$this->factory()->user->create(
+			array(
+				'user_login'    => 'recaption',
+				'user_nicename' => 'recaption',
+				'role'          => 'author',
+			)
+		);
+
+		$guest_author_id = $this->guest_authors->create(
+			array(
+				'display_name' => 'Recap Caption',
+				'user_login'   => 'recap-caption',
+			)
+		);
+
+		$this->assertIsInt( $guest_author_id );
+
+		$post_data = $this->filter_post_data( $guest_author_id, 'Recap Caption' );
+
+		$this->assertSame(
+			'cap-recap-caption',
+			$post_data['post_name'],
+			'The slug should keep its internal "cap-" and gain a single prefix.'
+		);
+	}
+
+	/**
+	 * A guest author whose nicename really is taken still cannot be saved.
+	 *
+	 * The control for the test above: the guard must still fire when the
+	 * stripped nicename genuinely belongs to a WordPress user.
+	 */
+	public function test_a_genuinely_colliding_nicename_is_still_refused(): void {
+		// The guest author first: create() refuses a user_login that already
+		// belongs to a WordPress user, so the collision has to arrive after.
+		$guest_author_id = $this->guest_authors->create(
+			array(
+				'display_name' => 'Ada Lovelace',
+				'user_login'   => 'ada-lovelace',
+			)
+		);
+
+		$this->assertIsInt( $guest_author_id );
+
+		$this->factory()->user->create(
+			array(
+				'user_login'    => 'ada-lovelace',
+				'user_nicename' => 'ada-lovelace',
+				'role'          => 'author',
+			)
+		);
+
+		$this->expectException( \WPDieException::class );
+
+		$this->filter_post_data( $guest_author_id, 'Ada Lovelace' );
+	}
+
+	/**
+	 * Only keys that start with the prefix invalidate the guest author cache.
+	 *
+	 * The metadata filter used strpos() !== false, so a third-party key merely
+	 * containing "cap-" anywhere busted the cache on every save.
+	 *
+	 * @dataProvider data_unrelated_meta_keys
+	 *
+	 * @param string $meta_key Key that should not invalidate the cache.
+	 */
+	public function test_an_unrelated_meta_key_leaves_the_cache_alone( string $meta_key ): void {
+		$guest_author_id = $this->guest_authors->create(
+			array(
+				'display_name' => 'Grace Hopper',
+				'user_login'   => 'grace-hopper',
+			)
+		);
+
+		$cache_key = $this->guest_authors->get_cache_key( 'ID', $guest_author_id );
+		$this->guest_authors->get_guest_author_by( 'ID', $guest_author_id );
+		$this->assertNotFalse(
+			wp_cache_get( $cache_key, \CoAuthors_Guest_Authors::$cache_group ),
+			'Precondition: the guest author should be cached.'
+		);
+
+		update_post_meta( $guest_author_id, $meta_key, 'some value' );
+
+		$this->assertNotFalse(
+			wp_cache_get( $cache_key, \CoAuthors_Guest_Authors::$cache_group ),
+			'An unrelated meta key should not invalidate the guest author cache.'
+		);
+	}
+
+	/**
+	 * Meta keys that contain "cap-" without starting with it.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function data_unrelated_meta_keys(): array {
+		return array(
+			'third-party key containing the prefix' => array( 'my-cap-setting' ),
+			'prefix at the end'                     => array( 'setting-cap-' ),
+			'unrelated key entirely'                => array( 'some_plugin_flag' ),
+		);
+	}
+
+	/**
+	 * A genuine guest author field still invalidates the cache.
+	 *
+	 * The control: without this, the assertions above would pass just as
+	 * happily against a check that never invalidated anything.
+	 */
+	public function test_a_guest_author_field_still_invalidates_the_cache(): void {
+		$guest_author_id = $this->guest_authors->create(
+			array(
+				'display_name' => 'Grace Hopper',
+				'user_login'   => 'grace-hopper',
+			)
+		);
+
+		$cache_key = $this->guest_authors->get_cache_key( 'ID', $guest_author_id );
+		$this->guest_authors->get_guest_author_by( 'ID', $guest_author_id );
+		$this->assertNotFalse(
+			wp_cache_get( $cache_key, \CoAuthors_Guest_Authors::$cache_group )
+		);
+
+		update_post_meta( $guest_author_id, $this->guest_authors->get_post_meta_key( 'first_name' ), 'Grace' );
+
+		$this->assertFalse(
+			wp_cache_get( $cache_key, \CoAuthors_Guest_Authors::$cache_group ),
+			'Changing a guest author field must invalidate its cache.'
+		);
+	}
+}

--- a/tests/Unit/Foundation/PrefixTest.php
+++ b/tests/Unit/Foundation/PrefixTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Unit tests for the 'cap-' prefix helper.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Foundation;
+
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use CoAuthors\Prefix;
+
+/**
+ * The two rules the prefix follows, and the difference between them.
+ *
+ * Slug prefixing is unconditional and matches case-sensitively; meta key
+ * prefixing is idempotent and matches case-insensitively. Getting either
+ * backwards silently points a byline at the wrong author or reads a postmeta
+ * key nothing writes, so both are pinned here rather than left to the reader.
+ *
+ * @covers \CoAuthors\Prefix
+ */
+final class PrefixTest extends TestCase {
+
+	/**
+	 * A slug is always prefixed, even when it already looks prefixed.
+	 *
+	 * This is the case that makes prefix_slug() deliberately not idempotent:
+	 * a guest author called "Cap Ri" has the user_nicename `cap-ri`, and its
+	 * term slug must be `cap-cap-ri`. Collapsing that to `cap-ri` would point
+	 * the byline at whatever author owns that term.
+	 *
+	 * @dataProvider data_slugs_to_prefix
+	 *
+	 * @param string $nicename Input user_nicename.
+	 * @param string $expected Expected term slug.
+	 */
+	public function test_prefix_slug_always_prefixes( string $nicename, string $expected ): void {
+		$this->assertSame( $expected, Prefix::prefix_slug( $nicename ) );
+	}
+
+	/**
+	 * Nicenames and the term slug each should produce.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function data_slugs_to_prefix(): array {
+		return array(
+			'ordinary nicename'    => array( 'ada-lovelace', 'cap-ada-lovelace' ),
+			'nicename starting cap' => array( 'cap-ri', 'cap-cap-ri' ),
+			'nicename containing cap' => array( 'recap-caption', 'cap-recap-caption' ),
+			'empty nicename'       => array( '', 'cap-' ),
+		);
+	}
+
+	/**
+	 * Slug detection is case-sensitive.
+	 *
+	 * Slugs are lower-cased by sanitize_title(), so an upper-case slug cannot
+	 * come from WordPress and is not treated as prefixed.
+	 *
+	 * @dataProvider data_slug_prefix_detection
+	 *
+	 * @param string $slug     Slug under test.
+	 * @param bool   $expected Whether it should count as prefixed.
+	 */
+	public function test_slug_prefix_detection_is_case_sensitive( string $slug, bool $expected ): void {
+		$this->assertSame( $expected, Prefix::slug_has_prefix( $slug ) );
+	}
+
+	/**
+	 * Slugs and whether they count as prefixed.
+	 *
+	 * @return array<string, array{string, bool}>
+	 */
+	public function data_slug_prefix_detection(): array {
+		return array(
+			'prefixed'            => array( 'cap-ada', true ),
+			'doubly prefixed'     => array( 'cap-cap-ri', true ),
+			'bare prefix'         => array( 'cap-', true ),
+			'unprefixed'          => array( 'ada-lovelace', false ),
+			'prefix in the middle' => array( 'recap-caption', false ),
+			'upper-case prefix'   => array( 'CAP-ada', false ),
+			'no dash'             => array( 'capital', false ),
+			'empty'               => array( '', false ),
+		);
+	}
+
+	/**
+	 * Stripping removes one leading prefix and nothing else.
+	 *
+	 * The `recap-caption` row is the bug this replaced: a str_replace() there
+	 * returned `recaption`, and the duplicate-username guard that consumed it
+	 * then looked up the wrong nicename.
+	 *
+	 * @dataProvider data_slugs_to_strip
+	 *
+	 * @param string $slug     Slug under test.
+	 * @param string $expected Expected result.
+	 */
+	public function test_strip_slug_prefix_removes_only_a_leading_prefix( string $slug, string $expected ): void {
+		$this->assertSame( $expected, Prefix::strip_slug_prefix( $slug ) );
+	}
+
+	/**
+	 * Slugs and their stripped form.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function data_slugs_to_strip(): array {
+		return array(
+			'prefixed'             => array( 'cap-ada', 'ada' ),
+			'doubly prefixed loses one' => array( 'cap-cap-ri', 'cap-ri' ),
+			'prefix in the middle survives' => array( 'recap-caption', 'recap-caption' ),
+			'trailing prefix survives' => array( 'cap-ri-cap', 'ri-cap' ),
+			'unprefixed'           => array( 'ada-lovelace', 'ada-lovelace' ),
+			'upper-case prefix survives' => array( 'CAP-ada', 'CAP-ada' ),
+			'bare prefix'          => array( 'cap-', '' ),
+			'empty'                => array( '', '' ),
+		);
+	}
+
+	/**
+	 * Prefixing a slug then stripping it returns the original.
+	 *
+	 * @dataProvider data_slugs_to_prefix
+	 *
+	 * @param string $nicename Input user_nicename.
+	 */
+	public function test_prefixing_then_stripping_a_slug_round_trips( string $nicename ): void {
+		$this->assertSame(
+			$nicename,
+			Prefix::strip_slug_prefix( Prefix::prefix_slug( $nicename ) )
+		);
+	}
+
+	/**
+	 * Meta key prefixing is idempotent and case-insensitive.
+	 *
+	 * Meta keys are not sanitised, so a coauthors_guest_author_fields filter
+	 * can supply `CAP-first_name`. Prefixing that again would read
+	 * `cap-CAP-first_name`, which nothing writes.
+	 *
+	 * @dataProvider data_meta_keys
+	 *
+	 * @param string $key      Input key.
+	 * @param string $expected Expected key.
+	 */
+	public function test_ensure_meta_key_prefix( string $key, string $expected ): void {
+		$this->assertSame( $expected, Prefix::ensure_meta_key_prefix( $key ) );
+	}
+
+	/**
+	 * Applying the meta key prefix twice changes nothing.
+	 *
+	 * @dataProvider data_meta_keys
+	 *
+	 * @param string $key Input key.
+	 */
+	public function test_ensure_meta_key_prefix_is_idempotent( string $key ): void {
+		$once = Prefix::ensure_meta_key_prefix( $key );
+
+		$this->assertSame( $once, Prefix::ensure_meta_key_prefix( $once ) );
+	}
+
+	/**
+	 * Meta keys and their prefixed form.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function data_meta_keys(): array {
+		return array(
+			'unprefixed gains the prefix' => array( 'first_name', 'cap-first_name' ),
+			'prefixed is left alone'      => array( 'cap-first_name', 'cap-first_name' ),
+			'upper-case prefix is left alone' => array( 'CAP-first_name', 'CAP-first_name' ),
+			'mixed-case prefix is left alone' => array( 'Cap-first_name', 'Cap-first_name' ),
+			'prefix elsewhere gains one'  => array( 'linked_cap-account', 'cap-linked_cap-account' ),
+			'merely starts with cap'      => array( 'capital', 'cap-capital' ),
+			'empty gains the bare prefix' => array( '', 'cap-' ),
+		);
+	}
+
+	/**
+	 * The two rules genuinely differ, and the names say which is which.
+	 *
+	 * If someone ever "tidies" prefix_slug() into being idempotent, or drops
+	 * the strtolower() from the meta key rule, this is what fails.
+	 */
+	public function test_the_two_rules_are_not_interchangeable(): void {
+		// Slug prefixing is unconditional; meta key prefixing is not.
+		$this->assertSame( 'cap-cap-ri', Prefix::prefix_slug( 'cap-ri' ) );
+		$this->assertSame( 'cap-ri', Prefix::ensure_meta_key_prefix( 'cap-ri' ) );
+
+		// Slug detection is case-sensitive; meta key detection is not.
+		$this->assertFalse( Prefix::slug_has_prefix( 'CAP-ada' ) );
+		$this->assertTrue( Prefix::meta_key_has_prefix( 'CAP-ada' ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,29 @@ if ( ! $is_integration ) {
 		define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 	}
 
+	/*
+	 * WordPress polyfills the PHP 8 string functions in wp-includes/compat.php,
+	 * and has done since 5.9 — comfortably below the 6.4 this plugin requires,
+	 * so plugin code may use them freely. Without WordPress loaded, the unit
+	 * suite has to stand in for that on the PHP 7.4 leg of the matrix.
+	 */
+	if ( ! function_exists( 'str_starts_with' ) ) {
+		/**
+		 * Polyfill for PHP 8.0's str_starts_with().
+		 *
+		 * @param string $haystack String to search in.
+		 * @param string $needle   String to search for.
+		 * @return bool
+		 */
+		function str_starts_with( string $haystack, string $needle ): bool {
+			if ( '' === $needle ) {
+				return true;
+			}
+
+			return 0 === strncmp( $haystack, $needle, strlen( $needle ) );
+		}
+	}
+
 	return;
 }
 


### PR DESCRIPTION
Closes #1397 in part — see *What this deliberately leaves alone* below.

## Summary

The `cap-` prefix was a bare literal in fifteen places across three files, spelled six different ways — `strpos`, `stripos`, `str_starts_with`, `preg_match`, `str_replace` and plain concatenation — while standing for two unrelated things that follow different rules. `CoAuthors\Prefix` now owns both.

**Slugs** (author term slugs and guest author `post_name` values) pass through `sanitize_title()`, which ends in `strtolower()`, so matching is case-sensitive. Prefixing is *unconditional*, and that turned out to matter: a guest author named "Cap Ri" has the `user_nicename` `cap-ri` and the term slug `cap-cap-ri`. My first draft made the slug prefixer idempotent, which would have collapsed that to `cap-ri` and pointed the byline at whatever author owns that term. `Prefix::prefix_slug()` is deliberately not idempotent, the docblock says why, and a test pins it.

**Postmeta keys** are not sanitised, so a `coauthors_guest_author_fields` filter can supply `CAP-first_name`; matching is case-insensitive and prefixing idempotent, because prefixing such a key again reads a key nothing writes.

The method names carry the difference rather than leaving it to be inferred: `prefix_slug()` always prefixes, `ensure_meta_key_prefix()` only prefixes what is not prefixed already.

## Two call sites were wrong

**`manage_guest_author_filter_post_data()`** stripped the prefix with `str_replace( 'cap-', '', $slug )` — every occurrence, not the leading one. A guest author called "Recap Caption" has the slug `recap-caption`, which became `recaption`, so the duplicate-username guard on the next line looked up an entirely different user. It could refuse a legitimate guest author, or miss a real collision.

| slug | before | after |
|---|---|---|
| `recap-caption` | `recaption` | `recap-caption` |
| `cap-ri-cap` | `ri-cap` | `ri-cap` |
| `cap-ri` | `ri` | `ri` |

**`filter_update_post_metadata()`** tested `false !== strpos( $meta_key, 'cap-' )` — "contains", not "starts with" — so any third-party key containing the string anywhere (`my-cap-setting`) busted the guest author cache on every save. Over-invalidation rather than incorrectness, but not the intent.

Both are covered by integration tests driven through the hooks that reach them, each with a control asserting the guard still fires when it genuinely should — otherwise the whole file would pass against a check that never fired at all.

## What this deliberately leaves alone

`create()` and the post-data filter still build `post_name` values with the **meta key** rule, which is the conflation behind the asymmetry in #1397: `Cap Ri` yields the byline `cap-ri` while `cap-ri`, `CAP-ri` and `Cap-Ri` all yield `ri`. Changing it would change the byline that guest authors created afterwards receive, so it needs a decision and an upgrade path rather than a quiet fix. Both sites now carry a comment saying so and pointing at the issue, so it reads as deliberate instead of accidental. I'd suggest keeping #1397 open for that part.

Also untouched: `cap-create-guest-author`, `cap-display_name`, `cap-linked_account` and the `cap-guest-author` privacy exporter group. Those are plain namespacing, not byline prefixes, and folding them in would imply a relationship that does not exist.

## A note on the unit suite

`Prefix` is pure string handling and belongs in the fast suite, but that suite runs without WordPress on PHP 7.4, where `str_starts_with()` does not exist. WordPress has polyfilled it since 5.9 — comfortably below the required 6.4 — so plugin code may use it freely; `tests/bootstrap.php` now stands in for that guarantee when WordPress is absent.

## Test plan

- [x] `composer test:unit` passes (86 tests, up from 47)
- [x] `composer lint` clean; `composer cs -- tests/` clean
- [x] PHPCS violations across the three touched files drop from 486 to 480; `class-prefix.php` is clean
- [ ] Integration suite in CI (WP 6.4/PHP 7.4 and WP master), including the two bug tests