### PR TITLE
Count and iterate only the terms migrate-author-terms migrates

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -319,24 +319,40 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 8 scenarios.)
 
-- The merge branch (bare term with a prefixed sibling) has no `continue`; after
-  merging it falls through and also logs "Term x (id) isn't prefixed, adding one"
-  before re-slugging the surviving bare term (php/class-wp-cli.php:857-872). The
-  net state is correct but the log narrates two operations for one term.
-  Confirmed, including that the surviving term keeps the BARE term's term_id with
-  the `cap-` slug and that the prefixed sibling's post relationships are
-  reassigned to it (`force_default`).
-- "Now migrating up to N terms" counts ALL author terms, including already
-  prefixed ones that will only be skipped (line 850). Confirmed.
-- Grammar oddities pinned as-is: "Now migrating up to 1 terms" and the success
-  message "All done! Grab a cold one (Affogatto)" (line 874). Confirmed.
-- Terms are processed in `get_terms` default order (name ASC), so `cap-someone`
-  is skipped before the bare `someone` is merged/prefixed. Confirmed.
-- Only the SLUG is prefixed; the term NAME is left untouched. Confirmed
-  2026-09-02: a term created as `Legacy Author` (slug `legacy-author`) ends up as
-  name `Legacy Author` / slug `cap-legacy-author`, and the log line reports the
-  SLUG (`Term legacy-author (N) isn't prefixed, adding one`), so name and slug
-  drift apart. Pinned in "The term name keeps its original value...".
+- **NOT A DEFECT — do not "fix" this.** The merge branch has no `continue`, so
+  after merging it also logs "isn't prefixed, adding one" and re-slugs the term.
+  That fall-through is REQUIRED. `wp_delete_term()` is called on the PREFIXED
+  sibling with the BARE term as its `default`, so the survivor is the bare term and
+  still holds the unprefixed slug; the re-slug is what completes the migration.
+  Adding a `continue` here would merge two terms and leave the survivor unprefixed —
+  a silently failed migration, and non-idempotent, since the next
+  `update_author_term()` would recreate the collision. Two log lines for two real
+  operations is honest narration. The comment claiming the term "doesn't have a
+  sibling" was wrong on this path and has been corrected in the source.
+- ~~"Now migrating up to N terms" counts ALL author terms, including already
+  prefixed ones that will only be skipped.~~ **FIXED.** Prefixed terms are filtered
+  out before the count and the loop, so the number is the work actually to be done.
+  One predicate fixes this and the stale-object entry below together: the only row
+  the loop deletes is a prefixed sibling, which the filtered list no longer holds,
+  so iterating a stale object became structurally impossible rather than merely
+  unobserved. A `get_terms()` `WP_Error` is now caught too — without that,
+  `array_filter()` on a non-array would have turned a PHP warning into a fatal.
+- ~~The success message reads "All done! Grab a cold one (Affogatto)".~~ **FIXED** —
+  the drink is an *affogato*. "Now migrating up to 1 terms" still does not
+  pluralise; that belongs to the pluralisation sweep, which is deliberately left as
+  one dedicated pass rather than scattered through fix PRs, since it touches nearly
+  every command and feature file.
+- Terms are processed in `get_terms` default order (name ASC). Still true, but no
+  longer observable from the log, since prefixed terms are never narrated.
+- **NOT A DEFECT — this entry was wrong.** Only the SLUG is prefixed and the term
+  NAME is left raw, which is not drift but the plugin-wide convention. Every author
+  term the plugin creates is built that way by `update_author_term()`
+  (`wp_insert_term( $coauthor->user_login, ..., array( 'slug' =>
+  Prefix::prefix_slug( ... ) ) )`), and both `rename-coauthor` and `reassign-terms`
+  write a prefixed slug with a raw name. The term name is also read exactly once in
+  the whole plugin, in a `rename-coauthor` log line — every lookup goes by slug.
+  Prefixing the name would diverge from all three creation sites and buy nothing.
+  The scenario stays as a guard on the convention rather than a pin on a bug.
 
 - Re-calibrated 2026-09-02 after adversarial review: 8 scenarios, all green.
 - Taxonomy scoping is now pinned. With a `guardian` category and a `cap-guardian`
