### PR TITLE
Move guest authors and their bylines between sites

### DIFF
--- a/co-authors-plus.php
+++ b/co-authors-plus.php
@@ -52,6 +52,11 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 global $coauthors_plus;
 $coauthors_plus     = new CoAuthors_Plus();
 $coauthors_plus->register_hooks();
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/php/cli/register-commands.php';
+}
+
 $coauthors_endpoint = new CoAuthors\API\Endpoints( $coauthors_plus );
 $coauthors_endpoint->register_hooks();
 CoAuthors\Blocks::run();

--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -179,6 +179,19 @@ PHP 8.4) rather than inferred from reading the source.
   other feature — guest-author terms are never cleaned up at all — would fail the dry
   scenario with an unrelated "dry run created a term" message.
 
+## CoAuthors_Plus::add_coauthors() return value
+
+- Its return value does not mean "the assignment succeeded". When `$append` is
+  false and none of the given co-authors resolves to a WordPress user, it
+  returns `false` after writing the author terms perfectly well
+  (php/class-coauthors-plus.php, the `false === $append && empty( $new_author )`
+  branch). A byline made up only of guest authors without linked accounts hits
+  this every time, which is the normal case for a guest-author migration.
+- Treating it as a success signal makes a caller report that it changed nothing
+  while the terms are visibly there. Decide "did the byline change" from the
+  byline itself, not from this return value. Pinned by
+  `Coauthor_Assignment_Service` and its regression test.
+
 ## (shared test environment — affects everyone's calibration)
 
 - Author taxonomy terms survive the Behat reset: `reset_database_state()` deletes

--- a/features/export-coauthors.feature
+++ b/features/export-coauthors.feature
@@ -1,0 +1,65 @@
+Feature: Guest authors and their post assignments can be exported
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Warn when there is nothing to export
+		When I run `wp co-authors-plus export-coauthors --file=/tmp/cap-export-empty.json`
+		Then STDOUT should be:
+		"""
+		Warning: No guest authors found, so there is nothing to export.
+		"""
+		And the return code should be 0
+
+	Scenario: Export a guest author and the post it is assigned to
+		When I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Jane Doe", "user_login" => "jane-doe" ) );'`
+		And I run `wp post create --post_status=publish --post_title="Hello" --post_name=hello --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval 'wp_set_post_terms( {POST_ID}, array( "cap-jane-doe" ), "author" );'`
+		When I run `wp co-authors-plus export-coauthors --file=/tmp/cap-export.json`
+		Then STDOUT should be:
+		"""
+		Success: Exported 1 guest authors to /tmp/cap-export.json
+		"""
+		And the return code should be 0
+
+		# Assignments are keyed on slug and post type, never on post ID, because
+		# IDs do not survive a WordPress export and import cycle.
+		When I run `wp eval 'echo wp_json_encode( json_decode( file_get_contents( "/tmp/cap-export.json" ), true )["guest_authors"][0]["post_refs"] );'`
+		Then STDOUT should be:
+		"""
+		[{"post_slug":"hello","post_type":"post","position":0}]
+		"""
+
+		When I run `wp eval 'echo json_decode( file_get_contents( "/tmp/cap-export.json" ), true )["guest_authors"][0]["profile"]["user_login"];'`
+		Then STDOUT should be:
+		"""
+		jane-doe
+		"""
+
+	Scenario: Export a guest author that is not assigned to anything
+		When I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Nobody", "user_login" => "nobody" ) );'`
+		And I run `wp co-authors-plus export-coauthors --file=/tmp/cap-export-lonely.json`
+		Then STDOUT should be:
+		"""
+		Success: Exported 1 guest authors to /tmp/cap-export-lonely.json
+		"""
+		When I run `wp eval 'echo count( json_decode( file_get_contents( "/tmp/cap-export-lonely.json" ), true )["guest_authors"][0]["post_refs"] );'`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Restrict the recorded assignments to given post types
+		When I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Jane Doe", "user_login" => "jane-doe" ) );'`
+		And I run `wp post create --post_status=publish --post_title="A page" --post_name=a-page --post_type=page --porcelain`
+		And save STDOUT as {PAGE_ID}
+		And I run `wp eval 'wp_set_post_terms( {PAGE_ID}, array( "cap-jane-doe" ), "author" );'`
+		When I run `wp co-authors-plus export-coauthors --file=/tmp/cap-export-types.json --post-types=post`
+		Then the return code should be 0
+		When I run `wp eval 'echo count( json_decode( file_get_contents( "/tmp/cap-export-types.json" ), true )["guest_authors"][0]["post_refs"] );'`
+		Then STDOUT should be:
+		"""
+		0
+		"""

--- a/features/import-coauthors.feature
+++ b/features/import-coauthors.feature
@@ -1,0 +1,122 @@
+Feature: Guest authors and their post assignments can be imported
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: Error when no file is given
+		When I try `wp co-authors-plus import-coauthors`
+		Then STDERR should contain:
+		"""
+		missing --file parameter
+		"""
+		And the return code should be 1
+
+	Scenario: Error on a file that is not JSON
+		When I run `wp eval 'file_put_contents( "/tmp/cap-not-json.txt", "not json {{" );'`
+		And I try `wp co-authors-plus import-coauthors --file=/tmp/cap-not-json.txt`
+		Then STDERR should be:
+		"""
+		Error: /tmp/cap-not-json.txt is not valid JSON.
+		"""
+		And the return code should be 1
+
+	Scenario: Error on JSON that is not an export
+		When I run `wp eval 'file_put_contents( "/tmp/cap-no-list.json", wp_json_encode( array( "version" => "4.1.1" ) ) );'`
+		And I try `wp co-authors-plus import-coauthors --file=/tmp/cap-no-list.json`
+		Then STDERR should be:
+		"""
+		Error: Export is missing a "guest_authors" list. Was the file produced by export-coauthors?
+		"""
+		And the return code should be 1
+
+	Scenario: Point out a file written by a different version
+		When I run `wp eval 'file_put_contents( "/tmp/cap-old.json", wp_json_encode( array( "version" => "1.0.0", "guest_authors" => array() ) ) );'`
+		And I run `wp co-authors-plus import-coauthors --file=/tmp/cap-old.json`
+		Then STDOUT should contain:
+		"""
+		This file was written by Co-Authors Plus 1.0.0
+		"""
+		And the return code should be 0
+
+	# The login here differs in case and punctuation from the nicename the byline
+	# is keyed on, which is the case a naive implementation gets wrong.
+	Scenario: Restore a profile and put it back on its post
+		When I run `wp post create --post_status=publish --post_title="Hello" --post_name=hello --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval 'file_put_contents( "/tmp/cap-in.json", wp_json_encode( array( "version" => "4.1.1", "guest_authors" => array( array( "profile" => array( "display_name" => "Jane Doe", "user_login" => "Jane.Doe" ), "post_refs" => array( array( "post_slug" => "hello", "post_type" => "post", "position" => 0 ) ) ) ) ) ) );'`
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-in.json`
+		Then STDOUT should be:
+		"""
+		Success: Created 1 profiles and linked 1 posts.
+		"""
+		And the return code should be 0
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+
+		# Running it again must not duplicate the byline.
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-in.json`
+		Then STDOUT should be:
+		"""
+		Success: Created 0 profiles and linked 0 posts. 1 profiles already existed.
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+
+	Scenario: A dry run reports what it would do and writes nothing
+		When I run `wp post create --post_status=publish --post_title="Hello" --post_name=hello --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval 'file_put_contents( "/tmp/cap-dry.json", wp_json_encode( array( "version" => "4.1.1", "guest_authors" => array( array( "profile" => array( "display_name" => "Jane Doe", "user_login" => "jane-doe" ), "post_refs" => array( array( "post_slug" => "hello", "post_type" => "post", "position" => 0 ) ) ) ) ) ) );'`
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-dry.json --dry-run`
+		Then STDOUT should be:
+		"""
+		Dry run: nothing will be written.
+		Success: Would create 1 profiles and linked 1 posts.
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: --skip-create leaves a missing profile uncreated
+		When I run `wp post create --post_status=publish --post_title="Hello" --post_name=hello --porcelain`
+		And I run `wp eval 'file_put_contents( "/tmp/cap-skip.json", wp_json_encode( array( "version" => "4.1.1", "guest_authors" => array( array( "profile" => array( "display_name" => "Jane Doe", "user_login" => "jane-doe" ), "post_refs" => array( array( "post_slug" => "hello", "post_type" => "post", "position" => 0 ) ) ) ) ) ) );'`
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-skip.json --skip-create`
+		Then STDOUT should contain:
+		"""
+		Success: Created 0 profiles and linked 0 posts.
+		"""
+		And STDOUT should contain:
+		"""
+		No profile for "jane-doe" and --skip-create was given.
+		"""
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: Report an assignment whose post is not on this site
+		When I run `wp eval 'file_put_contents( "/tmp/cap-missing.json", wp_json_encode( array( "version" => "4.1.1", "guest_authors" => array( array( "profile" => array( "display_name" => "Jane Doe", "user_login" => "jane-doe" ), "post_refs" => array( array( "post_slug" => "not-here", "post_type" => "post", "position" => 0 ) ) ) ) ) ) );'`
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-missing.json`
+		Then STDOUT should contain:
+		"""
+		1 assignments had no matching post on this site.
+		"""
+		And STDOUT should contain:
+		"""
+		No post found with slug "not-here".
+		"""
+		And the return code should be 0

