### PR TITLE
Stop create-terms-for-posts claiming posts it left untouched

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -492,37 +492,44 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
 
-- When a post's `post_author` user does not exist, `update_author_term()` returns
-  `false` and the command dereferences it anyway (php/class-wp-cli.php:131-132).
-  Confirmed live: `Warning: Attempt to read property "slug" on false in .../php/class-wp-cli.php on line 131`
-  and the same for `"user_nicename"` on line 132 (PHP 8.4 says "on false", not
-  "on bool"). Each warning appears TWICE in combined output: once as a
-  timestamped debug-log line (`[date] PHP Warning: ...`) and once as a plain
-  `Warning: ...` display line. No `trim(): Passing null` deprecation from
-  `wp_set_object_terms()` was observed. The post is still logged as
-  `Added - Post #N ... now has an author term for: ` (trailing empty author),
-  counted in `$affected`, and the final message claims
-  `Success: Done! Of 1 posts, 1 now have author terms.` even though NO term was
-  set (verified: `wp term list author --object_ids=N --format=count` is 0).
-  Pinned with `should contain:` + the count state assertion.
-- `Updating author terms with new counts` is misleading: `update_author_term()`
-  only refreshes the term description; it never recalculates counts
-  (`update_author_term_post_count()` is not called here).
+- ~~When a post's `post_author` user does not exist, `update_author_term()` returns
+  `false` and the command dereferences it anyway, emitting PHP warnings for `slug`
+  and `user_nicename`. The post is still logged as `Added ... now has an author term
+  for: ` with a trailing empty author, counted in `$affected`, and the run claims
+  `Of 1 posts, 1 now have author terms.` though NO term was set.~~ **FIXED.** The
+  resolved term is checked with `! $author_term instanceof WP_Term`, which covers
+  both failure modes — `false` for a missing user, and a `WP_Error` if the term
+  cannot be created — and the post is skipped with a warning naming the post and the
+  user ID. The summary counts it honestly, so the state assertion (`0` terms) now
+  agrees with the reported figure instead of contradicting it. The memo also moved
+  from `! empty()` to `??`, so a failed lookup is cached too and an orphaned author
+  is resolved once per run rather than once per post.
+- ~~`Updating author terms with new counts` is misleading: `update_author_term()`
+  only refreshes the term description; it never recalculates counts.~~ **FIXED, and
+  the original diagnosis here was wrong.** Counts *are* recalculated — CAP registers
+  `_update_users_posts_count` as the taxonomy's `update_count_callback`, and core
+  fires it from `wp_set_object_terms()`, so setting the term on each post already
+  maintains the count. The real defect was that the whole trailing pass was
+  REDUNDANT: it looped over authors that had every one been through
+  `update_author_term()` moments earlier in the same run, with a description derived
+  from user fields that cannot have changed meanwhile, so `wp_update_term()` never
+  fired. A second pass doing nothing, announced by a message describing something
+  else. Both are deleted. A new scenario forces a term count to 5, runs the command,
+  and asserts the count comes back to 1 — verified live, which is what confirmed the
+  write path maintains it and the deletion is safe.
 - The command walks every supported post type (post AND page by default), unlike
   `create-author-terms-for-posts` which defaults to `post` only. Pinned in the
   "Pages are inspected by default" scenario.
 - Never-pluralised grammar: `Of 1 posts, 1 now have author terms.`
