### PR TITLE
Stop reassign-terms reporting work it did not do

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -238,11 +238,15 @@ PHP 8.4) rather than inferred from reading the source.
   0.~~ **FIXED.** The variable is initialised, a mapping file that does not
   define `$cli_user_map` is reported, and the command now errors when it has
   nothing to reassign rather than pretending to succeed.
-- The rename path (target term absent) sets the surviving term's slug AND name to
-  the raw `--new_term` value with NO `cap-` prefix (lines 598-603), inconsistent
-  with the plugin's `cap-<nicename>` slug convention. The old guest author profile
-  keeps its original `user_login`/`post_name`, so term and profile drift apart.
-  Confirmed (term list shows `newuser,newuser` next to `admin,cap-admin`).
+- ~~The rename path (target term absent) sets the surviving term's slug AND name to
+  the raw `--new-term` value with NO `cap-` prefix, inconsistent with the plugin's
+  `cap-<nicename>` slug convention.~~ **FIXED.** The slug is now
+  `Prefix::prefix_slug( $new_user )` while the name stays raw, matching what
+  `rename-coauthor` already does. Note this does NOT make a second run idempotent,
+  and deliberately so: the command never touches the guest-author profile, so
+  `post_name` still holds the old login and the entry below about the second run
+  reporting a missing term still stands. Renaming the profile too is
+  `rename-coauthor`'s job.
 - "Error: Term 'x' doesn't exist, skipping" is emitted via `WP_CLI::log` to STDOUT
   and the exit code stays 0 (line 580), so scripted callers cannot detect the miss
   from the exit code. Confirmed.
