### PR TITLE
Let create-terms-for-posts choose post statuses

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -541,14 +541,14 @@ PHP 8.4) rather than inferred from reading the source.
   `$total_posts`. No output change today; it removes a latent divergence.
 
 - Hardened 2026-09-02 after adversarial review: 9 scenarios, all green.
-- Drafts, pending and private posts are INVISIBLE to this command. The WP_Query at
-  :94-101 sets no `post_status`, and a CLI request has no current user, so only
-  public statuses are inspected — despite the docblock's claim that it walks all
-  posts, and unlike `create-author-terms-for-posts`, which exposes
-  `--post-statuses`. Pinned in "Draft and private posts are never inspected": the
-  command reports `Now inspecting or updating 0 total posts.` and both posts end
-  with zero author terms. A "tidy-up" adding `'post_status' => 'any'` would be a
-  silent scope change.
+- ~~Drafts, pending and private posts are INVISIBLE to this command. The WP_Query
+  sets no `post_status`, and a CLI request has no current user, so only public
+  statuses are inspected — despite the docblock's claim that it walks all posts, and
+  unlike `create-author-terms-for-posts`, which exposes `--post-statuses`. A
+  "tidy-up" adding `'post_status' => 'any'` would be a silent scope
+  change.~~ **FIXED** by the flag rather than by widening, for exactly the reason
+  that last sentence gives. The default-scope scenario is retained and renamed to
+  say "by default", with a companion scenario covering `--post-statuses=draft`.
 - The skip guard is "has ANY term in the author taxonomy", not "has the term for
   this post's author", so a post deliberately attributed to somebody other than
   `post_author` is skipped and never reconciled. Pinned in "A post whose existing
@@ -563,12 +563,17 @@ PHP 8.4) rather than inferred from reading the source.
 - The orphan-author scenario was pinned with an end-anchored regex on the empty
   trailing nicename. That is gone with the bug: the scenario now pins the whole of
   STDOUT exactly, since a skipped post produces a short and fully predictable run.
-- STILL OPEN: drafts, pending and private posts remain invisible, and the docblock
-  still overclaims. The sibling `create-author-terms-for-posts` exposes
-  `--post-statuses`; adding the same flag here (defaulting to `publish`, so no
-  silent scope change on a command that WRITES) is the natural fix, kept separate
-  from the corrections above because it adds public interface rather than fixing
-  behaviour.
+- ~~Drafts, pending and private posts are invisible, and the docblock overclaims
+  that the command walks every supported post.~~ **FIXED** by adding
+  `--post-statuses`, spelled and defaulted exactly as the sibling
+  `create-author-terms-for-posts` does. The default stays `publish` deliberately:
+  this command WRITES, so widening it would silently multiply the scope of a
+  backfill and attach terms to drafts nobody asked about. Contrast
+  `list-posts-without-terms`, where the default WAS widened — that one is read-only,
+  so a narrow default bought no safety and only withheld evidence. Naming the status
+  explicitly also removes an oddity: `WP_Query`'s default is publish PLUS whatever
+  private statuses the current user can read, so the scope of a backfill previously
+  depended on whether `--user` was passed.
 
 ## create-author-terms-for-posts
 

--- a/features/create-terms-for-posts.feature
+++ b/features/create-terms-for-posts.feature
@@ -154,7 +154,9 @@ Feature: Author terms can be created for all posts
 		cap-beta
 		"""
 
-	Scenario: Draft and private posts are never inspected
+	# The default is deliberately still publish: this command WRITES, so widening it
+	# would silently multiply the scope of a backfill. --post-statuses is the opt-in.
+	Scenario: Draft and private posts are not inspected by default
 		When I run `wp post create --post_title="Draft post" --post_author=1 --porcelain`
 		And save STDOUT as {DRAFT_ID}
 		And I run `wp post create --post_title="Private post" --post_status=private --post_author=1 --porcelain`
@@ -221,4 +223,22 @@ Feature: Author terms can be created for all posts
 		Then STDOUT should be:
 		"""
 		1
