### PR TITLE
Make update-author-terms see draft guest authors and report real term counts

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -711,28 +711,38 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
 
 (Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
 
-- The `changed from A to B` message NEVER shows the corrected count. Confirmed
-  live: with a term count forced to 5 (real count 1), the command prints
-  `Term cap-admin (N) changed from 5 to 5 and the description was refreshed`,
-  yet a fresh process then reads count 1 from the DB. Cause:
-  `update_author_term_post_count()` writes the correct count via a direct
-  `$wpdb->update`, but the command re-reads the term after
-  `wp_cache_delete( $term_id, 'author' )` — the wrong cache group (core caches
-  terms in the `terms` group) — so `get_term_by( 'id', ... )` returns the stale
-  cached object and `$new_count` always equals `$old_count`. Pinned: misleading
-  `5 to 5` message plus the state assertion that the DB count really is 1.
+- ~~The `changed from A to B` message NEVER shows the corrected count, because
+  the command re-read the term after `wp_cache_delete( $term_id, 'author' )` —
+  the wrong cache group, since core caches terms in the `terms` group — so
+  `get_term_by( 'id', ... )` returned the stale cached object and `$new_count`
+  always equalled `$old_count`.~~ **FIXED.** `update_author_term_post_count()`
+  writes the corrected count via a direct `$wpdb->update`, which leaves core's
+  term cache stale. The command now invalidates it with
+  `clean_term_cache( $term_id, $taxonomy )`, matching what `reassign-terms`
+  already does. The scenario that pinned `changed from 5 to 5` now pins
+  `changed from 5 to 1`, alongside the existing assertion that the DB count is 1.
+  Note the fix belongs in the command rather than in
+  `update_author_term_post_count()`: core's `wp_update_term_count_now()` calls
+  `clean_term_cache()` after the `update_count_callback`, so the method is
+  correctly invalidated on its normal path and only this direct caller was
+  affected.
 - `Term X (N) changed from A to B and the description was refreshed` is printed
   even when NO co-author matches the term slug: `update_author_term( false )`
   returns false and `update_author_term_post_count()` returns a silent WP_Error,
   so nothing is refreshed at all. Confirmed and pinned in the orphan-term
   scenario (`changed from 0 to 0`).
-- The guest author pass queries the `guest-author` CPT with WP_Query's default
+- ~~The guest author pass queries the `guest-author` CPT with WP_Query's default
   post_status (`publish`), but guest author posts created via
   `CoAuthors_Guest_Authors::create()` (and hence `create-guest-authors`) are
-  DRAFTS (`wp_insert_post` default). Confirmed live: the pass reports
-  `Now inspecting or updating 0 Guest Authors.` even when guest authors exist;
-  publishing the guest-author post makes it visible and its term is created.
-  Pinned in the drafts-invisible and published-guest-author scenarios.
+  DRAFTS (`wp_insert_post` default), so the pass reported
+  `Now inspecting or updating 0 Guest Authors.` even when guest authors
+  existed.~~ **FIXED.** The query now passes `post_status => 'any'`, so the pass
+  sees drafts — which is the ordinary case, not the exception — while still
+  excluding trashed and auto-draft profiles. The whole guest-author half of the
+  command was previously dead on any site whose profiles were created by the CLI
+  or programmatically. A new scenario covers a term being created for a *draft*
+  guest author, mirroring the published one; the drafts-invisible scenario now
+  pins `Now inspecting or updating 1 Guest Authors.`
 - `wp term list author --field=slug` returns name-ascending order (`cap-admin`
   before `cap-ghost`/`cap-guest-one`) — confirmed, relied on by exact
   assertions.

--- a/features/update-author-terms.feature
+++ b/features/update-author-terms.feature
@@ -37,7 +37,7 @@ Feature: Author terms can be recounted and recreated
 		1
 		"""
 
-	Scenario: A stale term count is corrected in the database but the log reports the stale value
+	Scenario: A stale term count is corrected and the log reports the corrected value
 		When I run `wp post create --post_title="A post" --post_status=publish --post_author=1 --porcelain`
 		And I run `wp term list author --slug=cap-admin --field=term_id`
 		And save STDOUT as {TERM_ID}
@@ -51,7 +51,7 @@ Feature: Author terms can be recounted and recreated
 		Then STDOUT should be:
 		"""
 		Now updating 1 terms
-		Term cap-admin ({TERM_ID}) changed from 5 to 5 and the description was refreshed
+		Term cap-admin ({TERM_ID}) changed from 5 to 1 and the description was refreshed
 		Now inspecting or updating 0 Guest Authors.
 		Success: All done
 		"""
@@ -113,7 +113,7 @@ Feature: Author terms can be recounted and recreated
 		cap-zsub
 		"""
 
-	Scenario: Guest authors created via the CLI are drafts and invisible to the guest author pass
+	Scenario: Guest authors created via the CLI are drafts and are still inspected by the guest author pass
 		When I run `wp co-authors-plus create-guest-authors`
 		And I run `wp post list --post_type=guest-author --fields=post_name,post_status --format=csv`
 		Then STDOUT should be:
@@ -128,7 +128,7 @@ Feature: Author terms can be recounted and recreated
 		"""
 		Now updating 1 terms
 		Term cap-admin ({TERM_ID}) changed from 0 to 0 and the description was refreshed
-		Now inspecting or updating 0 Guest Authors.
+		Now inspecting or updating 1 Guest Authors.
 		Success: All done
 		"""
 
@@ -138,6 +138,35 @@ Feature: Author terms can be recounted and recreated
 		And I run `wp post update {GA_ID} --post_status=publish`
 		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
 		When I run `wp co-authors-plus update-author-terms`
+		Then STDOUT should be:
+		"""
+		Now updating 0 terms
+		Created author term for admin
+		Now inspecting or updating 1 Guest Authors.
+		Created author term for Guest Author guest-one
+		Success: All done
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-guest-one
+		"""
+
+	# Guest authors are inserted as drafts, so this is the ordinary case rather than
+	# the exception. Before the post_status fix the pass reported 0 guest authors
+	# and the term below was never created.
+	Scenario: An author term is created for a draft guest author without one
+		When I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Guest One", "user_login" => "guest-one" ) );'`
+		And save STDOUT as {GA_ID}
+		And I run `wp post list --post_type=guest-author --fields=post_status --format=csv`
+		Then STDOUT should be:
+		"""
+		post_status
+		draft
+		"""
+		When I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+		And I run `wp co-authors-plus update-author-terms`
 		Then STDOUT should be:
 		"""
 		Now updating 0 terms

--- a/php/cli/class-update-author-terms-command.php
+++ b/php/cli/class-update-author-terms-command.php
@@ -17,8 +17,7 @@ use WP_Query;
 /**
  * Refreshes author term counts and descriptions.
  *
- * Moved here from CoAuthorsPlus_Command unchanged. Behaviour is pinned by
- * features/update-author-terms.feature.
+ * Behaviour is pinned by features/update-author-terms.feature.
  */
 class Update_Author_Terms_Command {
 
@@ -41,8 +40,7 @@ class Update_Author_Terms_Command {
 	/**
 	 * Refresh every author term's description and post count.
 	 *
-	 * Also creates any author term missing for an existing user or published guest
-	 * author.
+	 * Also creates any author term missing for an existing user or guest author.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -69,7 +67,7 @@ class Update_Author_Terms_Command {
 			$coauthor  = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_term->slug );
 			$coauthors_plus->update_author_term( $coauthor );
 			$coauthors_plus->update_author_term_post_count( $author_term );
-			wp_cache_delete( $author_term->term_id, $coauthors_plus->coauthor_taxonomy );
+			clean_term_cache( $author_term->term_id, $coauthors_plus->coauthor_taxonomy );
 			$new_count = get_term_by( 'id', $author_term->term_id, $coauthors_plus->coauthor_taxonomy )->count;
 			WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) changed from {$old_count} to {$new_count} and the description was refreshed" );
 		}
@@ -89,6 +87,8 @@ class Update_Author_Terms_Command {
 				'order'             => 'ASC',
 				'orderby'           => 'ID',
 				'post_type'         => $coauthors_plus->guest_authors->post_type,
+				// Guest authors are inserted as drafts, so the default 'publish' would hide them.
+				'post_status'       => 'any',
 				'posts_per_page'    => 100,
 				'paged'             => 1,
 				'update_meta_cache' => false,


### PR DESCRIPTION
## Summary

`wp co-authors-plus update-author-terms` exists to repair author terms, and it was quietly failing at both halves of that job.

The guest author pass queried the `guest-author` post type through `WP_Query` without specifying a `post_status`, so it inherited the default of `publish`. But `CoAuthors_Guest_Authors::create()` inserts guest author posts with no status, which `wp_insert_post()` resolves to `draft`. Every profile created by `create-guest-authors`, `create-author`, the CSV and WXR importers, or any code calling `create()` is therefore a draft, and the pass could not see a single one of them. On such a site the command printed `Now inspecting or updating 0 Guest Authors.` and created none of their terms, then exited successfully. This was not an edge case: drafts are the ordinary state for a guest author profile, so the entire guest author half of the command was dead on arrival for most installations. The query now passes `post_status => 'any'`, which picks up drafts and pending profiles while still excluding trashed and auto-draft ones.

The second problem was the count. `update_author_term_post_count()` writes the corrected count straight to `term_taxonomy` with a direct query, so the command re-reads the term afterwards in order to report the new value. It invalidated the cache first, but under the taxonomy name rather than `terms`, which is the group core actually caches terms in. The delete therefore missed, `get_term_by()` handed back the stale object, and `$new_count` was always identical to `$old_count`. The database was corrected while the operator was told nothing had changed, so a term whose count went from 5 to 1 reported `changed from 5 to 5`. Switching to `clean_term_cache()` fixes it and matches the idiom `reassign-terms` already uses.

Worth noting for review: the stale cache originates in `update_author_term_post_count()`, but the fix deliberately stays in the command. Core's `wp_update_term_count_now()` calls `clean_term_cache()` itself after running a taxonomy's `update_count_callback`, so the shared method is correctly invalidated on its normal path and this direct caller was the only one affected. Adding invalidation inside the method would have duplicated core's work on every post save for no gain.

Both behaviours were previously pinned as defects by the characterisation suite, so the scenarios that documented them have been re-pinned to the corrected output. A new scenario covers a term being created for a draft guest author, mirroring the existing published one, and fails without the `post_status` change.

## Test plan

- [x] `features/update-author-terms.feature` green at 9 scenarios / 81 steps
- [x] PHPCS clean on the changed command file
- [ ] Full Behat suite via CI