@@ -267,27 +271,32 @@ PHP 8.4) rather than inferred from reading the source.
   $authors_to_migrate`, rc 0, all-zero summary. The `if ( $old_term && $new_term )`
   guard at :557 has no else branch and there is no validation of the pair. Pinned in
   the no-args scenario.
-- NEW (silent false success): the rename branch ignores `wp_update_term()`'s return
-  value (:598-606). When the target slug is already taken by an unrelated author
-  term, `wp_update_term()` returns `WP_Error( 'duplicate_term_slug' )`, nothing is
-  renamed, and the command still logs `Success: Converted 'olduser' term to
-  'newuser'` and counts `- 1 authors were successfully reassigned terms`. Confirmed:
-  `cap-olduser` survives untouched next to the pre-existing `newuser` term. Pinned in
-  "A target slug already taken by another term still reports success".
-- NEW (unresolved numeric `--new_term`): `--new_term=999999` with no such user makes
-  `get_user_by( 'id', ... )` return false, and PHP 8.4 emits `Warning: Attempt to
-  read property "user_login" on false` (:574). `$new_user` becomes null, the rename
-  branch calls `wp_update_term()` with a null name/slug, and that WP_Error is
-  discarded too. rc stays 0 and the summary still prints. Nothing is renamed —
-  the scenario asserts the unchanged term list, so the pin holds whichever way a
-  refactor resolves this.
-- NEW (data loss): `--old_term=x --new_term=x` takes the MERGE branch, because both
-  lookups return the same term object. `wp_delete_term( $id, 'author', array(
+- ~~NEW (silent false success): the rename branch ignores `wp_update_term()`'s
+  return value. When the target slug is already taken by an unrelated author term it
+  returns `WP_Error( 'duplicate_term_slug' )`, nothing is renamed, and the command
+  still logs `Success: Converted ...` and counts it a success.~~ **FIXED.** The
+  return is checked and a failed rename reports a warning naming the term and the
+  underlying reason, and is not counted. The scenario's fixture term had to move to
+  slug `cap-newuser` to keep provoking the collision, since the prefix fix above
+  changed what the rename targets — worth knowing, because had the prefix fix landed
+  second this scenario would have started passing while proving nothing. Core owns
+  the duplicate-slug wording, so only CAP's half of the message is pinned.
+- ~~NEW (unresolved numeric `--new-term`): `--new-term=999999` with no such user
+  makes `get_user_by( 'id', ... )` return false, PHP 8.4 emits `Warning: Attempt to
+  read property "user_login" on false`, `$new_user` becomes null, and the rename
+  branch calls `wp_update_term()` with a null name/slug whose WP_Error is discarded
+  too.~~ **FIXED.** The lookup result is checked and the row is skipped with a
+  warning naming the ID, so no null ever reaches core. rc stays 0, which is
+  consistent with the other skip paths — see the open note about exit codes below.
+- ~~NEW (data loss): `--old-term=x --new-term=x` takes the MERGE branch, because
+  both lookups return the same term object. `wp_delete_term( $id, 'author', array(
   'default' => $id, 'force_default' => true ) )` reassigns the term's posts to the
   term that is about to be deleted, so those posts end up with NO author term at all
-  while the summary reports `- 1 authors had their old term merged to their new
-  term`. Confirmed. Pinned in "Reassigning a term to itself deletes the term and
-  orphans its posts".
+  while the summary reports a successful merge.~~ **FIXED.** The merge branch now
+  compares `term_id` and skips with a warning. Comparing the two *inputs* would not
+  have been enough: two different spellings can resolve to the same co-author, so the
+  guard has to be on the resolved term. The scenario now asserts the post keeps
+  `cap-olduser` and the term survives.
 - The docblock (:518-525) advertises cleaning up after an import that created
   'author' terms under the OLD user_login, but the old-term lookup goes through
   `get_coauthor_by( 'login', ... )` -> `get_author_term()`, which returns null for a

--- a/features/reassign-terms.feature
+++ b/features/reassign-terms.feature
@@ -22,7 +22,7 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 		name,slug
 		admin,cap-admin
-		newuser,newuser
+		newuser,cap-newuser
 		"""
 		When I run `wp post list --post_type=guest-author --orderby=ID --order=asc --field=post_name`
 		Then STDOUT should be:
@@ -43,7 +43,7 @@ Feature: Author terms can be reassigned between co-authors
 		Then STDOUT should be:
 		"""
 		cap-admin
-		newuser
+		cap-newuser
 		"""
 
 	Scenario: Merge into an existing term and reassign its posts
@@ -82,7 +82,7 @@ Feature: Author terms can be reassigned between co-authors
 		cap-olduser
 		"""
 
-	Scenario: Reassigning a term to itself deletes the term and orphans its posts
+	Scenario: Reassigning a term to itself is skipped
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
 		And I run `wp post create --post_title="Owned post" --post_status=publish --porcelain`
@@ -92,19 +92,23 @@ Feature: Author terms can be reassigned between co-authors
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Success: There's already a 'olduser' term for 'olduser'. Reassigning 1 posts and then deleting the term
+		Warning: Term 'olduser' is already 'olduser', skipping
 		Reassignment complete. Here are your results:
 		- 0 authors were successfully reassigned terms
-		- 1 authors had their old term merged to their new term
+		- 0 authors had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
-		Then STDOUT should be empty
+		Then STDOUT should be:
+		"""
+		cap-olduser
+		"""
 		And the return code should be 0
 		When I run `wp term list author --field=slug`
 		Then STDOUT should be:
 		"""
 		cap-admin
+		cap-olduser
 		"""
 
 	Scenario: A numeric --new-term is resolved to that user's login
@@ -125,17 +129,17 @@ Feature: Author terms can be reassigned between co-authors
 		Then STDOUT should be:
 		"""
 		cap-admin
-		newuser
+		cap-newuser
 		"""
 
-	Scenario: A numeric --new-term for an unknown user id is not resolved
+	Scenario: A numeric --new-term for an unknown user id is skipped
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
 		And I try `wp co-authors-plus reassign-terms --old-term=olduser --new-term=999999`
 		Then the return code should be 0
 		And STDERR should contain:
 		"""
-		Attempt to read property "user_login" on false
+		Warning: No user has the ID 999999, skipping 'olduser'
 		"""
 		And STDOUT should contain:
 		"""
@@ -148,18 +152,21 @@ Feature: Author terms can be reassigned between co-authors
 		cap-olduser
 		"""
 
-	Scenario: A target slug already taken by another term still reports success
+	Scenario: A target slug already taken by another term is reported, not counted
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`
-		And I run `wp term create author newuser --porcelain`
+		And I run `wp term create author newuser --slug=cap-newuser --porcelain`
 		And save STDOUT as {EXISTING_ID}
 		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=newuser`
 		Then the return code should be 0
-		And STDOUT should be:
+		And STDOUT should contain:
 		"""
-		Success: Converted 'olduser' term to 'newuser'
+		Warning: Could not convert 'olduser' term to 'newuser':
+		"""
+		And STDOUT should contain:
+		"""
 		Reassignment complete. Here are your results:
-		- 1 authors were successfully reassigned terms
+		- 0 authors were successfully reassigned terms
 		- 0 authors had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
@@ -167,7 +174,7 @@ Feature: Author terms can be reassigned between co-authors
 		Then STDOUT should be:
 		"""
 		cap-admin
-		newuser
+		cap-newuser
 		cap-olduser
 		"""
 
@@ -239,7 +246,7 @@ Feature: Author terms can be reassigned between co-authors
 		Then STDOUT should be:
 		"""
 		cap-admin
-		newuser
+		cap-newuser
 		"""
 
 	Scenario: Report a missing --author-mapping file
@@ -270,7 +277,7 @@ Feature: Author terms can be reassigned between co-authors
 		Then STDOUT should be:
 		"""
 		cap-admin
-		newuser
+		cap-newuser
 		"""
 
 	Scenario: The underscore variant --author_mapping is rejected as an unknown parameter

--- a/php/cli/class-reassign-terms-command.php
+++ b/php/cli/class-reassign-terms-command.php
@@ -9,15 +9,14 @@ declare( strict_types=1 );
 
 namespace Automattic\CoAuthorsPlus\CLI;
 
+use CoAuthors\Prefix;
 use CoAuthors_Plus;
 use WP_CLI;
 
 /**
  * Renames or merges author terms, so an import can be tidied up afterwards.
  *
- * Moved here from CoAuthorsPlus_Command unchanged, save for the scratch
- * property holding its parsed arguments becoming a local. Behaviour is pinned
- * by features/reassign-terms.feature.
+ * Behaviour is pinned by features/reassign-terms.feature.
  */
 class Reassign_Terms_Command {
 
@@ -141,7 +140,12 @@ class Reassign_Terms_Command {
 		foreach ( $authors_to_migrate as $old_user => $new_user ) {
 
 			if ( is_numeric( $new_user ) ) {
-				$new_user = get_user_by( 'id', $new_user )->user_login;
+				$new_user_object = get_user_by( 'id', (int) $new_user );
+				if ( ! $new_user_object ) {
+					WP_CLI::warning( "No user has the ID {$new_user}, skipping '{$old_user}'" );
+					continue;
+				}
+				$new_user = $new_user_object->user_login;
 			}
 
 			// The old user should exist as a term.
@@ -157,22 +161,35 @@ class Reassign_Terms_Command {
 			// Otherwise, simply rename the old term.
 			$new_term = $coauthors_plus->get_author_term( $coauthors_plus->get_coauthor_by( 'login', $new_user ) );
 			if ( is_object( $new_term ) ) {
+				// Both logins can resolve to the same term. Merging would hand the posts
+				// to the very term about to be deleted, leaving them with none at all.
+				if ( (int) $new_term->term_id === (int) $old_term->term_id ) {
+					WP_CLI::warning( "Term '{$old_user}' is already '{$new_user}', skipping" );
+					continue;
+				}
+
 				WP_CLI::log( "Success: There's already a '{$new_user}' term for '{$old_user}'. Reassigning {$old_term->count} posts and then deleting the term" );
-				$args = array(
+				$term_args = array(
 					'default'       => $new_term->term_id,
 					'force_default' => true,
 				);
-				wp_delete_term( $old_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
+				wp_delete_term( $old_term->term_id, $coauthors_plus->coauthor_taxonomy, $term_args );
 				$results->new_term_exists++;
 			} else {
-				$args = array(
-					'slug' => $new_user,
+				// Every other author term is stored prefixed, so a rename must be too.
+				$term_args = array(
+					'slug' => Prefix::prefix_slug( $new_user ),
 					'name' => $new_user,
 				);
-				wp_update_term( $old_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
+				$updated   = wp_update_term( $old_term->term_id, $coauthors_plus->coauthor_taxonomy, $term_args );
+				if ( is_wp_error( $updated ) ) {
+					WP_CLI::warning( "Could not convert '{$old_user}' term to '{$new_user}': " . $updated->get_error_message() );
+					continue;
+				}
+
 				WP_CLI::log( "Success: Converted '{$old_user}' term to '{$new_user}'" );
 				$results->success++;
-			}
+			}//end if
 			clean_term_cache( $old_term->term_id, $coauthors_plus->coauthor_taxonomy );
 		}//end foreach
 


### PR DESCRIPTION
## Summary

`reassign-terms` is a post-import tidy-up tool, so it tends to be pointed at a mapping file covering thousands of authors and run once, in anger, against a database someone has just migrated. That makes "reported success, did something else" an especially bad failure mode here, and it had four of them, all inside the one loop that does the work.

**The first destroys data.** Passing the same value to `--old-term` and `--new-term` makes both lookups return the same term object, which sends it down the *merge* branch. That branch calls `wp_delete_term()` with the doomed term as its own `default` and `force_default` set, so core reassigns the term's posts to the term it is about to delete. The posts end up with no author term whatsoever, and the summary cheerfully reports `- 1 authors had their old term merged to their new term`. The guard compares the resolved `term_id` rather than the two input strings, because two different spellings can resolve to the same co-author and the string comparison would have missed those.

**The rename branch discarded `wp_update_term()`'s return value.** When the target slug is already taken by another author term, core returns `WP_Error( 'duplicate_term_slug' )` and renames nothing — and the command logged `Success: Converted 'olduser' term to 'newuser'` and counted it. Relatedly, a numeric `--new-term` naming a user that does not exist read `->user_login` off `false`, so a PHP warning was followed by an update with a null name and slug, and *that* `WP_Error` was discarded too. Both now report a warning naming the term and the reason, and neither is counted as a success.

**The rename also wrote its slug unprefixed**, alone among every author term the plugin stores. It now uses `Prefix::prefix_slug()` for the slug while keeping the raw value as the name, which is exactly what `rename-coauthor` already does.

One thing I want to be explicit about rather than let a reviewer discover: the prefix fix does **not** make a second run idempotent, and I have deliberately left that alone. This command never touches the guest-author profile, so `post_name` still holds the old login and a second run still reports the term as missing. Reconciling term and profile is `rename-coauthor`'s job, and doing it here would turn a term-only tool into something else. The behaviour notes now say so explicitly instead of leaving it looking like an oversight.

## Worth a reviewer's attention

The order these landed in mattered, which is not obvious from the final diff. The scenario covering the slug collision creates a term to collide with. Once the rename started producing `cap-newuser` instead of `newuser`, that fixture no longer collided — so had the prefix fix been applied after the return-value fix, the scenario guarding it would have **passed while proving nothing**. I moved the fixture to `--slug=cap-newuser` to keep the collision real. This is the same class of problem as a stale guard: the test does not go red, it just quietly stops testing.

Only CAP's half of that warning is pinned. The duplicate-slug wording belongs to wordpress-develop, is translatable and entity-encoded, so pinning it would be pinning someone else's string.

## Test plan

- [x] `features/reassign-terms.feature` green at 12 scenarios / 131 steps
- [x] All four fixes have a scenario that failed before them — confirmed by running the suite against the patched code before re-pinning, which failed exactly the seven predicted scenarios
- [x] PHPCS clean on the changed file by exit code
- [ ] Full Behat suite via CI