-- The unused global `$wp_post_types` is imported at :89.
-- The two per-post log lines use DIFFERENT identifiers for the same term: the
-  "Skipping" line prints term NAMES (`already has these terms: admin`) while the
-  "Added" line prints the user's `user_nicename` (`... an author term for:
-  writer`) — neither shows the `cap-` prefixed slug that is actually stored.
-  Confirmed 2026-09-02 and pinned in "The author term reflects the post author
-  rather than always being admin" (log says `writer`, stored slug is
-  `cap-writer`).
-- The "Skipping" line uses `{$posts->found_posts}` as the denominator while the
-  "Added" line uses `$total_posts` (:118 vs :129). They are equal today only
-  because `found_posts` is re-read from an identical query each page.
+- ~~The two per-post log lines use DIFFERENT identifiers for the same term: the
+  "Skipping" line prints term NAMES while the "Added" line prints the user's
+  `user_nicename` — neither shows the `cap-` prefixed slug that is actually
+  stored.~~ **FIXED.** Both lines now print the slug, so the log names the thing
+  the command wrote and an operator can paste it straight into `wp term list`.
+- ~~The "Skipping" line uses `{$posts->found_posts}` as the denominator while the
+  "Added" line uses `$total_posts`. They are equal today only because
+  `found_posts` is re-read from an identical query each page.~~ **FIXED.** Both use
+  `$total_posts`. No output change today; it removes a latent divergence.
 
 - Hardened 2026-09-02 after adversarial review: 9 scenarios, all green.
 - Drafts, pending and private posts are INVISIBLE to this command. The WP_Query at
@@ -544,9 +551,15 @@ PHP 8.4) rather than inferred from reading the source.
   `$author_terms[ ... ]`, :123-127) is now exercised with two distinct authors in
   "Each post gets an author term for its own author", so hoisting the lookup out
   of the loop can no longer pass.
-- The orphan-author "Added" line is now pinned with an end-anchored regex
-  (`... now has an author term for: ?$`) instead of a substring, so a refactor
-  that substituted a placeholder nicename would fail.
+- The orphan-author scenario was pinned with an end-anchored regex on the empty
+  trailing nicename. That is gone with the bug: the scenario now pins the whole of
+  STDOUT exactly, since a skipped post produces a short and fully predictable run.
+- STILL OPEN: drafts, pending and private posts remain invisible, and the docblock
+  still overclaims. The sibling `create-author-terms-for-posts` exposes
+  `--post-statuses`; adding the same flag here (defaulting to `publish`, so no
+  silent scope change on a command that WRITES) is the natural fix, kept separate
+  from the corrections above because it adds public interface rather than fixing
+  behaviour.
 
 ## create-author-terms-for-posts
 

--- a/features/create-terms-for-posts.feature
+++ b/features/create-terms-for-posts.feature
@@ -9,7 +9,6 @@ Feature: Author terms can be created for all posts
 		Then STDOUT should be:
 		"""
 		Now inspecting or updating 0 total posts.
-		Updating author terms with new counts
 		Success: Done! Of 0 posts, 0 now have author terms.
 		"""
 
@@ -25,10 +24,9 @@ Feature: Author terms can be created for all posts
 		"""
 		Now inspecting or updating 2 total posts.
 		No co-authors found for post #{POST_A}.
-		1/2) Added - Post #{POST_A} 'First post' now has an author term for: admin
+		1/2) Added - Post #{POST_A} 'First post' now has this author term: cap-admin
 		No co-authors found for post #{POST_B}.
-		2/2) Added - Post #{POST_B} 'Second post' now has an author term for: admin
-		Updating author terms with new counts
+		2/2) Added - Post #{POST_B} 'Second post' now has this author term: cap-admin
 		Success: Done! Of 2 posts, 2 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -40,9 +38,8 @@ Feature: Author terms can be created for all posts
 		Then STDOUT should be:
 		"""
 		Now inspecting or updating 2 total posts.
-		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: admin
-		2/2) Skipping - Post #{POST_B} 'Second post' already has these terms: admin
-		Updating author terms with new counts
+		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: cap-admin
+		2/2) Skipping - Post #{POST_B} 'Second post' already has these terms: cap-admin
 		Success: Done! Of 2 posts, 0 now have author terms.
 		"""
 
@@ -56,10 +53,9 @@ Feature: Author terms can be created for all posts
 		Then STDOUT should be:
 		"""
 		Now inspecting or updating 2 total posts.
-		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: admin
+		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: cap-admin
 		No co-authors found for post #{POST_B}.
-		2/2) Added - Post #{POST_B} 'Second post' now has an author term for: admin
-		Updating author terms with new counts
+		2/2) Added - Post #{POST_B} 'Second post' now has this author term: cap-admin
 		Success: Done! Of 2 posts, 1 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={POST_B} --field=slug`
