### PR TITLE
List drafts and emit valid CSV from list-posts-without-terms

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -677,14 +677,38 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
 
 - The command only ever prints CSV-ish lines; there is no summary and no
   success message, and an empty result prints nothing (exit 0). Pinned.
-- Post titles go through `addslashes()` (php/class-wp-cli.php:818), so an
-  apostrophe renders as `\'` in the output — PHP-style escaping inside
-  CSV-style quoting. Pinned.
-- Only `publish` posts are inspected (WP_Query default status with no logged-in
-  user), so drafts without terms are silently excluded. Pinned.
-- `$assoc_args` is merged straight into the WP_Query args (wp_parse_args at
-  :807), so ANY WP_Query var (e.g. `--year=`) is accepted, not just the
-  documented `--post_type`. Noted; not pinned.
+- ~~Post titles go through `addslashes()`, so an apostrophe renders as `\'` in
+  the output — PHP-style escaping inside CSV-style quoting.~~ **FIXED.** Every
+  field is wrapped in `"` and joined with `,`, which is CSV, and CSV escapes an
+  embedded quote by doubling it rather than with a backslash. A title containing
+  a quote therefore produced a line no CSV parser could read back, and
+  apostrophes and backslashes were mangled for no reason at all — neither needs
+  escaping in CSV. `addslashes()` is replaced by doubling `"`, and it appeared
+  nowhere else in the plugin. Two scenarios now pin it: an apostrophe printed
+  literally, and a quoted title round-tripping as `""`.
+- ~~Only `publish` posts are inspected (WP_Query default status with no logged-in
+  user), so drafts without terms are silently excluded.~~ **FIXED.** The query
+  now passes `post_status => 'any'`. This is the command whose entire purpose is
+  finding posts that lack author terms, and drafts are exactly where they go
+  missing, so the omission defeated the diagnostic. There was also no way to work
+  around it: the synopsis declares only `[--post_type]`, and WP-CLI treats an
+  undeclared argument as fatal, so `--post_status=draft` exited 1. `'any'` still
+  excludes trashed and auto-draft posts, which a new scenario pins so the
+  boundary cannot drift. No opt-in flag was added: this is a read-only
+  diagnostic, so a narrow default buys no safety, and the two comparable fixes in
+  this catalogue (`update-author-terms` and
+  `delete-postmeta-that-skip-author-term-backfill`) both widened rather than
+  adding a flag.
+- ~~`$assoc_args` is merged straight into the WP_Query args, so ANY WP_Query var
+  (e.g. `--year=`) is accepted, not just the documented `--post_type`.~~ **NEVER
+  TRUE**, rather than fixed. The pre-split code already declared
+  `@synopsis [--post_type=<ptype>]`, and WP-CLI rejects an undeclared associative
+  argument as a fatal parameter error, so `--year` has never reached
+  `wp_parse_args`. The entry was reasoned from reading the merge without
+  accounting for WP-CLI's synopsis gate, and it was explicitly "Noted; not
+  pinned" — the note's own methodology gave it away. The vestigial `'year' => ''`
+  default it described has been deleted. Worth treating the other "not pinned"
+  entries with the same suspicion, since they are the ones never executed.
 
 
 - Hardened 2026-09-02 after adversarial review: 7 scenarios.
@@ -706,7 +730,8 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   so the ordering regex keys on the post titles rather than on saved IDs.
 - The draft scenario now asserts the draft genuinely has no author term before the
   command runs, so its empty output can only be explained by the post_status
-  filter.
+  filter. (Since the post_status fix it asserts the draft IS listed, and the
+  no-author-term check still rules out the other explanation.)
 ## update-author-terms
 
 (Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)

--- a/features/list-posts-without-terms.feature
+++ b/features/list-posts-without-terms.feature
@@ -68,16 +68,28 @@ Feature: Posts without author terms can be listed
 		"{PAGE_ID}","About page","
 		"""
 
-	Scenario: Post titles are passed through addslashes
+	Scenario: An apostrophe in a post title is printed literally
 		When I run `wp post create --post_title="No Man's Sky" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp co-authors-plus list-posts-without-terms`
 		Then STDOUT should contain:
 		"""
-		"{POST_ID}","No Man\'s Sky","
+		"{POST_ID}","No Man's Sky","
 		"""
 
-	Scenario: Draft posts are not listed even though they have no author terms
+	# Every field is quoted, so a quote inside one has to be doubled for the line to
+	# survive a CSV parser. addslashes() backslash-escaped it, which nothing reads.
+	Scenario: A double quote in a post title is doubled, as CSV requires
+		When I run `wp post create --post_title='He said "hi"' --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should contain:
+		"""
+		"{POST_ID}","He said ""hi""","
+		"""
+		And the return code should be 0
+
+	Scenario: Draft posts without author terms are listed
 		When I run `wp post create --post_title="Draft post" --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp term list author --object_ids={POST_ID} --format=count`
@@ -86,6 +98,22 @@ Feature: Posts without author terms can be listed
 		0
 		"""
 		When I run `wp co-authors-plus list-posts-without-terms`