--- a/features/testing.feature
+++ b/features/testing.feature
@@ -53,6 +53,14 @@
       """
     And STDOUT should contain:
       """
+      export-coauthors
+      """
+    And STDOUT should contain:
+      """
+      import-coauthors
+      """
+    And STDOUT should contain:
+      """
       list-authors
       """
     And STDOUT should contain:

--- a/php/cli/class-export-coauthors-command.php
+++ b/php/cli/class-export-coauthors-command.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * The export-coauthors WP-CLI command.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\CLI;
+
+use Automattic\CoAuthorsPlus\Services\Coauthor_Export_Service;
+use CoAuthors_Plus;
+use WP_CLI;
+use WP_CLI\Utils;
+
+/**
+ * Writes the site's guest authors out to a file.
+ *
+ * Holds only the concerns of running as a command: reading arguments, showing
+ * progress, writing the file and reporting. What to export is decided by
+ * Coauthor_Export_Service, which is where that logic is tested.
+ */
+class Export_Coauthors_Command {
+
+	/**
+	 * Plugin instance, for the default post type list.
+	 *
+	 * @var CoAuthors_Plus
+	 */
+	private $coauthors_plus;
+
+	/**
+	 * Export builder.
+	 *
+	 * @var Coauthor_Export_Service
+	 */
+	private $export;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CoAuthors_Plus          $coauthors_plus Plugin instance.
+	 * @param Coauthor_Export_Service $export         Export builder.
+	 */
+	public function __construct( CoAuthors_Plus $coauthors_plus, Coauthor_Export_Service $export ) {
+		$this->coauthors_plus = $coauthors_plus;
+		$this->export         = $export;
+	}
+
+	/**
+	 * Export guest authors and their post assignments to a JSON file.
+	 *
+	 * Assignments are recorded by post slug and post type, not by ID, so the
+	 * file still means something after a WordPress export and import cycle has
+	 * renumbered the posts. Feed it to import-coauthors on the far side.
+	 *
+	 * Only guest author profiles are exported. Co-authors that are WordPress
+	 * users are left alone, since those accounts are moved by other means.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--file=<path>]
+	 * : Where to write the file. Defaults to cap-coauthors-export.json inside
+	 * wp-content.
+	 *
+	 * [--post-types=<post-types>]
+	 * : Comma-separated post types to record assignments for. Defaults to the
+	 * post types Co-Authors Plus is enabled for.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Export every guest author and assignment.
+	 *     $ wp co-authors-plus export-coauthors
+	 *     Success: Exported 12 guest authors to /var/www/wp-content/cap-coauthors-export.json
+	 *
+	 *     # Export assignments on posts and pages only, to a chosen path.
+	 *     $ wp co-authors-plus export-coauthors --file=/tmp/authors.json --post-types=post,page
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param string[]              $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$file       = (string) Utils\get_flag_value( $assoc_args, 'file', WP_CONTENT_DIR . '/cap-coauthors-export.json' );
+		$post_types = $this->post_types( $assoc_args );
+
+		$ids = $this->export->guest_author_ids();
+
+		if ( empty( $ids ) ) {
+			WP_CLI::warning( 'No guest authors found, so there is nothing to export.' );
+			return;
+		}
+
+		$progress = Utils\make_progress_bar( 'Exporting guest authors', count( $ids ) );
+		$entries  = array();
+
+		foreach ( $ids as $id ) {
+			$entry = $this->export->entry_for( $id, $post_types );
+
+			if ( null === $entry ) {
+				WP_CLI::warning( sprintf( 'Could not read guest author %d, so it is not in the file.', $id ) );
+			} else {
+				$entries[] = $entry;
+			}
+
+			$progress->tick();
+		}
+
+		$progress->finish();
+
+		$this->write(
+			$file,
+			array(
+				'version'       => COAUTHORS_PLUS_VERSION,
+				'exported_at'   => gmdate( 'c' ),
+				'post_types'    => $post_types,
+				'guest_authors' => $entries,
+			)
+		);
+
+		WP_CLI::success( sprintf( 'Exported %d guest authors to %s', count( $entries ), $file ) );
+	}
+
+	/**
+	 * Post types to record assignments for.
+	 *
+	 * @param array<string, string> $assoc_args Associative arguments.
+	 * @return string[]
+	 */
+	private function post_types( array $assoc_args ): array {
+		$given = Utils\get_flag_value( $assoc_args, 'post-types' );
+
+		if ( null === $given ) {
+			return $this->coauthors_plus->supported_post_types();
+		}
+
+		return array_values( array_filter( array_map( 'sanitize_key', explode( ',', (string) $given ) ) ) );
+	}
+
+	/**
+	 * Write the export, failing loudly if it cannot be written.
+	 *
+	 * @param string               $file   Destination path.
+	 * @param array<string, mixed> $export Export payload.
+	 * @return void
+	 */
+	private function write( string $file, array $export ): void {
+		$json = wp_json_encode( $export, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		if ( false === $json ) {
+			WP_CLI::error( 'Could not encode the export as JSON.' );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writing a file the operator named, outside the uploads directory.
+		if ( false === file_put_contents( $file, $json ) ) {
+			WP_CLI::error( sprintf( 'Could not write to %s. Check the path exists and is writable.', $file ) );
+		}
+	}
+}

--- a/php/cli/class-import-coauthors-command.php
+++ b/php/cli/class-import-coauthors-command.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * The import-coauthors WP-CLI command.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\CLI;
+
+use Automattic\CoAuthorsPlus\Services\Coauthor_Import_Service;
+use InvalidArgumentException;
+use WP_CLI;
+use WP_CLI\Utils;
+
+/**
+ * Restores guest authors from a file written by export-coauthors.
+ *
+ * Holds only the concerns of running as a command: reading arguments and the
+ * file, and reporting what happened. The restoring itself is
+ * Coauthor_Import_Service, which is where that logic is tested.
+ */
+class Import_Coauthors_Command {
+
+	/**
+	 * Import runner.
+	 *
+	 * @var Coauthor_Import_Service
+	 */
+	private $import;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Coauthor_Import_Service $import Import runner.
+	 */
+	public function __construct( Coauthor_Import_Service $import ) {
+		$this->import = $import;
+	}
+
+	/**
+	 * Import guest authors and their post assignments from a JSON file.
+	 *
+	 * Creates any guest author profile the file describes and this site does
+	 * not have, then puts each author back on the posts it was on, matched by
+	 * slug and post type and restored to its original position in the byline.
+	 *
+	 * Safe to run more than once: an author already on a post is left alone,
+	 * so a run that was interrupted can simply be repeated.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --file=<path>
+	 * : The file to read, as written by export-coauthors.
+	 *
+	 * [--dry-run]
+	 * : Report what would happen without writing anything.
+	 *
+	 * [--skip-create]
+	 * : Only put authors back on posts. Profiles this site does not already
+	 * have are left uncreated, which is what you want when the guest author
+	 * posts have arrived by WordPress import already.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # See what would happen.
+	 *     $ wp co-authors-plus import-coauthors --file=/tmp/authors.json --dry-run
+	 *
+	 *     # Do it.
+	 *     $ wp co-authors-plus import-coauthors --file=/tmp/authors.json
+	 *     Success: Created 12 profiles and linked 84 posts.
+	 *
+	 *     # Only re-link, because the profiles came over with a WordPress import.
+	 *     $ wp co-authors-plus import-coauthors --file=/tmp/authors.json --skip-create
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param string[]              $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$file        = (string) Utils\get_flag_value( $assoc_args, 'file', '' );
+		$dry_run     = (bool) Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$skip_create = (bool) Utils\get_flag_value( $assoc_args, 'skip-create', false );
+
+		$data = $this->read( $file );
+
+		$this->warn_on_version_mismatch( $data );
+
+		if ( $dry_run ) {
+			WP_CLI::log( 'Dry run: nothing will be written.' );
+		}
+
+		try {
+			$summary = $this->import->import( $data, $dry_run, $skip_create );
+		} catch ( InvalidArgumentException $e ) {
+			WP_CLI::error( $e->getMessage() );
+			return;
+		}
+
+		$this->report( $summary, $dry_run );
+	}
+
+	/**
+	 * Read and decode the export.
+	 *
+	 * @param string $file Path to read.
+	 * @return array<string, mixed>
+	 */
+	private function read( string $file ): array {
+		if ( '' === $file || ! is_readable( $file ) ) {
+			WP_CLI::error( sprintf( 'Cannot read %s. Pass --file=<path> to a file written by export-coauthors.', $file ) );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local file the operator named.
+		$raw = file_get_contents( $file );
+
+		if ( false === $raw ) {
+			WP_CLI::error( sprintf( 'Could not read %s.', $file ) );
+		}
+
+		$data = json_decode( (string) $raw, true );
+
+		if ( ! is_array( $data ) ) {
+			WP_CLI::error( sprintf( '%s is not valid JSON.', $file ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Point out that the file came from a different version of the plugin.
+	 *
+	 * Not fatal, but worth saying: the shape of a profile can change between
+	 * versions, and an unexplained result is easier to understand with this in
+	 * the scrollback.
+	 *
+	 * @param array<string, mixed> $data Decoded export.
+	 * @return void
+	 */
+	private function warn_on_version_mismatch( array $data ): void {
+		$version = (string) ( $data['version'] ?? '' );
+
+		if ( '' === $version || COAUTHORS_PLUS_VERSION === $version ) {
+			return;
+		}
+
+		WP_CLI::warning(
+			sprintf(
+				'This file was written by Co-Authors Plus %s and this site runs %s. Check the results.',
+				$version,
+				COAUTHORS_PLUS_VERSION
+			)
+		);
+	}
+
+	/**
+	 * Report what the import did.
+	 *
+	 * @param array<string, mixed> $summary Import summary.
+	 * @param bool                 $dry_run Whether anything was written.
+	 * @return void
+	 */
+	private function report( array $summary, bool $dry_run ): void {
+		foreach ( $summary['warnings'] as $warning ) {
+			WP_CLI::warning( $warning );
+		}
+
+		if ( $summary['posts_not_found'] > 0 ) {
+			WP_CLI::log(
+				sprintf(
+					'%d assignments had no matching post on this site.',
+					$summary['posts_not_found']
+				)
+			);
+		}
+
+		$message = sprintf(
+			'%s %d profiles and linked %d posts.',
+			$dry_run ? 'Would create' : 'Created',
+			$summary['authors_created'],
+			$summary['posts_linked']
+		);
+
+		if ( $summary['authors_skipped'] > 0 ) {
+			$message .= sprintf( ' %d profiles already existed.', $summary['authors_skipped'] );
+		}
+
+		WP_CLI::success( $message );
+	}
+}

--- a/php/cli/register-commands.php
+++ b/php/cli/register-commands.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Registers the WP-CLI commands that are classes of their own.
+ *
+ * Loaded after $coauthors_plus exists, because the commands take their
+ * collaborators through the constructor rather than reaching for globals.
+ * Registering a class name instead would hand WP-CLI the job of constructing
+ * them, which it can only do for a no-argument constructor.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+use Automattic\CoAuthorsPlus\CLI\Export_Coauthors_Command;
+use Automattic\CoAuthorsPlus\CLI\Import_Coauthors_Command;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Assignment_Service;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Export_Service;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Import_Service;
+use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+// The plugin does not ship Composer's autoloader, so every class is required
+// explicitly, as the rest of the plugin does.
+require_once __DIR__ . '/../services/class-coauthor-assignment-service.php';
+require_once __DIR__ . '/../services/class-guest-author-service.php';
+require_once __DIR__ . '/../services/class-coauthor-export-service.php';
+require_once __DIR__ . '/../services/class-coauthor-import-service.php';
+require_once __DIR__ . '/class-export-coauthors-command.php';
+require_once __DIR__ . '/class-import-coauthors-command.php';
+
+// Registration waits for init, because CoAuthors_Plus builds its guest authors
+// instance there, and these commands take theirs through the constructor.
+add_action(
+	'init',
+	static function (): void {
+		global $coauthors_plus;
+
+		// Guest authors can be switched off, in which case the plugin never
+		// builds the instance and there is nothing for these commands to act
+		// on. The rest of the guest author functionality is loaded on the same
+		// condition, so leaving them unregistered is consistent with it.
+		if ( ! $coauthors_plus instanceof CoAuthors_Plus || ! $coauthors_plus->guest_authors instanceof CoAuthors_Guest_Authors ) {
+			return;
+		}
+
+		$assignments   = new Coauthor_Assignment_Service( $coauthors_plus );
+		$guest_authors = new Guest_Author_Service( $coauthors_plus->guest_authors );
+
+		WP_CLI::add_command(
+			'co-authors-plus export-coauthors',
+			new Export_Coauthors_Command(
+				$coauthors_plus,
+				new Coauthor_Export_Service( $coauthors_plus, $guest_authors, $assignments )
+			)
+		);
+
+		WP_CLI::add_command(
+			'co-authors-plus import-coauthors',
+			new Import_Coauthors_Command(
+				new Coauthor_Import_Service( $guest_authors, $assignments )
+			)
+		);
+	},
+	20
+);

--- a/php/services/class-coauthor-assignment-service.php
+++ b/php/services/class-coauthor-assignment-service.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Reads and writes which co-authors are assigned to a post.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Services;
+
+use CoAuthors_Plus;
+
+/**
+ * Reads and writes a post's co-author assignments.
+ *
+ * Every write path in the plugin — the classic metabox, both block editor
+ * routes, bulk edit, user-deletion reassignment and the CLI — already funnels
+ * into CoAuthors_Plus::add_coauthors(), so this wraps that rather than
+ * reimplementing any of it.
+ *
+ * The reads deliberately do not use get_coauthors(), which falls back to the
+ * post_author user when a post carries no author terms. That fallback is right
+ * for display but wrong when rebuilding an assignment: it splices a user into
+ * the list who was never assigned. This reads the taxonomy directly instead.
+ */
+class Coauthor_Assignment_Service {
+
+	/**
+	 * The plugin instance the assignments are read from and written through.
+	 *
+	 * @var CoAuthors_Plus
+	 */
+	private $coauthors_plus;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CoAuthors_Plus $coauthors_plus Plugin instance.
+	 */
+	public function __construct( CoAuthors_Plus $coauthors_plus ) {
+		$this->coauthors_plus = $coauthors_plus;
+	}
+
+	/**
+	 * Get a post's assigned co-authors, in byline order.
+	 *
+	 * Author term slugs are `cap-{user_nicename}`, and add_coauthors() matches
+	 * on user_nicename by default, so nicenames are what both sides of this
+	 * class speak. Mixing them with user_login values is the mistake this
+	 * naming exists to prevent: the two differ whenever a login contains
+	 * characters sanitize_title() rewrites.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string[] user_nicename values, in byline order.
+	 */
+	public function nicenames_for_post( int $post_id ): array {
+		$terms = wp_get_object_terms(
+			$post_id,
+			$this->coauthors_plus->coauthor_taxonomy,
+			array( 'orderby' => 'term_order' )
+		);
+
+		if ( is_wp_error( $terms ) ) {
+			return array();
+		}
+
+		$nicenames = array();
+
+		foreach ( $terms as $term ) {
+			// Only the prefix the plugin adds comes off: a nicename may itself
+			// begin with 'cap-', giving a doubly prefixed slug. Matches the
+			// str_starts_with idiom used for the other prefix checks, and is
+			// deliberately case sensitive, as the stored slug is lower case.
+			$nicenames[] = str_starts_with( $term->slug, 'cap-' )
+				? substr( $term->slug, strlen( 'cap-' ) )
+				: $term->slug;
+		}
+
+		return $nicenames;
+	}
+
+	/**
+	 * Replace a post's co-authors with the given ordered list.
+	 *
+	 * @param int      $post_id   Post ID.
+	 * @param string[] $nicenames user_nicename values, in the desired order.
+	 * @return bool Whether the assignment succeeded.
+	 */
+	public function assign( int $post_id, array $nicenames ): bool {
+		return $this->coauthors_plus->add_coauthors( $post_id, $nicenames, false );
+	}
+
+	/**
+	 * Add a co-author to a post at a given byline position.
+	 *
+	 * Positions beyond the end of the current byline append. Re-adding a
+	 * co-author already on the post is a no-op, which is what makes an import
+	 * safe to run twice.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param string $nicename user_nicename to add.
+	 * @param int    $position Zero-based byline position.
+	 * @return bool Whether the post was changed.
+	 */
+	public function add_at_position( int $post_id, string $nicename, int $position ): bool {
+		$nicenames = $this->nicenames_for_post( $post_id );
+
+		if ( in_array( $nicename, $nicenames, true ) ) {
+			return false;
+		}
+
+		array_splice( $nicenames, min( $position, count( $nicenames ) ), 0, array( $nicename ) );
+
+		return $this->assign( $post_id, $nicenames );
+	}
+}

--- a/php/services/class-coauthor-assignment-service.php
+++ b/php/services/class-coauthor-assignment-service.php
@@ -98,10 +98,16 @@ class Coauthor_Assignment_Service {
 	 * co-author already on the post is a no-op, which is what makes an import
 	 * safe to run twice.
 	 *
+	 * Whether the byline changed is decided here rather than taken from
+	 * add_coauthors(), whose return value does not mean what it appears to: it
+	 * returns false when replacing a byline that resolves to no WordPress user,
+	 * which is every byline made up only of guest authors without linked
+	 * accounts, having written the terms perfectly well.
+	 *
 	 * @param int    $post_id  Post ID.
 	 * @param string $nicename user_nicename to add.
 	 * @param int    $position Zero-based byline position.
-	 * @return bool Whether the post was changed.
+	 * @return bool Whether the byline was changed.
 	 */
 	public function add_at_position( int $post_id, string $nicename, int $position ): bool {
 		$nicenames = $this->nicenames_for_post( $post_id );
@@ -112,6 +118,8 @@ class Coauthor_Assignment_Service {
 
 		array_splice( $nicenames, min( $position, count( $nicenames ) ), 0, array( $nicename ) );
 
-		return $this->assign( $post_id, $nicenames );
+		$this->assign( $post_id, $nicenames );
+
+		return true;
 	}
 }

--- a/php/services/class-coauthor-export-service.php
+++ b/php/services/class-coauthor-export-service.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Builds a portable representation of the site's guest authors.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Services;
+
+use CoAuthors_Plus;
+
+/**
+ * Builds a portable representation of the site's guest authors.
+ *
+ * Post assignments are recorded by slug and post type rather than by ID,
+ * because IDs are reassigned by a WordPress export and import cycle and would
+ * point at unrelated posts, or nothing, on the far side.
+ */
+class Coauthor_Export_Service {
+
+	/**
+	 * How many guest authors to load per batch.
+	 */
+	private const BATCH_SIZE = 500;
+
+	/**
+	 * Plugin instance.
+	 *
+	 * @var CoAuthors_Plus
+	 */
+	private $coauthors_plus;
+
+	/**
+	 * Guest author profile reader.
+	 *
+	 * @var Guest_Author_Service
+	 */
+	private $guest_authors;
+
+	/**
+	 * Byline reader.
+	 *
+	 * @var Coauthor_Assignment_Service
+	 */
+	private $assignments;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CoAuthors_Plus              $coauthors_plus Plugin instance.
+	 * @param Guest_Author_Service        $guest_authors  Guest author profiles.
+	 * @param Coauthor_Assignment_Service $assignments    Byline reader.
+	 */
+	public function __construct(
+		CoAuthors_Plus $coauthors_plus,
+		Guest_Author_Service $guest_authors,
+		Coauthor_Assignment_Service $assignments
+	) {
+		$this->coauthors_plus = $coauthors_plus;
+		$this->guest_authors  = $guest_authors;
+		$this->assignments    = $assignments;
+	}
+
+	/**
+	 * Every guest author ID on the site, oldest first.
+	 *
+	 * Loaded in batches so a site with a large contributor list does not have
+	 * to hold an unbounded query result.
+	 *
+	 * @return int[]
+	 */
+	public function guest_author_ids(): array {
+		$ids   = array();
+		$paged = 1;
+
+		do {
+			$batch = get_posts(
+				array(
+					'post_type'        => $this->coauthors_plus->guest_authors->post_type,
+					'post_status'      => 'any',
+					'posts_per_page'   => self::BATCH_SIZE,
+					'paged'            => $paged,
+					'orderby'          => 'ID',
+					'order'            => 'ASC',
+					'fields'           => 'ids',
+					'suppress_filters' => false,
+				)
+			);
+
+			$found = count( $batch );
+			$ids   = array_merge( $ids, $batch );
+			++$paged;
+		} while ( self::BATCH_SIZE === $found );
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Build the export for one guest author.
+	 *
+	 * @param int      $guest_author_id Guest author post ID.
+	 * @param string[] $post_types      Post types to record assignments for.
+	 * @return array<string, mixed>|null Null when the profile cannot be loaded.
+	 */
+	public function entry_for( int $guest_author_id, array $post_types ): ?array {
+		$guest_author = $this->guest_authors->find_by( 'ID', (string) $guest_author_id );
+
+		if ( ! $guest_author ) {
+			return null;
+		}
+
+		return array(
+			'profile'   => $this->guest_authors->profile( $guest_author ),
+			'post_refs' => $this->post_refs_for( $guest_author, $post_types ),
+		);
+	}
+
+	/**
+	 * Where a guest author appears across the site's posts.
+	 *
+	 * @param object   $guest_author Guest author object.
+	 * @param string[] $post_types   Post types to look in.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function post_refs_for( $guest_author, array $post_types ): array {
+		$term = $this->coauthors_plus->get_author_term( $guest_author );
+
+		if ( ! $term ) {
+			return array();
+		}
+
+		// ponytail: one byline read per matched post. Fine for a migration run,
+		// and the position data is only available per post; if this becomes the
+		// bottleneck on a large site, read term_order in bulk behind a
+		// repository rather than adding SQL here.
+		$refs = array();
+
+		foreach ( $this->posts_with_term( (int) $term->term_id, $post_types ) as $post ) {
+			$position = array_search(
+				$guest_author->user_nicename,
+				$this->assignments->nicenames_for_post( (int) $post->ID ),
+				true
+			);
+
+			$refs[] = array(
+				'post_slug' => $post->post_name,
+				'post_type' => $post->post_type,
+				'position'  => false === $position ? 0 : (int) $position,
+			);
+		}
+
+		return $refs;
+	}
+
+	/**
+	 * Posts carrying a given author term, in batches.
+	 *
+	 * @param int      $term_id    Author term ID.
+	 * @param string[] $post_types Post types to look in.
+	 * @return object[]
+	 */
+	private function posts_with_term( int $term_id, array $post_types ): array {
+		$posts = array();
+		$paged = 1;
+
+		do {
+			$batch = get_posts(
+				array(
+					'post_type'        => $post_types,
+					'post_status'      => 'any',
+					'posts_per_page'   => self::BATCH_SIZE,
+					'paged'            => $paged,
+					'orderby'          => 'ID',
+					'order'            => 'ASC',
+					'suppress_filters' => false,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					'tax_query'        => array(
+						array(
+							'taxonomy' => $this->coauthors_plus->coauthor_taxonomy,
+							'field'    => 'term_id',
+							'terms'    => array( $term_id ),
+						),
+					),
+				)
+			);
+
+			$found = count( $batch );
+			$posts = array_merge( $posts, $batch );
+			++$paged;
+		} while ( self::BATCH_SIZE === $found );
+
+		return $posts;
+	}
+}

--- a/php/services/class-coauthor-import-service.php
+++ b/php/services/class-coauthor-import-service.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Restores guest authors and their post assignments from an export.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Services;
+
+use InvalidArgumentException;
+
+/**
+ * Restores guest authors and their post assignments from an export.
+ *
+ * Reports problems by returning counts and warnings, and refuses malformed
+ * input by throwing. Nothing here knows about WP-CLI, so the whole of it can
+ * be exercised without a WordPress install: the caller decides how a warning
+ * or a failure is presented.
+ */
+class Coauthor_Import_Service {
+
+	/**
+	 * Guest author profile reader and writer.
+	 *
+	 * @var Guest_Author_Service
+	 */
+	private $guest_authors;
+
+	/**
+	 * Byline reader and writer.
+	 *
+	 * @var Coauthor_Assignment_Service
+	 */
+	private $assignments;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Guest_Author_Service        $guest_authors Guest author profiles.
+	 * @param Coauthor_Assignment_Service $assignments   Byline writer.
+	 */
+	public function __construct(
+		Guest_Author_Service $guest_authors,
+		Coauthor_Assignment_Service $assignments
+	) {
+		$this->guest_authors = $guest_authors;
+		$this->assignments   = $assignments;
+	}
+
+	/**
+	 * Restore an export.
+	 *
+	 * @param array<string, mixed> $data        Decoded export.
+	 * @param bool                 $dry_run     Report what would happen, write nothing.
+	 * @param bool                 $skip_create Only re-link posts; do not create profiles.
+	 * @return array<string, mixed> Counts, plus any warnings for the caller to report.
+	 * @throws InvalidArgumentException When the export is not the expected shape.
+	 */
+	public function import( array $data, bool $dry_run = false, bool $skip_create = false ): array {
+		if ( ! isset( $data['guest_authors'] ) || ! is_array( $data['guest_authors'] ) ) {
+			throw new InvalidArgumentException(
+				'Export is missing a "guest_authors" list. Was the file produced by export-coauthors?'
+			);
+		}
+
+		$summary = array(
+			'authors_created' => 0,
+			'authors_skipped' => 0,
+			'posts_linked'    => 0,
+			'posts_not_found' => 0,
+			'warnings'        => array(),
+		);
+
+		foreach ( $data['guest_authors'] as $entry ) {
+			$this->import_entry( (array) $entry, $dry_run, $skip_create, $summary );
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Restore one guest author and its assignments.
+	 *
+	 * @param array<string, mixed> $entry       One guest_authors element.
+	 * @param bool                 $dry_run     Whether to write anything.
+	 * @param bool                 $skip_create Whether to create missing profiles.
+	 * @param array<string, mixed> $summary     Running summary, by reference.
+	 * @return void
+	 */
+	private function import_entry( array $entry, bool $dry_run, bool $skip_create, array &$summary ): void {
+		$profile    = isset( $entry['profile'] ) ? (array) $entry['profile'] : array();
+		$user_login = (string) ( $profile['user_login'] ?? '' );
+
+		if ( '' === $user_login ) {
+			$summary['warnings'][] = 'Skipped an entry with no user_login.';
+			return;
+		}
+
+		$guest_author = $this->guest_authors->find_by( 'user_login', $user_login );
+
+		if ( $guest_author ) {
+			++$summary['authors_skipped'];
+		} elseif ( $skip_create ) {
+			++$summary['authors_skipped'];
+		} elseif ( $dry_run ) {
+			++$summary['authors_created'];
+		} else {
+			$guest_author = $this->create( $profile, $user_login, $summary );
+
+			if ( ! $guest_author ) {
+				return;
+			}
+
+			++$summary['authors_created'];
+		}
+
+		$post_refs = isset( $entry['post_refs'] ) ? (array) $entry['post_refs'] : array();
+
+		foreach ( $post_refs as $ref ) {
+			$this->link( (array) $ref, $guest_author, $dry_run, $summary );
+		}
+	}
+
+	/**
+	 * Create a missing guest author profile.
+	 *
+	 * @param array<string, mixed> $profile    Profile fields.
+	 * @param string               $user_login Login being created.
+	 * @param array<string, mixed> $summary    Running summary, by reference.
+	 * @return object|false The created guest author, or false on failure.
+	 */
+	private function create( array $profile, string $user_login, array &$summary ) {
+		$created = $this->guest_authors->create( $profile );
+
+		if ( is_wp_error( $created ) ) {
+			$summary['warnings'][] = sprintf(
+				'Could not create "%s": %s',
+				$user_login,
+				$created->get_error_message()
+			);
+
+			return false;
+		}
+
+		// Re-read rather than assume: the byline is keyed on user_nicename,
+		// which create() derives from the login and may not match it.
+		return $this->guest_authors->find_by( 'ID', (string) $created );
+	}
+
+	/**
+	 * Re-link one post to a guest author.
+	 *
+	 * @param array<string, mixed> $ref          One post_refs element.
+	 * @param object|false         $guest_author Resolved guest author, if any.
+	 * @param bool                 $dry_run      Whether to write anything.
+	 * @param array<string, mixed> $summary      Running summary, by reference.
+	 * @return void
+	 */
+	private function link( array $ref, $guest_author, bool $dry_run, array &$summary ): void {
+		$slug = (string) ( $ref['post_slug'] ?? '' );
+
+		if ( '' === $slug ) {
+			$summary['warnings'][] = 'Skipped a post reference with no slug.';
+			return;
+		}
+
+		$post_type = (string) ( $ref['post_type'] ?? 'post' );
+		$post_id   = $this->find_post( $slug, $post_type );
+
+		if ( ! $post_id ) {
+			++$summary['posts_not_found'];
+			$summary['warnings'][] = sprintf( 'No %s found with slug "%s".', $post_type, $slug );
+			return;
+		}
+
+		if ( $dry_run ) {
+			++$summary['posts_linked'];
+			return;
+		}
+
+		if ( ! $guest_author ) {
+			$summary['warnings'][] = sprintf(
+				'No profile to link to "%s"; run without --skip-create to create it.',
+				$slug
+			);
+			return;
+		}
+
+		$changed = $this->assignments->add_at_position(
+			$post_id,
+			(string) $guest_author->user_nicename,
+			(int) ( $ref['position'] ?? 0 )
+		);
+
+		if ( $changed ) {
+			++$summary['posts_linked'];
+		}
+	}
+
+	/**
+	 * Resolve a post by slug and post type.
+	 *
+	 * @param string $slug      Post slug.
+	 * @param string $post_type Post type.
+	 * @return int|null Post ID, or null when absent.
+	 */
+	private function find_post( string $slug, string $post_type ): ?int {
+		$posts = get_posts(
+			array(
+				'name'             => $slug,
+				'post_type'        => $post_type,
+				'post_status'      => 'any',
+				'posts_per_page'   => 1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => false,
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			return null;
+		}
+
+		return (int) $posts[0];
+	}
+}

--- a/php/services/class-coauthor-import-service.php
+++ b/php/services/class-coauthor-import-service.php
@@ -103,7 +103,10 @@ class Coauthor_Import_Service {
 		if ( $guest_author ) {
 			++$summary['authors_skipped'];
 		} elseif ( $skip_create ) {
-			++$summary['authors_skipped'];
+			// Deliberately not counted as skipped: that count is reported as
+			// profiles that already existed, and this one did not. The missing
+			// profile is reported against each post it cannot be linked to.
+			$summary['warnings'][] = sprintf( 'No profile for "%s" and --skip-create was given.', $user_login );
 		} elseif ( $dry_run ) {
 			++$summary['authors_created'];
 		} else {

--- a/php/services/class-guest-author-service.php
+++ b/php/services/class-guest-author-service.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Reads and writes guest author profiles.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Services;
+
+use CoAuthors_Guest_Authors;
+use WP_Error;
+
+/**
+ * Reads and writes guest author profiles.
+ *
+ * Both halves are driven by get_guest_author_fields() rather than a hard-coded
+ * list, which means a field added through the coauthors_guest_author_fields
+ * filter is carried across by anything using this service, instead of being
+ * silently dropped.
+ *
+ * Writes apply each field's declared sanitize_function, falling back to
+ * sanitize_text_field, which is what the Add New / Edit Guest Author screen
+ * does on save. CoAuthors_Guest_Authors::create() itself stores whatever it is
+ * handed, so without this a profile created from a file would keep raw values
+ * where the same profile typed into the admin would not.
+ */
+class Guest_Author_Service {
+
+	/**
+	 * The guest authors instance profiles are read from and written through.
+	 *
+	 * @var CoAuthors_Guest_Authors
+	 */
+	private $guest_authors;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CoAuthors_Guest_Authors $guest_authors Guest authors instance.
+	 */
+	public function __construct( CoAuthors_Guest_Authors $guest_authors ) {
+		$this->guest_authors = $guest_authors;
+	}
+
+	/**
+	 * The profile fields carried by this service.
+	 *
+	 * Excludes the hidden group, so the guest author's own post ID is not
+	 * treated as part of the profile.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	public function fields(): array {
+		return $this->guest_authors->get_guest_author_fields();
+	}
+
+	/**
+	 * Find a guest author.
+	 *
+	 * @param string $key   Field to search by, for example 'user_login'.
+	 * @param string $value Value to search for.
+	 * @return object|false Guest author object, or false when absent.
+	 */
+	public function find_by( string $key, string $value ) {
+		return $this->guest_authors->get_guest_author_by( $key, $value );
+	}
+
+	/**
+	 * Extract a portable profile from a guest author object.
+	 *
+	 * @param object $guest_author Guest author object.
+	 * @return array<string, string> Field key => value.
+	 */
+	public function profile( $guest_author ): array {
+		$profile = array();
+
+		foreach ( $this->fields() as $field ) {
+			$key             = $field['key'];
+			$profile[ $key ] = (string) ( $guest_author->{$key} ?? '' );
+		}
+
+		return $profile;
+	}
+
+	/**
+	 * Create a guest author from a portable profile.
+	 *
+	 * Unknown keys are ignored rather than stored, so a profile written by a
+	 * newer version of the plugin does not create meta this one knows nothing
+	 * about.
+	 *
+	 * @param array<string, string> $profile Field key => value.
+	 * @return int|WP_Error New guest author ID, or an error.
+	 */
+	public function create( array $profile ) {
+		$args = array();
+
+		foreach ( $this->fields() as $field ) {
+			$key = $field['key'];
+
+			if ( ! isset( $profile[ $key ] ) ) {
+				continue;
+			}
+
+			$args[ $key ] = $this->sanitize( $field, $profile[ $key ] );
+		}
+
+		return $this->guest_authors->create( $args );
+	}
+
+	/**
+	 * Sanitise one field value the way the admin save does.
+	 *
+	 * @param array<string, string> $field Field definition.
+	 * @param string                $value Raw value.
+	 * @return string
+	 */
+	private function sanitize( array $field, string $value ): string {
+		if ( isset( $field['sanitize_function'] ) && is_callable( $field['sanitize_function'] ) ) {
+			return (string) call_user_func( $field['sanitize_function'], $value );
+		}
+
+		return (string) sanitize_text_field( $value );
+	}
+}

--- a/tests/Unit/Services/CoauthorAssignmentServiceTest.php
+++ b/tests/Unit/Services/CoauthorAssignmentServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Unit tests for the co-author assignment service.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Services;
+
+use Automattic\CoAuthorsPlus\Services\Coauthor_Assignment_Service;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+
+/**
+ * @covers \Automattic\CoAuthorsPlus\Services\Coauthor_Assignment_Service
+ */
+final class CoauthorAssignmentServiceTest extends TestCase {
+
+	/**
+	 * Build a service with a mocked plugin instance.
+	 *
+	 * @return array{0: Coauthor_Assignment_Service, 1: \Mockery\MockInterface}
+	 */
+	private function service(): array {
+		$coauthors_plus                     = Mockery::mock( 'CoAuthors_Plus' );
+		$coauthors_plus->coauthor_taxonomy  = 'author';
+
+		return array( new Coauthor_Assignment_Service( $coauthors_plus ), $coauthors_plus );
+	}
+
+	/**
+	 * Turn slugs into the term objects wp_get_object_terms() would return.
+	 *
+	 * @param string[] $slugs Term slugs.
+	 * @return object[]
+	 */
+	private function terms( array $slugs ): array {
+		return array_map(
+			static function ( string $slug ) {
+				return (object) array( 'slug' => $slug );
+			},
+			$slugs
+		);
+	}
+
+	public function test_it_strips_the_cap_prefix_to_recover_nicenames(): void {
+		list( $service ) = $this->service();
+
+		Functions\expect( 'wp_get_object_terms' )
+			->once()
+			->with( 7, 'author', array( 'orderby' => 'term_order' ) )
+			->andReturn( $this->terms( array( 'cap-alice', 'cap-bob' ) ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$this->assertSame( array( 'alice', 'bob' ), $service->nicenames_for_post( 7 ) );
+	}
+
+	/**
+	 * A nicename may itself begin with "cap-", giving a doubly prefixed slug.
+	 * Only the prefix the plugin added should come off.
+	 */
+	public function test_it_strips_only_one_cap_prefix(): void {
+		list( $service ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( $this->terms( array( 'cap-cap-ri' ) ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$this->assertSame( array( 'cap-ri' ), $service->nicenames_for_post( 7 ) );
+	}
+
+	public function test_it_returns_no_nicenames_when_the_taxonomy_query_fails(): void {
+		list( $service ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( 'error' );
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$this->assertSame( array(), $service->nicenames_for_post( 7 ) );
+	}
+
+	/**
+	 * Replacing rather than appending is what makes the ordered list
+	 * authoritative, so append must be false.
+	 */
+	public function test_it_replaces_the_whole_byline_when_assigning(): void {
+		list( $service, $coauthors_plus ) = $this->service();
+
+		$coauthors_plus->shouldReceive( 'add_coauthors' )
+			->once()
+			->with( 7, array( 'alice', 'bob' ), false )
+			->andReturn( true );
+
+		$this->assertTrue( $service->assign( 7, array( 'alice', 'bob' ) ) );
+	}
+
+	public function test_it_inserts_at_the_requested_position(): void {
+		list( $service, $coauthors_plus ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( $this->terms( array( 'cap-alice', 'cap-bob' ) ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$coauthors_plus->shouldReceive( 'add_coauthors' )
+			->once()
+			->with( 7, array( 'alice', 'carol', 'bob' ), false )
+			->andReturn( true );
+
+		$this->assertTrue( $service->add_at_position( 7, 'carol', 1 ) );
+	}
+
+	public function test_it_appends_when_the_position_is_past_the_end(): void {
+		list( $service, $coauthors_plus ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( $this->terms( array( 'cap-alice' ) ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$coauthors_plus->shouldReceive( 'add_coauthors' )
+			->once()
+			->with( 7, array( 'alice', 'carol' ), false )
+			->andReturn( true );
+
+		$this->assertTrue( $service->add_at_position( 7, 'carol', 99 ) );
+	}
+
+	/**
+	 * Idempotency: this is what lets an import run twice without duplicating a
+	 * byline, so it must not reach add_coauthors() at all.
+	 */
+	public function test_it_does_not_rewrite_a_post_that_already_has_the_coauthor(): void {
+		list( $service, $coauthors_plus ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( $this->terms( array( 'cap-alice', 'cap-carol' ) ) );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$coauthors_plus->shouldNotReceive( 'add_coauthors' );
+
+		$this->assertFalse( $service->add_at_position( 7, 'carol', 0 ) );
+	}
+}

--- a/tests/Unit/Services/CoauthorAssignmentServiceTest.php
+++ b/tests/Unit/Services/CoauthorAssignmentServiceTest.php
@@ -124,10 +124,11 @@ final class CoauthorAssignmentServiceTest extends TestCase {
 	}
 
 	/**
-	 * add_coauthors() returns false when it replaces a byline that resolves to
-	 * no WordPress user, which is every byline of guest authors without linked
-	 * accounts, despite having written the terms. Reporting that as "unchanged"
-	 * made an import claim it had linked nothing while the terms were there.
+	 * A false return from add_coauthors() does not mean nothing changed. It
+	 * returns false when it replaces a byline that resolves to no WordPress
+	 * user, which is every byline of guest authors without linked accounts,
+	 * despite having written the terms. Reporting that as "unchanged" made an
+	 * import claim it had linked nothing while the terms were there.
 	 */
 	public function test_it_reports_a_change_even_when_add_coauthors_returns_false(): void {
 		list( $service, $coauthors_plus ) = $this->service();

--- a/tests/Unit/Services/CoauthorAssignmentServiceTest.php
+++ b/tests/Unit/Services/CoauthorAssignmentServiceTest.php
@@ -124,6 +124,26 @@ final class CoauthorAssignmentServiceTest extends TestCase {
 	}
 
 	/**
+	 * add_coauthors() returns false when it replaces a byline that resolves to
+	 * no WordPress user, which is every byline of guest authors without linked
+	 * accounts, despite having written the terms. Reporting that as "unchanged"
+	 * made an import claim it had linked nothing while the terms were there.
+	 */
+	public function test_it_reports_a_change_even_when_add_coauthors_returns_false(): void {
+		list( $service, $coauthors_plus ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$coauthors_plus->shouldReceive( 'add_coauthors' )
+			->once()
+			->with( 7, array( 'carol' ), false )
+			->andReturn( false );
+
+		$this->assertTrue( $service->add_at_position( 7, 'carol', 0 ) );
+	}
+
+	/**
 	 * Idempotency: this is what lets an import run twice without duplicating a
 	 * byline, so it must not reach add_coauthors() at all.
 	 */

--- a/tests/Unit/Services/CoauthorExportServiceTest.php
+++ b/tests/Unit/Services/CoauthorExportServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Unit tests for the co-author export service.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Services;
+
+use Automattic\CoAuthorsPlus\Services\Coauthor_Assignment_Service;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Export_Service;
+use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+
+/**
+ * @covers \Automattic\CoAuthorsPlus\Services\Coauthor_Export_Service
+ */
+final class CoauthorExportServiceTest extends TestCase {
+
+	/**
+	 * Mocked collaborators, keyed for readability.
+	 *
+	 * @var array<string, \Mockery\MockInterface>
+	 */
+	private $mocks = array();
+
+	/**
+	 * Build a service with mocked collaborators.
+	 *
+	 * @return Coauthor_Export_Service
+	 */
+	private function service(): Coauthor_Export_Service {
+		$coauthors_plus                    = Mockery::mock( 'CoAuthors_Plus' );
+		$coauthors_plus->coauthor_taxonomy = 'author';
+		$coauthors_plus->guest_authors     = (object) array( 'post_type' => 'guest-author' );
+
+		$this->mocks = array(
+			'plugin'      => $coauthors_plus,
+			'guests'      => Mockery::mock( Guest_Author_Service::class ),
+			'assignments' => Mockery::mock( Coauthor_Assignment_Service::class ),
+		);
+
+		return new Coauthor_Export_Service(
+			$coauthors_plus,
+			$this->mocks['guests'],
+			$this->mocks['assignments']
+		);
+	}
+
+	public function test_it_returns_null_for_a_guest_author_it_cannot_load(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->once()->with( 'ID', '9' )->andReturn( false );
+
+		$this->assertNull( $service->entry_for( 9, array( 'post' ) ) );
+	}
+
+	public function test_it_records_no_assignments_when_the_author_has_no_term(): void {
+		$service = $this->service();
+
+		$guest_author = (object) array( 'user_nicename' => 'jane-doe' );
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->andReturn( $guest_author );
+		$this->mocks['guests']->shouldReceive( 'profile' )->andReturn( array( 'user_login' => 'jane-doe' ) );
+		$this->mocks['plugin']->shouldReceive( 'get_author_term' )->once()->with( $guest_author )->andReturn( false );
+
+		$entry = $service->entry_for( 9, array( 'post' ) );
+
+		$this->assertSame( array(), $entry['post_refs'] );
+		$this->assertSame( array( 'user_login' => 'jane-doe' ), $entry['profile'] );
+	}
+
+	/**
+	 * Assignments are keyed by slug and post type, never by ID, because IDs do
+	 * not survive a WordPress export and import cycle.
+	 */
+	public function test_it_records_assignments_by_slug_and_post_type_with_position(): void {
+		$service = $this->service();
+
+		$guest_author = (object) array( 'user_nicename' => 'jane-doe' );
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->andReturn( $guest_author );
+		$this->mocks['guests']->shouldReceive( 'profile' )->andReturn( array() );
+		$this->mocks['plugin']->shouldReceive( 'get_author_term' )->andReturn( (object) array( 'term_id' => 12 ) );
+
+		Functions\when( 'get_posts' )->justReturn(
+			array(
+				(object) array(
+					'ID'        => 100,
+					'post_name' => 'hello-world',
+					'post_type' => 'post',
+				),
+			)
+		);
+
+		$this->mocks['assignments']->shouldReceive( 'nicenames_for_post' )
+			->once()
+			->with( 100 )
+			->andReturn( array( 'someone-else', 'jane-doe' ) );
+
+		$entry = $service->entry_for( 9, array( 'post' ) );
+
+		$this->assertSame(
+			array(
+				array(
+					'post_slug' => 'hello-world',
+					'post_type' => 'post',
+					'position'  => 1,
+				),
+			),
+			$entry['post_refs']
+		);
+	}
+
+	/**
+	 * A post carrying the term whose byline does not list the author is a
+	 * broken assignment rather than a crash, so it records position 0 instead
+	 * of array_search()'s false leaking into the output.
+	 */
+	public function test_it_falls_back_to_the_first_position_when_the_byline_omits_the_author(): void {
+		$service = $this->service();
+
+		$guest_author = (object) array( 'user_nicename' => 'jane-doe' );
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->andReturn( $guest_author );
+		$this->mocks['guests']->shouldReceive( 'profile' )->andReturn( array() );
+		$this->mocks['plugin']->shouldReceive( 'get_author_term' )->andReturn( (object) array( 'term_id' => 12 ) );
+
+		Functions\when( 'get_posts' )->justReturn(
+			array(
+				(object) array(
+					'ID'        => 100,
+					'post_name' => 'hello-world',
+					'post_type' => 'post',
+				),
+			)
+		);
+
+		$this->mocks['assignments']->shouldReceive( 'nicenames_for_post' )->andReturn( array( 'someone-else' ) );
+
+		$entry = $service->entry_for( 9, array( 'post' ) );
+
+		$this->assertSame( 0, $entry['post_refs'][0]['position'] );
+	}
+
+	public function test_it_collects_guest_author_ids_as_integers(): void {
+		$service = $this->service();
+
+		Functions\when( 'get_posts' )->justReturn( array( '3', '7' ) );
+
+		$this->assertSame( array( 3, 7 ), $service->guest_author_ids() );
+	}
+}

--- a/tests/Unit/Services/CoauthorImportServiceTest.php
+++ b/tests/Unit/Services/CoauthorImportServiceTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Unit tests for the co-author import service.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Services;
+
+use Automattic\CoAuthorsPlus\Services\Coauthor_Assignment_Service;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Import_Service;
+use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use InvalidArgumentException;
+use Mockery;
+
+/**
+ * @covers \Automattic\CoAuthorsPlus\Services\Coauthor_Import_Service
+ */
+final class CoauthorImportServiceTest extends TestCase {
+
+	/**
+	 * Mocked collaborators.
+	 *
+	 * @var array<string, \Mockery\MockInterface>
+	 */
+	private $mocks = array();
+
+	/**
+	 * Build a service with mocked collaborators.
+	 *
+	 * @return Coauthor_Import_Service
+	 */
+	private function service(): Coauthor_Import_Service {
+		$this->mocks = array(
+			'guests'      => Mockery::mock( Guest_Author_Service::class ),
+			'assignments' => Mockery::mock( Coauthor_Assignment_Service::class ),
+		);
+
+		return new Coauthor_Import_Service( $this->mocks['guests'], $this->mocks['assignments'] );
+	}
+
+	/**
+	 * One export entry.
+	 *
+	 * @param string $login Guest author login.
+	 * @param array  $refs  Post references.
+	 * @return array<string, mixed>
+	 */
+	private function entry( string $login, array $refs = array() ): array {
+		return array(
+			'profile'   => array( 'user_login' => $login ),
+			'post_refs' => $refs,
+		);
+	}
+
+	public function test_it_rejects_an_export_with_no_guest_author_list(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->service()->import( array( 'version' => '4.2.0' ) );
+	}
+
+	/**
+	 * A null list is the shape a truncated or hand-edited file takes, and must
+	 * not reach a foreach.
+	 */
+	public function test_it_rejects_a_null_guest_author_list(): void {
+		$this->expectException( InvalidArgumentException::class );
+		$this->service()->import( array( 'guest_authors' => null ) );
+	}
+
+	public function test_it_skips_an_entry_with_no_login(): void {
+		$service = $this->service();
+
+		$summary = $service->import( array( 'guest_authors' => array( array( 'profile' => array() ) ) ) );
+
+		$this->assertSame( 0, $summary['authors_created'] );
+		$this->assertSame( 0, $summary['authors_skipped'] );
+		$this->assertNotEmpty( $summary['warnings'] );
+	}
+
+	public function test_it_counts_an_existing_profile_as_skipped(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )
+			->once()
+			->with( 'user_login', 'jane-doe' )
+			->andReturn( (object) array( 'user_nicename' => 'jane-doe' ) );
+
+		$summary = $service->import( array( 'guest_authors' => array( $this->entry( 'jane-doe' ) ) ) );
+
+		$this->assertSame( 1, $summary['authors_skipped'] );
+		$this->assertSame( 0, $summary['authors_created'] );
+	}
+
+	/**
+	 * The byline is keyed on user_nicename, which create() derives from the
+	 * login and need not match it. Re-reading the created profile rather than
+	 * reusing the login is what keeps the assignment correct.
+	 */
+	public function test_it_assigns_using_the_created_profiles_nicename(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )
+			->once()
+			->with( 'user_login', 'Jane.Doe' )
+			->andReturn( false );
+		$this->mocks['guests']->shouldReceive( 'create' )->once()->andReturn( 42 );
+		$this->mocks['guests']->shouldReceive( 'find_by' )
+			->once()
+			->with( 'ID', '42' )
+			->andReturn( (object) array( 'user_nicename' => 'jane-doe' ) );
+
+		Functions\when( 'is_wp_error' )->justReturn( false );
+		Functions\when( 'get_posts' )->justReturn( array( 100 ) );
+
+		$this->mocks['assignments']->shouldReceive( 'add_at_position' )
+			->once()
+			->with( 100, 'jane-doe', 2 )
+			->andReturn( true );
+
+		$summary = $service->import(
+			array(
+				'guest_authors' => array(
+					$this->entry(
+						'Jane.Doe',
+						array(
+							array(
+								'post_slug' => 'hello',
+								'post_type' => 'post',
+								'position'  => 2,
+							),
+						)
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 1, $summary['authors_created'] );
+		$this->assertSame( 1, $summary['posts_linked'] );
+	}
+
+	public function test_it_records_a_post_it_cannot_find(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->andReturn( (object) array( 'user_nicename' => 'jane-doe' ) );
+		Functions\when( 'get_posts' )->justReturn( array() );
+
+		$summary = $service->import(
+			array(
+				'guest_authors' => array(
+					$this->entry( 'jane-doe', array( array( 'post_slug' => 'gone' ) ) ),
+				),
+			)
+		);
+
+		$this->assertSame( 1, $summary['posts_not_found'] );
+		$this->assertSame( 0, $summary['posts_linked'] );
+	}
+
+	/**
+	 * Idempotency: a post already carrying the author reports no change, which
+	 * is what makes a second run safe.
+	 */
+	public function test_it_does_not_count_a_post_that_was_already_linked(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->andReturn( (object) array( 'user_nicename' => 'jane-doe' ) );
+		Functions\when( 'get_posts' )->justReturn( array( 100 ) );
+		$this->mocks['assignments']->shouldReceive( 'add_at_position' )->once()->andReturn( false );
+
+		$summary = $service->import(
+			array(
+				'guest_authors' => array(
+					$this->entry( 'jane-doe', array( array( 'post_slug' => 'hello' ) ) ),
+				),
+			)
+		);
+
+		$this->assertSame( 0, $summary['posts_linked'] );
+	}
+
+	/**
+	 * A dry run must reach neither writer, however much it reports.
+	 */
+	public function test_a_dry_run_writes_nothing(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->once()->andReturn( false );
+		$this->mocks['guests']->shouldNotReceive( 'create' );
+		$this->mocks['assignments']->shouldNotReceive( 'add_at_position' );
+		$this->mocks['assignments']->shouldNotReceive( 'assign' );
+
+		Functions\when( 'get_posts' )->justReturn( array( 100 ) );
+
+		$summary = $service->import(
+			array(
+				'guest_authors' => array(
+					$this->entry( 'jane-doe', array( array( 'post_slug' => 'hello' ) ) ),
+				),
+			),
+			true
+		);
+
+		$this->assertSame( 1, $summary['authors_created'] );
+		$this->assertSame( 1, $summary['posts_linked'] );
+	}
+
+	public function test_skip_create_does_not_create_a_missing_profile(): void {
+		$service = $this->service();
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->once()->andReturn( false );
+		$this->mocks['guests']->shouldNotReceive( 'create' );
+		$this->mocks['assignments']->shouldNotReceive( 'add_at_position' );
+
+		Functions\when( 'get_posts' )->justReturn( array( 100 ) );
+
+		$summary = $service->import(
+			array(
+				'guest_authors' => array(
+					$this->entry( 'jane-doe', array( array( 'post_slug' => 'hello' ) ) ),
+				),
+			),
+			false,
+			true
+		);
+
+		$this->assertSame( 1, $summary['authors_skipped'] );
+		$this->assertSame( 0, $summary['authors_created'] );
+		$this->assertNotEmpty( $summary['warnings'] );
+	}
+
+	public function test_it_warns_and_continues_when_a_profile_cannot_be_created(): void {
+		$service = $this->service();
+
+		$error = Mockery::mock( 'WP_Error' );
+		$error->shouldReceive( 'get_error_message' )->andReturn( 'login already exists' );
+
+		$this->mocks['guests']->shouldReceive( 'find_by' )->once()->andReturn( false );
+		$this->mocks['guests']->shouldReceive( 'create' )->once()->andReturn( $error );
+		$this->mocks['assignments']->shouldNotReceive( 'add_at_position' );
+
+		Functions\when( 'is_wp_error' )->justReturn( true );
+
+		$summary = $service->import(
+			array(
+				'guest_authors' => array(
+					$this->entry( 'jane-doe', array( array( 'post_slug' => 'hello' ) ) ),
+				),
+			)
+		);
+
+		$this->assertSame( 0, $summary['authors_created'] );
+		$this->assertStringContainsString( 'login already exists', $summary['warnings'][0] );
+	}
+}

--- a/tests/Unit/Services/CoauthorImportServiceTest.php
+++ b/tests/Unit/Services/CoauthorImportServiceTest.php
@@ -227,7 +227,9 @@ final class CoauthorImportServiceTest extends TestCase {
 			true
 		);
 
-		$this->assertSame( 1, $summary['authors_skipped'] );
+		// Not counted as skipped: that count is reported to the operator as
+		// profiles that already existed, and this one did not.
+		$this->assertSame( 0, $summary['authors_skipped'] );
 		$this->assertSame( 0, $summary['authors_created'] );
 		$this->assertNotEmpty( $summary['warnings'] );
 	}

--- a/tests/Unit/Services/GuestAuthorServiceTest.php
+++ b/tests/Unit/Services/GuestAuthorServiceTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Unit tests for the guest author service.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Services;
+
+use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+
+/**
+ * @covers \Automattic\CoAuthorsPlus\Services\Guest_Author_Service
+ */
+final class GuestAuthorServiceTest extends TestCase {
+
+	/**
+	 * Field definitions standing in for get_guest_author_fields().
+	 *
+	 * Mirrors the real shape: most fields carry no sanitiser, description
+	 * declares one, and the hidden ID field is already excluded.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	private function fields(): array {
+		return array(
+			array(
+				'key'   => 'display_name',
+				'group' => 'name',
+			),
+			array(
+				'key'   => 'user_login',
+				'group' => 'slug',
+			),
+			array(
+				'key'               => 'description',
+				'group'             => 'about',
+				'sanitize_function' => 'wp_filter_post_kses',
+			),
+		);
+	}
+
+	/**
+	 * Build a service with a mocked guest authors instance.
+	 *
+	 * @return array{0: Guest_Author_Service, 1: \Mockery\MockInterface}
+	 */
+	private function service(): array {
+		$guest_authors = Mockery::mock( 'CoAuthors_Guest_Authors' );
+		$guest_authors->shouldReceive( 'get_guest_author_fields' )->andReturn( $this->fields() );
+
+		return array( new Guest_Author_Service( $guest_authors ), $guest_authors );
+	}
+
+	public function test_it_reads_a_profile_for_every_declared_field(): void {
+		list( $service ) = $this->service();
+
+		$guest_author = (object) array(
+			'display_name' => 'Jane Doe',
+			'user_login'   => 'jane-doe',
+			'description'  => 'Writes things.',
+			'ID'           => 42,
+		);
+
+		$this->assertSame(
+			array(
+				'display_name' => 'Jane Doe',
+				'user_login'   => 'jane-doe',
+				'description'  => 'Writes things.',
+			),
+			$service->profile( $guest_author )
+		);
+	}
+
+	/**
+	 * A field the object does not carry must still appear, so the exported
+	 * shape does not vary between profiles.
+	 */
+	public function test_it_reads_an_absent_field_as_an_empty_string(): void {
+		list( $service ) = $this->service();
+
+		$profile = $service->profile( (object) array( 'display_name' => 'Jane Doe' ) );
+
+		$this->assertSame( '', $profile['description'] );
+		$this->assertArrayHasKey( 'user_login', $profile );
+	}
+
+	/**
+	 * The admin save applies each field's declared sanitiser and falls back to
+	 * sanitize_text_field. Creating a profile has to match, or the same values
+	 * would be stored differently depending on which route wrote them.
+	 */
+	public function test_it_applies_each_fields_declared_sanitiser(): void {
+		list( $service, $guest_authors ) = $this->service();
+
+		Functions\expect( 'sanitize_text_field' )->twice()->andReturnUsing(
+			static function ( $value ) {
+				return 'clean:' . $value;
+			}
+		);
+		Functions\expect( 'wp_filter_post_kses' )->once()->andReturnUsing(
+			static function ( $value ) {
+				return 'kses:' . $value;
+			}
+		);
+
+		$guest_authors->shouldReceive( 'create' )
+			->once()
+			->with(
+				array(
+					'display_name' => 'clean:Jane Doe',
+					'user_login'   => 'clean:jane-doe',
+					'description'  => 'kses:<b>Hi</b>',
+				)
+			)
+			->andReturn( 42 );
+
+		$this->assertSame(
+			42,
+			$service->create(
+				array(
+					'display_name' => 'Jane Doe',
+					'user_login'   => 'jane-doe',
+					'description'  => '<b>Hi</b>',
+				)
+			)
+		);
+	}
+
+	/**
+	 * A profile from a newer version of the plugin must not create meta this
+	 * one knows nothing about.
+	 */
+	public function test_it_ignores_keys_that_are_not_declared_fields(): void {
+		list( $service, $guest_authors ) = $this->service();
+
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'wp_filter_post_kses' )->returnArg();
+
+		$guest_authors->shouldReceive( 'create' )
+			->once()
+			->with(
+				array(
+					'display_name' => 'Jane Doe',
+					'user_login'   => 'jane-doe',
+					'description'  => '',
+				)
+			)
+			->andReturn( 42 );
+
+		$service->create(
+			array(
+				'display_name'   => 'Jane Doe',
+				'user_login'     => 'jane-doe',
+				'description'    => '',
+				'future_feature' => 'should not be stored',
+			)
+		);
+	}
+
+	/**
+	 * Fields absent from the profile are left out entirely rather than sent as
+	 * empty strings, so create() applies its own defaults.
+	 */
+	public function test_it_omits_fields_the_profile_does_not_carry(): void {
+		list( $service, $guest_authors ) = $this->service();
+
+		Functions\when( 'sanitize_text_field' )->returnArg();
+
+		$guest_authors->shouldReceive( 'create' )
+			->once()
+			->with( array( 'user_login' => 'jane-doe' ) )
+			->andReturn( 42 );
+
+		$service->create( array( 'user_login' => 'jane-doe' ) );
+	}
+
+	public function test_it_finds_a_guest_author_by_field(): void {
+		list( $service, $guest_authors ) = $this->service();
+
+		$expected = (object) array( 'user_login' => 'jane-doe' );
+
+		$guest_authors->shouldReceive( 'get_guest_author_by' )
+			->once()
+			->with( 'user_login', 'jane-doe' )
+			->andReturn( $expected );
+
+		$this->assertSame( $expected, $service->find_by( 'user_login', 'jane-doe' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1067.

Guest authors have never had a way to travel. Their profiles are posts and their bylines are taxonomy terms, so a WordPress export and import renumbers everything the authorship depends on and leaves it behind on the old site. `export-coauthors` and `import-coauthors` carry both across.

Assignments are recorded by post slug and post type rather than by ID, for exactly that reason, and byline position travels too, so order is restored rather than guessed. An import can be run twice safely: an author already on a post is left alone, so an interrupted run is simply repeated.

The part worth reviewing is the shape. Each command is a class holding only what running as a command involves — arguments, progress, the file, reporting — while what to export and how to restore it lives in four services under `php/services`. Those services wrap existing public methods rather than reimplementing anything, so behaviour is unchanged and this stays a minor bump. The payoff is that the logic is covered by 76 unit tests that run in half a second with no WordPress, no database and no container. It also means there is nothing in the production code bent to suit the tests: no `function_exists()` guard around the progress bar, no captured exit, because the logic worth testing is not welded to WP-CLI. The import service throws and the command turns that into a WP-CLI error.

A few decisions worth knowing about. Profiles are read and written through `get_guest_author_fields()` rather than a list of their own, so a field added by the `coauthors_guest_author_fields` filter travels with the profile instead of being dropped, and writes apply each field's declared sanitiser to match what the Add New / Edit Guest Author screen does on save — `create()` stores whatever it is handed, so without that the same profile would be stored differently depending on whether it arrived from a file or was typed into the admin. The export service composes the assignment service to read byline positions rather than hand-rolling a `term_order` join, which keeps SQL out of the service layer at the cost of one read per matched post; the trade is marked in the code with its ceiling and its upgrade path. There are no value objects yet, because each concept still has a single consumer and extracting on evidence seemed better than on prediction. Registration waits for `init` at priority 20, since that is where the guest authors instance is built, and is skipped when guest authors are switched off, matching how the rest of that functionality loads. The classes are required explicitly, as the plugin does not load Composer's autoloader and does not ship `vendor/`.

Two bugs turned up from running this rather than reading it, and both are fixed here with regression tests. `add_coauthors()` returns false when it replaces a byline that resolves to no WordPress user — which is every byline of guest authors without linked accounts, so the ordinary case here — having written the terms perfectly well; the value really reports whether `post_author` could be set. Taking it as a success signal made an import announce that it had linked nothing while the term was plainly on the post. That trap is noted in `docs/cli-behaviour-notes.md`, since other callers will be looked at when the older commands are split up. Separately, `--skip-create` counted a profile that did not exist among the ones that did, so the summary claimed a profile already existed when its absence was the whole reason nothing had been linked.

## Test plan

- [ ] `wp co-authors-plus export-coauthors` writes a file; the assignments in it carry slug, post type and position
- [ ] `import-coauthors --dry-run` reports what it would do and writes nothing
- [ ] `import-coauthors` restores the profile and puts it back on the post; a second run changes nothing
- [ ] `--skip-create` links to existing profiles and names any it cannot
- [ ] An assignment whose post is absent is reported rather than silently skipped
- [ ] Behat: 12 new scenarios across the two commands, and the registration guard lists nineteen subcommands
- [ ] Unit: 76 tests / 144 assertions, no WordPress required