@@ -77,8 +73,7 @@ Feature: Author terms can be created for all posts
 		"""
 		Now inspecting or updating 1 total posts.
 		No co-authors found for post #{PAGE_ID}.
-		1/1) Added - Post #{PAGE_ID} 'About page' now has an author term for: admin
-		Updating author terms with new counts
+		1/1) Added - Post #{PAGE_ID} 'About page' now has this author term: cap-admin
 		Success: Done! Of 1 posts, 1 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
@@ -98,8 +93,7 @@ Feature: Author terms can be created for all posts
 		"""
 		Now inspecting or updating 1 total posts.
 		No co-authors found for post #{POST_ID}.
-		1/1) Added - Post #{POST_ID} 'Writer post' now has an author term for: writer
-		Updating author terms with new counts
+		1/1) Added - Post #{POST_ID} 'Writer post' now has this author term: cap-writer
 		Success: Done! Of 1 posts, 1 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -108,31 +102,20 @@ Feature: Author terms can be created for all posts
 		cap-writer
 		"""
 
-	Scenario: A post whose author does not exist is reported as updated even though no term is set
+	# The post is still reported, but as skipped rather than done, and the summary
+	# no longer counts a post that came away with no term.
+	Scenario: A post whose author does not exist is skipped with a warning
 		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp co-authors-plus create-terms-for-posts`
-		Then STDOUT should contain:
+		Then STDOUT should be:
 		"""
 		Now inspecting or updating 1 total posts.
-		"""
-		And STDOUT should contain:
-		"""
 		No co-authors found for post #{POST_ID}.
+		Warning: 1/1) Skipping - Post #{POST_ID} 'Orphan post' has no author term for user ID 999.
+		Success: Done! Of 1 posts, 0 now have author terms.
 		"""
-		And STDOUT should contain:
-		"""
-		Warning: Attempt to read property "slug" on false
-		"""
-		And STDOUT should contain:
-		"""
-		Warning: Attempt to read property "user_nicename" on false
-		"""
-		And STDOUT should match #^1/1\) Added - Post \#\d+ 'Orphan post' now has an author term for: ?$#m
-		And STDOUT should contain:
-		"""
-		Success: Done! Of 1 posts, 1 now have author terms.
-		"""
+		And the return code should be 0
 		When I run `wp term list author --object_ids={POST_ID} --format=count`
 		Then STDOUT should be:
 		"""
@@ -155,10 +138,9 @@ Feature: Author terms can be created for all posts
 		"""
 		Now inspecting or updating 2 total posts.
 		No co-authors found for post #{POST_A}.
-		1/2) Added - Post #{POST_A} 'Alpha post' now has an author term for: alpha
+		1/2) Added - Post #{POST_A} 'Alpha post' now has this author term: cap-alpha
 		No co-authors found for post #{POST_B}.
-		2/2) Added - Post #{POST_B} 'Beta post' now has an author term for: beta
-		Updating author terms with new counts
+		2/2) Added - Post #{POST_B} 'Beta post' now has this author term: cap-beta
 		Success: Done! Of 2 posts, 2 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -183,7 +165,6 @@ Feature: Author terms can be created for all posts
 		Then STDOUT should be:
 		"""
 		Now inspecting or updating 0 total posts.