+		Then STDOUT should contain:
+		"""
+		"{POST_ID}","Draft post","
+		"""
+		And the return code should be 0
+		And STDERR should be empty
+
+	# 'any' is deliberately not 'every status': a binned post is not a post missing
+	# its author term, and listing it would be noise in the diagnostic.
+	Scenario: Trashed posts are not listed
+		When I run `wp post create --post_title="Binned post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post delete {POST_ID}`
+		And I run `wp co-authors-plus list-posts-without-terms`
 		Then STDOUT should be empty
 		And the return code should be 0
 		And STDERR should be empty
+		When I run `wp post delete {POST_ID} --force`
+		Then the return code should be 0

--- a/php/cli/class-list-posts-without-terms-command.php
+++ b/php/cli/class-list-posts-without-terms-command.php
@@ -63,13 +63,13 @@ class List_Posts_Without_Terms_Command {
 	 * @return void
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
-		$coauthors_plus = $this->coauthors_plus;
-
 		$defaults   = array(
 			'post_type'         => 'post',
+			// Without this the query defaults to publish, hiding the drafts this
+			// command exists to find. 'any' still excludes trash and auto-drafts.
+			'post_status'       => 'any',
 			'order'             => 'ASC',
 			'orderby'           => 'ID',
-			'year'              => '',
 			'posts_per_page'    => 300,
 			'paged'             => 1,
 			'no_found_rows'     => true,
@@ -86,11 +86,13 @@ class List_Posts_Without_Terms_Command {
 				if ( empty( $terms ) ) {
 					$saved = array(
 						$single_post->ID,
-						addslashes( $single_post->post_title ),
+						$single_post->post_title,
 						get_permalink( $single_post->ID ),
 						$single_post->post_date,
 					);
-					WP_CLI::log( '"' . implode( '","', $saved ) . '"' );
+					// Every field is quoted, so CSV needs an embedded quote doubled.
+					// addslashes() backslash-escaped it instead, which no CSV parser reads.
+					WP_CLI::log( '"' . implode( '","', str_replace( '"', '""', $saved ) ) . '"' );
 				}
 			}
 


### PR DESCRIPTION
## Summary

`wp co-authors-plus list-posts-without-terms` exists to find posts that are missing their author terms. Drafts are precisely where terms go missing — a post saved before its byline is set, or one whose import half-completed — and the command could not see a single one of them. The `WP_Query` carried no `post_status`, so it inherited the default of `publish`, and the report that exists to surface the problem was quietly hiding most of it.

There was also no way to work around that. The synopsis declares only `[--post_type]`, and WP-CLI treats an undeclared associative argument as a fatal parameter error rather than a warning, so `--post_status=draft` exits 1 with `unknown --post_status parameter`. The narrow default was not a default at all; it was the only behaviour available.

I have widened it to `post_status => 'any'` rather than adding an opt-in flag, and it is worth saying why, because the sibling `create-author-terms-for-posts` does expose a `--post-statuses` flag defaulting to `publish`. That sibling is a *write* command, where a narrow default is a blast-radius control deciding what gets mutated. This one writes nothing. A `publish` default here controls no risk; it only withholds evidence. An opt-in flag would document the omission rather than fix it, and would leave it in place for everyone who does not know to look — which is everyone the diagnostic is for. The two comparable fixes already in the behaviour catalogue, on `update-author-terms` and `delete-postmeta-that-skip-author-term-backfill`, both widened the default rather than adding a flag, so this keeps the third of them consistent. `'any'` still excludes trashed and auto-draft posts, which is the behaviour you want and which a new scenario now pins so the boundary cannot drift unnoticed.

Separately, post titles were passed through `addslashes()`. Each field is wrapped in `"` and joined with `,` — that is CSV, and CSV escapes an embedded quote by doubling it, not with a backslash. A title containing a quote therefore produced a row no CSV parser could read back correctly, and depending on where the quote fell the parser would mis-split the row entirely. Apostrophes and backslashes were mangled too, despite neither needing any escaping in CSV. That call was the only `addslashes()` in the plugin.

The vestigial `'year' => ''` query default went with them. Nothing could ever reach it: the pre-split code already declared `@synopsis [--post_type=<ptype>]`, so the catalogue's claim that any `WP_Query` var was accepted was never true, and the notes now record it as such rather than as fixed. Tellingly, that entry was one of the ones marked "Noted; not pinned" — reasoned from reading the source and never executed, which is exactly the kind that turns out to be wrong.

## Test plan

- [x] `features/list-posts-without-terms.feature` green at 9 scenarios / 72 steps, up from 7
- [x] PHPCS clean on the changed file
- [x] Full Behat suite via CI