### PR TITLE
Clear the taxonomy remove-terms-from-revisions actually read

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -354,10 +354,16 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 7 scenarios.)
 
-- The taxonomy is hardcoded as `'author'` in the `wp_set_post_terms` call
-  (php/class-wp-cli.php:977) instead of `$coauthors_plus->coauthor_taxonomy`, and
-  revisions are read via direct SQL on `post_type='revision' AND
-  post_status='inherit'` (line 965).
+- ~~The taxonomy is hardcoded as `'author'` in the `wp_set_post_terms` call
+  instead of `$coauthors_plus->coauthor_taxonomy`.~~ **FIXED.** The read side
+  went through the configured taxonomy while the write named `author`
+  directly, so on a site that had changed the property the command found the
+  terms, logged a removal for each revision, counted them, and cleared nothing
+  — reporting success for work it had not done. A unit guard now reads the
+  command sources and fails if any of them names the taxonomy directly, since
+  covering it live would mean registering a taxonomy under another name before
+  init. Revisions are still read via direct SQL on `post_type='revision' AND
+  post_status='inherit'`.
 - All output is `WP_CLI::log` — there is no `WP_CLI::success` and the exit code is
   always 0. Count lines never pluralise: "Found 1 revisions to look through",
   "1 revisions had author terms removed". Confirmed.

--- a/php/cli/class-remove-terms-from-revisions-command.php
+++ b/php/cli/class-remove-terms-from-revisions-command.php
@@ -9,17 +9,31 @@ declare( strict_types=1 );
 
 namespace Automattic\CoAuthorsPlus\CLI;
 
+use CoAuthors_Plus;
 use WP_CLI;
 
 /**
  * Strips author terms from revisions, which were assigned them for years.
  *
- * Moved here from CoAuthorsPlus_Command unchanged, including its use of a
- * hardcoded taxonomy name rather than the configured one; correcting that
- * changes behaviour and belongs in its own change. Behaviour is pinned by
- * features/remove-terms-from-revisions.feature.
+ * Behaviour is pinned by features/remove-terms-from-revisions.feature.
  */
 class Remove_Terms_From_Revisions_Command {
+
+	/**
+	 * Plugin instance.
+	 *
+	 * @var CoAuthors_Plus
+	 */
+	private $coauthors_plus;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CoAuthors_Plus $coauthors_plus Plugin instance.
+	 */
+	public function __construct( CoAuthors_Plus $coauthors_plus ) {
+		$this->coauthors_plus = $coauthors_plus;
+	}
 
 	/**
 	 * Remove author terms from revisions.
@@ -53,7 +67,7 @@ class Remove_Terms_From_Revisions_Command {
 			}
 
 			WP_CLI::log( "#{$post_id}: Removing " . implode( ',', wp_list_pluck( $terms, 'slug' ) ) );
-			wp_set_post_terms( $post_id, array(), 'author' );
+			wp_set_post_terms( $post_id, array(), $this->coauthors_plus->coauthor_taxonomy );
 			$affected++;
 		}
 		WP_CLI::log( "All done! {$affected} revisions had author terms removed" );

--- a/php/cli/register-commands.php
+++ b/php/cli/register-commands.php
@@ -109,7 +109,7 @@ add_action(
 
 		WP_CLI::add_command(
 			'co-authors-plus remove-terms-from-revisions',
-			new Remove_Terms_From_Revisions_Command()
+			new Remove_Terms_From_Revisions_Command( $coauthors_plus )
 		);
 
 		WP_CLI::add_command(

--- a/tests/Unit/Cli/CoauthorTaxonomyUsageTest.php
+++ b/tests/Unit/Cli/CoauthorTaxonomyUsageTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Guards that the commands use the configured co-author taxonomy.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Cli;
+
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+
+/**
+ * The taxonomy holding co-author terms is a public property, not a constant.
+ *
+ * The remove-terms-from-revisions command used to read its terms through the configured
+ * taxonomy and then clear the hardcoded 'author' one. On a site that had
+ * changed the property the command logged a removal for every revision it
+ * found and reported how many it had cleared, having cleared none.
+ *
+ * A live test would have to register a taxonomy under another name before
+ * init, which is more machinery than the risk deserves. Reading the source is
+ * enough to catch the name being written in again, and follows the same
+ * approach as the cache-flush guard alongside it.
+ *
+ * @coversNothing
+ */
+final class CoauthorTaxonomyUsageTest extends TestCase {
+
+	/**
+	 * Command classes must not name the taxonomy directly.
+	 */
+	public function test_no_command_hardcodes_the_taxonomy_name(): void {
+		$sources = glob( dirname( __DIR__, 3 ) . '/php/cli/class-*.php' );
+
+		$this->assertNotEmpty( $sources, 'The command classes must be readable for this check to mean anything.' );
+
+		foreach ( $sources as $source ) {
+			$code = (string) file_get_contents( $source );
+
+			// Strip comments and docblocks, which discuss the taxonomy by name.
+			$code = (string) preg_replace( '#/\*.*?\*/|//[^\n]*#s', '', $code );
+
+			$this->assertStringNotContainsString(
+				"'author'",
+				$code,
+				sprintf(
+					'%s names the co-author taxonomy directly. Use $coauthors_plus->coauthor_taxonomy, '
+					. 'which is a public property a site can change.',
+					basename( $source )
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`remove-terms-from-revisions` found a revision's author terms through the configured taxonomy and then cleared the one named `author` directly. By default those are the same thing, so nothing looked wrong. But the taxonomy is a public property rather than a constant, and the plugin's own integration tests reassign it to prove other code respects it.

Change it and the two halves stop agreeing. The command finds the terms, logs a removal line for every revision, counts them, and clears nothing — then reports how many revisions it dealt with. Reporting work it has not done is the worse half: a command that silently does nothing is at least discoverable by looking at the result, whereas one that claims success is not.

Every other command already reads the property, so this was the odd one out. It now takes the plugin instance like the rest.

**On covering it.** A live scenario would have to register a taxonomy under another name before `init`, which is a good deal more machinery than this risk deserves, and the seven existing scenarios only exercise the default where both halves agree. So instead there is a unit guard that reads the command sources and fails if any of them writes the taxonomy name in directly. I checked it against the bug it exists for, by putting the hardcoded name back and confirming it failed with a message naming the file — a guard nobody has seen fail is not yet a guard.

That guard covers all nineteen commands, not just this one, so the same mistake cannot quietly reappear elsewhere.

## Test plan

- [ ] `features/remove-terms-from-revisions.feature` passes unchanged: 7 scenarios
- [ ] The new unit guard passes, and fails if the taxonomy name is written back in
- [ ] Unit suite passes; PHPCS clean on `php/cli/` and `tests/`