+		"""
+
+	Scenario: Drafts are covered when asked for
+		When I run `wp post create --post_title="Draft post" --post_author=1 --porcelain`
+		And save STDOUT as {DRAFT_ID}
+		And I run `wp post term remove {DRAFT_ID} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts --post-statuses=draft`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 1 total posts.
+		No co-authors found for post #{DRAFT_ID}.
+		1/1) Added - Post #{DRAFT_ID} 'Draft post' now has this author term: cap-admin
+		Success: Done! Of 1 posts, 1 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={DRAFT_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
 		"""

--- a/php/cli/class-create-terms-for-posts-command.php
+++ b/php/cli/class-create-terms-for-posts-command.php
@@ -44,10 +44,18 @@ class Create_Terms_For_Posts_Command {
 	 * create-author-terms-for-posts for a version that targets only the posts that
 	 * need it, which is faster on all but the smallest sites.
 	 *
+	 * ## OPTIONS
+	 *
+	 * [--post-statuses=<post-statuses>]
+	 * : Comma-separated post statuses to cover. Defaults to publish.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Backfill author terms across the site.
 	 *     $ wp co-authors-plus create-terms-for-posts
+	 *
+	 *     # Cover drafts and pending posts as well.
+	 *     $ wp co-authors-plus create-terms-for-posts --post-statuses=publish,draft,pending
 	 *
 	 * @when after_wp_load
 	 *
@@ -61,10 +69,16 @@ class Create_Terms_For_Posts_Command {
 		// Cache this to prevent repeated lookups.
 		$author_terms = array();
 
+		// Named explicitly rather than left to WP_Query's default, which is publish
+		// plus whatever private statuses the current user can read — so the scope of a
+		// backfill would otherwise depend on whether --user was passed.
+		$post_statuses = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : array( 'publish' );
+
 		$args = array(
 			'order'             => 'ASC',
 			'orderby'           => 'ID',
 			'post_type'         => $coauthors_plus->supported_post_types(),
+			'post_status'       => $post_statuses,
 			'posts_per_page'    => 100,
 			'paged'             => 1,
 			'update_meta_cache' => false,


### PR DESCRIPTION
## Summary

The docblock for `create-terms-for-posts` says it walks every supported post type from the start of the table, but the query named no `post_status`, so it only ever saw what `WP_Query` falls back to. Drafts were never backfilled, and nothing in the output said so — the command reported `Now inspecting or updating 0 total posts.` and exited successfully on a site full of draft posts with no author terms.

The sibling `create-author-terms-for-posts` already solves this with a `--post-statuses` flag, so this adds the same flag with the same spelling and the same default rather than inventing a second convention for the same idea.

**The default deliberately stays `publish`.** This command *writes*, and widening it would silently multiply the scope of a backfill and attach author terms to drafts nobody asked about — the behaviour catalogue flagged that specific risk when the omission was first recorded. That is the opposite of the call made recently on `list-posts-without-terms`, where the default *was* widened, and the difference is the point: that command only reports, so a narrow default limited no risk and merely withheld evidence. Here there is real write volume behind the choice, so the widening is opt-in.

Naming the status explicitly also removes an oddity worth knowing about. `WP_Query`'s default is not simply `publish` — it is publish plus whatever private statuses the current user can read. Under `wp --user=1` the command would therefore also pick up private posts, so the scope of a backfill depended on whether `--user` was passed. Anyone relying on that has a better, explicit replacement in `--post-statuses=publish,private`.

The scenario that pinned the old narrow scope is kept and renamed to say "by default", since that behaviour is unchanged and still worth guarding, with a companion scenario covering `--post-statuses=draft`.

## Test plan

- [x] `features/create-terms-for-posts.feature` green at 11 scenarios / 124 steps, up from 10
- [x] The default-scope scenario still passes unchanged, confirming no silent widening
- [x] PHPCS clean on the changed file by exit code
- [ ] Full Behat suite via CI