@@ -347,17 +363,23 @@ PHP 8.4) rather than inferred from reading the source.
   dropped it would start `wp_delete_term()`-ing same-slug terms from other
   taxonomies. NB category/post_tag terms are NOT cleared by the Behat reset either,
   so the scenario deletes its own two terms first via `wp eval`.
-- Reverse `get_terms()` ordering is now pinned. With names "Aaa" (slug `someone`) and
-  "Zzz" (slug `cap-someone`) the BARE term is processed first, its prefixed sibling
-  is deleted mid-loop, and the loop then still logs `Term cap-someone (<id>) is
-  already prefixed, skipping` for a term that no longer exists — the `foreach`
-  iterates over term objects fetched before the loop, so it narrates a skip for a
-  deleted row. Confirmed exactly. The survivor keeps the bare term's term_id and its
-  original name ("Aaa") with slug `cap-someone`.
+- ~~Reverse `get_terms()` ordering: with names "Aaa" (slug `someone`) and "Zzz"
+  (slug `cap-someone`) the BARE term is processed first, its prefixed sibling is
+  deleted mid-loop, and the loop then still logs `already prefixed, skipping` for a
+  term that no longer exists, because the `foreach` iterates term objects fetched
+  before the loop.~~ **FIXED** by the same filter as the count above. The scenario is
+  retained, retitled around what it still proves — that the merge works whatever the
+  ordering — since its original subject no longer exists.
 - Return code 0 is now asserted on the primary happy paths: `I run` does not check
   exit codes despite its docblock, and when the exit code is non-zero the harness
   moves `Error:` lines off STDOUT, so a command that died after printing the expected
   lines would previously have satisfied every `STDOUT should be:` block here.
+- Watch the discriminators here. Because skipped terms are no longer narrated, the
+  "already prefixed" and "run twice" scenarios now print exactly what a run against
+  an empty database prints, so their state assertions are the only thing left
+  distinguishing them — the run-twice scenario had none and has been given one. A
+  new scenario with two prefixed terms and one bare one exercises the count
+  properly; the file previously never held more than two terms.
 
 ## remove-terms-from-revisions
 