-		Updating author terms with new counts
 		Success: Done! Of 0 posts, 0 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={DRAFT_ID} --format=count`
@@ -212,12 +193,32 @@ Feature: Author terms can be created for all posts
 		Then STDOUT should be:
 		"""
 		Now inspecting or updating 1 total posts.
-		1/1) Skipping - Post #{POST_ID} 'Ghostwritten post' already has these terms: writer
-		Updating author terms with new counts
+		1/1) Skipping - Post #{POST_ID} 'Ghostwritten post' already has these terms: cap-writer
 		Success: Done! Of 1 posts, 0 now have author terms.
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
 		"""
 		cap-writer
+		"""
+
+	# Guards the removal of the "Updating author terms with new counts" pass. The
+	# count is recalculated by the taxonomy's update_count_callback when the term is
+	# set, so a second pass over the authors was never what maintained it.
+	Scenario: Setting an author term recalculates that term's count
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		And I run `wp eval '$t = get_term_by( "slug", "cap-admin", "author" ); global $wpdb; $wpdb->update( $wpdb->term_taxonomy, array( "count" => 5 ), array( "term_taxonomy_id" => $t->term_taxonomy_id ) );'`
+		And I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		5
+		"""
+		When I run `wp co-authors-plus create-terms-for-posts`
+		Then the return code should be 0
+		When I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		1
 		"""

--- a/php/cli/class-create-terms-for-posts-command.php
+++ b/php/cli/class-create-terms-for-posts-command.php
@@ -12,13 +12,12 @@ namespace Automattic\CoAuthorsPlus\CLI;
 use CoAuthors_Plus;
 use WP_CLI;
 use WP_Query;
+use WP_Term;
 
 /**
  * Adds a missing author term to every supported post.
  *
- * Moved here from CoAuthorsPlus_Command unchanged, but for a global that was
- * declared and never read. Behaviour is pinned by
- * features/create-terms-for-posts.feature.
+ * Behaviour is pinned by features/create-terms-for-posts.feature.
  */
 class Create_Terms_For_Posts_Command {
 
@@ -59,8 +58,7 @@ class Create_Terms_For_Posts_Command {
 	public function __invoke( array $args, array $assoc_args ): void {
 		$coauthors_plus = $this->coauthors_plus;
 
-		// Cache these to prevent repeated lookups.
-		$authors      = array();
+		// Cache this to prevent repeated lookups.
 		$author_terms = array();
 
 		$args = array(
@@ -89,18 +87,23 @@ class Create_Terms_For_Posts_Command {
 				}
 
 				if ( ! empty( $terms ) ) {
-					WP_CLI::log( "{$count}/{$posts->found_posts}) Skipping - Post #{$single_post->ID} '{$single_post->post_title}' already has these terms: " . implode( ', ', wp_list_pluck( $terms, 'name' ) ) );
+					WP_CLI::log( "{$count}/{$total_posts}) Skipping - Post #{$single_post->ID} '{$single_post->post_title}' already has these terms: " . implode( ', ', wp_list_pluck( $terms, 'slug' ) ) );
 					continue;
 				}
 
-				$author                               = ( ! empty( $authors[ $single_post->post_author ] ) ) ? $authors[ $single_post->post_author ] : get_user_by( 'id', $single_post->post_author );
-				$authors[ $single_post->post_author ] = $author;
-
-				$author_term                               = ( ! empty( $author_terms[ $single_post->post_author ] ) ) ? $author_terms[ $single_post->post_author ] : $coauthors_plus->update_author_term( $author );
+				$author_term                               = $author_terms[ $single_post->post_author ] ?? $coauthors_plus->update_author_term( get_user_by( 'id', $single_post->post_author ) );
 				$author_terms[ $single_post->post_author ] = $author_term;
 
+				// update_author_term() returns false for a missing user and a WP_Error if the
+				// term cannot be created. Both used to be dereferenced, setting no term while
+				// still counting the post as done.
+				if ( ! $author_term instanceof WP_Term ) {
+					WP_CLI::warning( "{$count}/{$total_posts}) Skipping - Post #{$single_post->ID} '{$single_post->post_title}' has no author term for user ID {$single_post->post_author}." );
+					continue;
+				}
+
 				wp_set_post_terms( $single_post->ID, array( $author_term->slug ), $coauthors_plus->coauthor_taxonomy );
-				WP_CLI::log( "{$count}/{$total_posts}) Added - Post #{$single_post->ID} '{$single_post->post_title}' now has an author term for: " . $author->user_nicename );
+				WP_CLI::log( "{$count}/{$total_posts}) Added - Post #{$single_post->ID} '{$single_post->post_title}' now has this author term: {$author_term->slug}" );
 				$affected++;
 			}//end foreach
 
@@ -112,11 +115,6 @@ class Create_Terms_For_Posts_Command {
 			$args['paged']++;
 			$posts = new WP_Query( $args );
 		}//end while
-		WP_CLI::log( 'Updating author terms with new counts' );
-		foreach ( $authors as $author ) {
-			$coauthors_plus->update_author_term( $author );
-		}
-
 		WP_CLI::success( "Done! Of {$total_posts} posts, {$affected} now have author terms." );
 	}
 }


### PR DESCRIPTION
## Summary

This command backfills author terms onto posts that lack them, and it had three problems: it claimed posts it had not touched, it named something other than what it wrote, and it ended with a pass that did nothing at all.

**The false success.** When a post's `post_author` no longer exists — an orphaned author is common after a migration, which is exactly when you reach for this command — `update_author_term()` returns `false`, and the command dereferenced it anyway for both `->slug` and `->user_nicename`. Two PHP warnings later it logged the post as `Added ... now has an author term for: ` with a trailing empty name, counted it in `$affected`, and finished `Success: Done! Of 1 posts, 1 now have author terms.` while the post had no author term whatsoever. The old scenario captured that contradiction perfectly: it asserted the summary said `1` and then asserted the stored term count was `0`. Checking `! $author_term instanceof WP_Term` covers both ways this fails — `false` for the missing user, and a `WP_Error` if the term cannot be created — and the post is now skipped with a warning naming it and the user ID.

**The wrong identifier.** The two per-post lines named different things, and neither was what got stored: the skipping line printed term *names*, the added line the author's *nicename*, while the taxonomy holds the `cap-` prefixed slug. Both now print the slug, so what you read in the log can be pasted straight into `wp term list`.

**The pass that did nothing.** This is the part worth reading carefully, because the behaviour catalogue had it wrong and so did I. The note said `Updating author terms with new counts` was misleading because counts are never recalculated. They are: CAP registers `_update_users_posts_count` as the `author` taxonomy's `update_count_callback`, and core fires it from `wp_set_object_terms()`, so setting the term on each post already maintains the count. The actual defect was that the entire trailing loop was **redundant** — every author in it had been through `update_author_term()` moments earlier in the same run, with a description derived from user fields that cannot change mid-run, so `wp_update_term()` never fired. A second pass doing nothing, announced by a message describing something else. Both are gone.

I did not want to delete that on reasoning alone, so there is a new scenario that forces a term's count to 5, runs the command, and asserts it comes back to 1. It passes, which is what actually establishes that the write path maintains the count and the deletion is safe.

## Deliberately not included

Drafts, pending and private posts are still invisible to this command, and the docblock still overclaims that it walks every supported post. The sibling `create-author-terms-for-posts` exposes a `--post-statuses` flag for exactly this, and adding the same one here is the right fix — defaulting to `publish`, so there is no silent scope change on a command that *writes*. That adds public interface rather than correcting behaviour, so it belongs in its own change rather than riding along with three corrections. The behaviour notes record it as still open.

## Test plan

- [x] `features/create-terms-for-posts.feature` green at 10 scenarios / 115 steps, up from 9
- [x] All nine pre-existing scenarios failed against the patched code before re-pinning, confirming each one was actually pinning the old output
- [x] PHPCS clean on the changed file by exit code
- [ ] Full Behat suite via CI