--- a/features/migrate-author-terms.feature
+++ b/features/migrate-author-terms.feature
@@ -10,7 +10,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And STDOUT should be:
 		"""
 		Now migrating up to 0 terms
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 
 	Scenario: Prefix an unprefixed author term
@@ -22,7 +22,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		"""
 		Now migrating up to 1 terms
 		Term someone ({TERM_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --field=slug`
 		Then STDOUT should be:
@@ -38,7 +38,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		"""
 		Now migrating up to 1 terms
 		Term legacy-author ({TERM_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --fields=name,slug --format=csv`
 		Then STDOUT should be:
@@ -53,10 +53,11 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And I run `wp co-authors-plus migrate-author-terms`
 		Then STDOUT should be:
 		"""
-		Now migrating up to 1 terms
-		Term cap-someone ({TERM_ID}) is already prefixed, skipping
-		Success: All done! Grab a cold one (Affogatto)
+		Now migrating up to 0 terms
+		Success: All done! Grab a cold one (Affogato)
 		"""
+		# With the log silent, this state assertion is the sole discriminator: an
+		# inverted filter would produce cap-cap-someone here.
 		When I run `wp term list author --field=slug`
 		Then STDOUT should be:
 		"""
@@ -74,11 +75,10 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And I run `wp co-authors-plus migrate-author-terms`
 		Then STDOUT should be:
 		"""
-		Now migrating up to 2 terms
-		Term cap-someone ({PREFIXED_ID}) is already prefixed, skipping
+		Now migrating up to 1 terms
 		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
 		Term someone ({BARE_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --fields=term_id,slug --format=csv`
 		Then STDOUT should be:
@@ -92,16 +92,23 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		{BARE_ID}
 		"""
 
-	Scenario: Running the migration twice only skips already-prefixed terms
+	Scenario: Running the migration twice finds nothing left to do
 		When I run `wp term create author someone --porcelain`
 		And save STDOUT as {TERM_ID}
 		And I run `wp co-authors-plus migrate-author-terms`
 		And I run the previous command again
 		Then STDOUT should be:
 		"""
-		Now migrating up to 1 terms
-		Term cap-someone ({TERM_ID}) is already prefixed, skipping
-		Success: All done! Grab a cold one (Affogatto)
+		Now migrating up to 0 terms
+		Success: All done! Grab a cold one (Affogato)
+		"""
+		# The second run's output is now identical to a run with no terms at all, so
+		# only this proves the first run did the migrating.
+		When I run `wp term list author --fields=term_id,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		term_id,slug
+		{TERM_ID},cap-someone
 		"""
 
 	Scenario: Same-slug terms in other taxonomies are left alone
@@ -116,7 +123,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		"""
 		Now migrating up to 1 terms
 		Term guardian ({TERM_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list post_tag --slug=cap-guardian --field=slug`
 		Then STDOUT should be:
@@ -135,7 +142,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		{TERM_ID},cap-guardian
 		"""
 
-	Scenario: A sibling deleted earlier in the run is still logged as already prefixed
+	Scenario: A prefixed sibling is merged and deleted whatever the term ordering
 		When I run `wp term create author "Aaa" --slug=someone --porcelain`
 		And save STDOUT as {BARE_ID}
 		And I run `wp term create author "Zzz" --slug=cap-someone --porcelain`
@@ -144,15 +151,35 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Now migrating up to 2 terms
+		Now migrating up to 1 terms
 		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
 		Term someone ({BARE_ID}) isn't prefixed, adding one
-		Term cap-someone ({PREFIXED_ID}) is already prefixed, skipping
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --fields=term_id,name,slug --format=csv`
 		Then STDOUT should be:
 		"""
 		term_id,name,slug
 		{BARE_ID},Aaa,cap-someone
+		"""
+
+	Scenario: The count reports only the terms that will be migrated
+		When I run `wp term create author alice --slug=cap-alice`
+		And I run `wp term create author bob --slug=cap-bob`
+		And I run `wp term create author someone --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term someone ({TERM_ID}) isn't prefixed, adding one
+		Success: All done! Grab a cold one (Affogato)
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-alice
+		cap-bob
+		cap-someone
 		"""

--- a/php/cli/class-migrate-author-terms-command.php
+++ b/php/cli/class-migrate-author-terms-command.php
@@ -62,34 +62,45 @@ class Migrate_Author_Terms_Command {
 			array(
 				'taxonomy'   => $coauthors_plus->coauthor_taxonomy,
 				'hide_empty' => false,
-			) 
+			)
 		);
+
+		if ( is_wp_error( $author_terms ) ) {
+			WP_CLI::error( $author_terms->get_error_message() );
+		}
+
+		// Prefixed terms need nothing doing, and counting them made the total wrong.
+		// Dropping them here also keeps the loop off stale term objects, since the only
+		// row it deletes is a prefixed sibling the loop no longer holds.
+		$author_terms = array_filter(
+			$author_terms,
+			static fn ( $author_term ): bool => ! Prefix::slug_has_prefix( $author_term->slug )
+		);
+
 		WP_CLI::log( 'Now migrating up to ' . count( $author_terms ) . ' terms' );
+
 		foreach ( $author_terms as $author_term ) {
-			// Term is already prefixed. We're good.
-			if ( Prefix::slug_has_prefix( $author_term->slug ) ) {
-				WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) is already prefixed, skipping" );
-				continue;
-			}
 			// A prefixed term was accidentally created, and the old term needs to be merged into the new (WordPress.com VIP).
 			$prefixed_term = get_term_by( 'slug', Prefix::prefix_slug( $author_term->slug ), $coauthors_plus->coauthor_taxonomy );
 
 			if ( $prefixed_term ) {
 				WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) has a new term too: $prefixed_term->slug ($prefixed_term->term_id). Merging" );
-				$args = array(
+				$delete_args = array(
 					'default'       => $author_term->term_id,
 					'force_default' => true,
 				);
-				wp_delete_term( $prefixed_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
+				wp_delete_term( $prefixed_term->term_id, $coauthors_plus->coauthor_taxonomy, $delete_args );
 			}
 
-			// Term isn't prefixed, doesn't have a sibling, and should be updated.
+			// Whether or not a sibling was just merged in, this term still holds the
+			// unprefixed slug: the merge reassigns the sibling's posts to THIS term and
+			// deletes the sibling, so re-slugging here is what completes the migration.
 			WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) isn't prefixed, adding one" );
-			$args = array(
+			$update_args = array(
 				'slug' => Prefix::prefix_slug( $author_term->slug ),
 			);
-			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
+			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $update_args );
 		}//end foreach
-		WP_CLI::success( 'All done! Grab a cold one (Affogatto)' );
+		WP_CLI::success( 'All done! Grab a cold one (Affogato)' );
 	}
 }


### PR DESCRIPTION
## Summary

`migrate-author-terms` fetched every author term and then skipped the already-prefixed ones inside the loop. Two consequences: `Now migrating up to N terms` counted work the command was never going to do, and on a site with a few thousand authors every subsequent run printed a skip line for each of them — the migration is a one-off, so almost every run after the first was pure noise.

More subtly, iterating the full set meant the loop held term objects fetched before any deletion. The merge branch deletes a prefixed sibling mid-loop, so a later iteration could narrate `already prefixed, skipping` for a row that no longer existed. Filtering prefixed terms out before the loop fixes both at once, and fixes the second one *structurally* rather than incidentally: the only row this command ever deletes is a prefixed sibling, which the filtered list no longer holds, so iterating a stale object stops being possible rather than merely stopping being observed.

The `get_terms()` result is now checked for `WP_Error` first. That is not a bonus extra — it is what makes the filter safe. `get_terms()` returns `WP_Error` for an unregistered taxonomy, and `array_filter()` on a non-array is a `TypeError` on PHP 8, so without the guard this change would have upgraded today's PHP warning into a fatal.

## Two things I deliberately did not change, because the behaviour notes were wrong

Both were on my list as defects. Investigating them showed the catalogue was mistaken, and I would rather record that than quietly drop them.

**The merge branch's missing `continue` is required, not a bug.** It looks like a fall-through that narrates two operations for one term. But `wp_delete_term()` is called on the *prefixed* sibling with the *bare* term as its `default`, so the survivor is the bare term and still holds the unprefixed slug — the re-slug afterwards is what actually completes the migration. Adding a `continue` would merge two terms and leave the survivor unprefixed: a silently failed migration, and a non-idempotent one, since the next `update_author_term()` would recreate the collision. The source comment claiming the term "doesn't have a sibling" on that path was wrong and is corrected.

**Prefixing only the slug and leaving the name raw is the convention, not drift.** Every author term the plugin creates is built that way by `update_author_term()`, and both `rename-coauthor` and `reassign-terms` write a prefixed slug with a raw name. The term name is read exactly once in the entire plugin — a `rename-coauthor` log line — while every lookup goes by slug. Prefixing the name would diverge from all three creation sites and buy nothing.

## Worth a reviewer's attention

Because skipped terms are no longer narrated, two scenarios now print *exactly* what a run against an empty database prints. Their state assertions are the only thing left distinguishing them — and the "run the migration twice" scenario had **no state assertion at all**, so after this change it would have passed while proving nothing. It now asserts the term really was prefixed by the first run. There is also a new scenario with two prefixed terms and one bare one, because the file never previously held more than two terms and so exercised the count only weakly.

## Test plan

- [x] `features/migrate-author-terms.feature` green at 9 scenarios / 92 steps, up from 8
- [x] All eight pre-existing scenarios failed against the patched code before re-pinning, confirming each was pinning real output
- [x] PHPCS clean on the changed file by exit code
- [ ] Full Behat suite via CI