### PR TITLE
Carry on deleting skip postmeta past a post without it

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -675,22 +675,35 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
 
 (Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
 
-- Success/failure per post is reported with bare emoji (`Success: 👍` /
-  `Error: 👎`). Confirmed live: both survive the wp-env output filter and pin
-  as exact-match assertions (the `Error: 👎` line splits to STDERR with exit 1).
-- `WP_CLI::error( '👎' )` (php/class-wp-cli.php:335) aborts the whole loop on the
-  FIRST post whose meta cannot be deleted (e.g. an ID without the meta), leaving
-  any later IDs in `--specific-post-ids` unprocessed, with exit code 1 — even if
-  earlier deletions succeeded. Confirmed and pinned 2026-09-02 in the
-  "stops at the first post that does not have it" scenario: given
-  `--specific-post-ids=<no-meta-post>,<has-meta-post>`, STDOUT holds only the
-  `Deleting postmeta key ... for Post ID <no-meta-post>` line, STDERR is
-  `Error: 👎`, rc 1, and the second post STILL has its
-  `_cap_skip_backfill` meta. A partial run is therefore indistinguishable from a
-  total failure, and re-running is the only recovery.
-- With no `--specific-post-ids` the lookup WP_Query uses defaults
-  (`post_type=post`, `post_status=publish`), so skip metas on drafts, pages or
-  other post types are never found in the no-args mode. Noted; not pinned.
+- ~~Success/failure per post is reported with bare emoji (`Success: 👍` /
+  `Error: 👎`), carrying no post ID and so no diagnostic value.~~ **FIXED.** Each
+  line now names the meta key and the post, which also matters for the harness:
+  `FeatureContext` splits STDERR back out with `array_diff`, which compares values,
+  so identical emoji lines would all have been removed together. Distinct lines are
+  a prerequisite for the split behaving per-line. The pre-emptive
+  `Deleting postmeta key ... for Post ID N` line is dropped with them — it was pure
+  duplication once the outcome line carried the ID, and it halved the output of a
+  bare run over thousands of posts.
+- ~~`WP_CLI::error( '👎' )` aborts the whole loop on the FIRST post whose meta
+  cannot be deleted (e.g. an ID without the meta), leaving any later IDs in
+  `--specific-post-ids` unprocessed, with exit code 1 — even if earlier deletions
+  succeeded. A partial run is indistinguishable from a total failure, and
+  re-running is the only recovery.~~ **FIXED.** A post that never carried the marker
+  is now a warning, and the loop carries on. The run exits 0, which is the
+  deliberate part: the command's contract is that the named posts end up without the
+  marker, and that holds. `delete_post_meta()` returning false cannot distinguish
+  "never had it" — the common `--specific-post-ids` typo — from a database error, so
+  failing the whole run on it was over-reading a weak signal. The scenario that
+  pinned the abort is inverted: it now asserts the *second* post's meta really is
+  gone, which is what fails against the old code.
+- ~~With no `--specific-post-ids` the lookup WP_Query uses defaults, so skip metas
+  on drafts, pages or other post types are never found.~~ **STALE, not fixed as
+  written** — there is no `WP_Query` in this command any more; the bare lookup is a
+  direct prepared read of the postmeta table, superseded by the struck entry below.
+  (The struck entry's own wording is also inaccurate: it says the query "now passes
+  `post_type=any`, `post_status=any` and `posts_per_page=-1`", which describes an
+  approach that was tried and replaced. Another reminder that "Noted; not pinned"
+  entries are the ones to distrust.)
 - When there is nothing to delete the command prints nothing at all (no summary,
   exit 0). Pinned.
 

--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -319,24 +319,40 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 8 scenarios.)
 
-- The merge branch (bare term with a prefixed sibling) has no `continue`; after
-  merging it falls through and also logs "Term x (id) isn't prefixed, adding one"
-  before re-slugging the surviving bare term (php/class-wp-cli.php:857-872). The
-  net state is correct but the log narrates two operations for one term.
-  Confirmed, including that the surviving term keeps the BARE term's term_id with
-  the `cap-` slug and that the prefixed sibling's post relationships are
-  reassigned to it (`force_default`).
-- "Now migrating up to N terms" counts ALL author terms, including already
-  prefixed ones that will only be skipped (line 850). Confirmed.
-- Grammar oddities pinned as-is: "Now migrating up to 1 terms" and the success
-  message "All done! Grab a cold one (Affogatto)" (line 874). Confirmed.
-- Terms are processed in `get_terms` default order (name ASC), so `cap-someone`
-  is skipped before the bare `someone` is merged/prefixed. Confirmed.
-- Only the SLUG is prefixed; the term NAME is left untouched. Confirmed
-  2026-09-02: a term created as `Legacy Author` (slug `legacy-author`) ends up as
-  name `Legacy Author` / slug `cap-legacy-author`, and the log line reports the
-  SLUG (`Term legacy-author (N) isn't prefixed, adding one`), so name and slug
-  drift apart. Pinned in "The term name keeps its original value...".
+- **NOT A DEFECT — do not "fix" this.** The merge branch has no `continue`, so
+  after merging it also logs "isn't prefixed, adding one" and re-slugs the term.
+  That fall-through is REQUIRED. `wp_delete_term()` is called on the PREFIXED
+  sibling with the BARE term as its `default`, so the survivor is the bare term and
+  still holds the unprefixed slug; the re-slug is what completes the migration.
+  Adding a `continue` here would merge two terms and leave the survivor unprefixed —
+  a silently failed migration, and non-idempotent, since the next
+  `update_author_term()` would recreate the collision. Two log lines for two real
+  operations is honest narration. The comment claiming the term "doesn't have a
+  sibling" was wrong on this path and has been corrected in the source.
+- ~~"Now migrating up to N terms" counts ALL author terms, including already
+  prefixed ones that will only be skipped.~~ **FIXED.** Prefixed terms are filtered
+  out before the count and the loop, so the number is the work actually to be done.
+  One predicate fixes this and the stale-object entry below together: the only row
+  the loop deletes is a prefixed sibling, which the filtered list no longer holds,
+  so iterating a stale object became structurally impossible rather than merely
+  unobserved. A `get_terms()` `WP_Error` is now caught too — without that,
+  `array_filter()` on a non-array would have turned a PHP warning into a fatal.
+- ~~The success message reads "All done! Grab a cold one (Affogatto)".~~ **FIXED** —
+  the drink is an *affogato*. "Now migrating up to 1 terms" still does not
+  pluralise; that belongs to the pluralisation sweep, which is deliberately left as
+  one dedicated pass rather than scattered through fix PRs, since it touches nearly
+  every command and feature file.
+- Terms are processed in `get_terms` default order (name ASC). Still true, but no
+  longer observable from the log, since prefixed terms are never narrated.
+- **NOT A DEFECT — this entry was wrong.** Only the SLUG is prefixed and the term
+  NAME is left raw, which is not drift but the plugin-wide convention. Every author
+  term the plugin creates is built that way by `update_author_term()`
+  (`wp_insert_term( $coauthor->user_login, ..., array( 'slug' =>
+  Prefix::prefix_slug( ... ) ) )`), and both `rename-coauthor` and `reassign-terms`
+  write a prefixed slug with a raw name. The term name is also read exactly once in
+  the whole plugin, in a `rename-coauthor` log line — every lookup goes by slug.
+  Prefixing the name would diverge from all three creation sites and buy nothing.
+  The scenario stays as a guard on the convention rather than a pin on a bug.
 
 - Re-calibrated 2026-09-02 after adversarial review: 8 scenarios, all green.
 - Taxonomy scoping is now pinned. With a `guardian` category and a `cap-guardian`
@@ -347,17 +363,23 @@ PHP 8.4) rather than inferred from reading the source.
   dropped it would start `wp_delete_term()`-ing same-slug terms from other
   taxonomies. NB category/post_tag terms are NOT cleared by the Behat reset either,
   so the scenario deletes its own two terms first via `wp eval`.
-- Reverse `get_terms()` ordering is now pinned. With names "Aaa" (slug `someone`) and
-  "Zzz" (slug `cap-someone`) the BARE term is processed first, its prefixed sibling
-  is deleted mid-loop, and the loop then still logs `Term cap-someone (<id>) is
-  already prefixed, skipping` for a term that no longer exists — the `foreach`
-  iterates over term objects fetched before the loop, so it narrates a skip for a
-  deleted row. Confirmed exactly. The survivor keeps the bare term's term_id and its
-  original name ("Aaa") with slug `cap-someone`.
+- ~~Reverse `get_terms()` ordering: with names "Aaa" (slug `someone`) and "Zzz"
+  (slug `cap-someone`) the BARE term is processed first, its prefixed sibling is
+  deleted mid-loop, and the loop then still logs `already prefixed, skipping` for a
+  term that no longer exists, because the `foreach` iterates term objects fetched
+  before the loop.~~ **FIXED** by the same filter as the count above. The scenario is
+  retained, retitled around what it still proves — that the merge works whatever the
+  ordering — since its original subject no longer exists.
 - Return code 0 is now asserted on the primary happy paths: `I run` does not check
   exit codes despite its docblock, and when the exit code is non-zero the harness
   moves `Error:` lines off STDOUT, so a command that died after printing the expected
   lines would previously have satisfied every `STDOUT should be:` block here.
+- Watch the discriminators here. Because skipped terms are no longer narrated, the
+  "already prefixed" and "run twice" scenarios now print exactly what a run against
+  an empty database prints, so their state assertions are the only thing left
+  distinguishing them — the run-twice scenario had none and has been given one. A
+  new scenario with two prefixed terms and one bare one exercises the count
+  properly; the file previously never held more than two terms.
 
 ## remove-terms-from-revisions
 

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -408,8 +408,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
 		Then STDOUT should be:
 		"""
-		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
-		Success: 👍
+		Success: Deleted `_cap_skip_backfill` postmeta from post {POST_ID}.
 		"""
 		When I run `wp post meta list {POST_ID} --keys=_cap_skip_backfill --format=count`
 		Then STDOUT should be:
@@ -427,40 +426,36 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Success: Done!
 		"""
 
-	Scenario: Error when deleting skip postmeta from a post that does not have it
+	Scenario: Deleting skip postmeta from a post that does not have it warns and carries on
 		When I run `wp post create --post_title="Regular post" --post_status=publish --post_author=1 --porcelain`
 		And save STDOUT as {POST_ID}
-		When I try `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids={POST_ID}`
+		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids={POST_ID}`
 		Then STDOUT should be:
 		"""
-		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		Warning: No `_cap_skip_backfill` postmeta to delete on post {POST_ID}.
 		"""
-		And STDERR should be:
-		"""
-		Error: 👎
-		"""
-		And the return code should be 1
+		And the return code should be 0
+		And STDERR should be empty
 
-	Scenario: Deleting skip postmeta stops at the first post that does not have it
+	Scenario: Deleting skip postmeta continues past a post that does not have it
 		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
 		And save STDOUT as {ORPHAN_ID}
 		And I run `wp co-authors-plus create-author-terms-for-posts`
 		And I run `wp post create --post_title="Regular post" --post_status=publish --post_author=1 --porcelain`
 		And save STDOUT as {POST_ID}
-		When I try `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids={POST_ID},{ORPHAN_ID}`
+		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids={POST_ID},{ORPHAN_ID}`
 		Then STDOUT should be:
 		"""
-		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		Warning: No `_cap_skip_backfill` postmeta to delete on post {POST_ID}.
+		Success: Deleted `_cap_skip_backfill` postmeta from post {ORPHAN_ID}.
 		"""
-		And STDERR should be:
-		"""
-		Error: 👎
-		"""
-		And the return code should be 1
-		When I run `wp post meta get {ORPHAN_ID} _cap_skip_backfill`
+		And the return code should be 0
+		# The orphan is named second on purpose: the run used to abort on the first
+		# post and never reach it, so this assertion is what fails without the fix.
+		When I run `wp post meta list {ORPHAN_ID} --keys=_cap_skip_backfill --format=count`
 		Then STDOUT should be:
 		"""
-		nonexistent_post_author_id
+		0
 		"""
 
 	Scenario: Deleting skip postmeta with nothing to delete produces no output
@@ -480,7 +475,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
 		Then STDOUT should contain:
 		"""
-		Deleting postmeta key `_cap_skip_backfill` for Post ID {POST_ID}
+		Success: Deleted `_cap_skip_backfill` postmeta from post {POST_ID}.
 		"""
 		And the return code should be 0
 		When I run `wp post meta list {POST_ID} --keys=_cap_skip_backfill --format=count`
@@ -498,7 +493,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill`
 		Then the return code should be 0
-		And STDOUT should match #(Deleting postmeta key[\s\S]*?){11}#
+		And STDOUT should match #(Success: Deleted[\s\S]*?){11}#
 		When I run `wp post list --meta_key=_cap_skip_backfill --post_status=any --format=count`
 		Then STDOUT should be:
 		"""

--- a/features/migrate-author-terms.feature
+++ b/features/migrate-author-terms.feature
@@ -10,7 +10,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And STDOUT should be:
 		"""
 		Now migrating up to 0 terms
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 
 	Scenario: Prefix an unprefixed author term
@@ -22,7 +22,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		"""
 		Now migrating up to 1 terms
 		Term someone ({TERM_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --field=slug`
 		Then STDOUT should be:
@@ -38,7 +38,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		"""
 		Now migrating up to 1 terms
 		Term legacy-author ({TERM_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --fields=name,slug --format=csv`
 		Then STDOUT should be:
@@ -53,10 +53,11 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And I run `wp co-authors-plus migrate-author-terms`
 		Then STDOUT should be:
 		"""
-		Now migrating up to 1 terms
-		Term cap-someone ({TERM_ID}) is already prefixed, skipping
-		Success: All done! Grab a cold one (Affogatto)
+		Now migrating up to 0 terms
+		Success: All done! Grab a cold one (Affogato)
 		"""
+		# With the log silent, this state assertion is the sole discriminator: an
+		# inverted filter would produce cap-cap-someone here.
 		When I run `wp term list author --field=slug`
 		Then STDOUT should be:
 		"""
@@ -74,11 +75,10 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And I run `wp co-authors-plus migrate-author-terms`
 		Then STDOUT should be:
 		"""
-		Now migrating up to 2 terms
-		Term cap-someone ({PREFIXED_ID}) is already prefixed, skipping
+		Now migrating up to 1 terms
 		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
 		Term someone ({BARE_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --fields=term_id,slug --format=csv`
 		Then STDOUT should be:
@@ -92,16 +92,23 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		{BARE_ID}
 		"""
 
-	Scenario: Running the migration twice only skips already-prefixed terms
+	Scenario: Running the migration twice finds nothing left to do
 		When I run `wp term create author someone --porcelain`
 		And save STDOUT as {TERM_ID}
 		And I run `wp co-authors-plus migrate-author-terms`
 		And I run the previous command again
 		Then STDOUT should be:
 		"""
-		Now migrating up to 1 terms
-		Term cap-someone ({TERM_ID}) is already prefixed, skipping
-		Success: All done! Grab a cold one (Affogatto)
+		Now migrating up to 0 terms
+		Success: All done! Grab a cold one (Affogato)
+		"""
+		# The second run's output is now identical to a run with no terms at all, so
+		# only this proves the first run did the migrating.
+		When I run `wp term list author --fields=term_id,slug --format=csv`
+		Then STDOUT should be:
+		"""
+		term_id,slug
+		{TERM_ID},cap-someone
 		"""
 
 	Scenario: Same-slug terms in other taxonomies are left alone
@@ -116,7 +123,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		"""
 		Now migrating up to 1 terms
 		Term guardian ({TERM_ID}) isn't prefixed, adding one
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list post_tag --slug=cap-guardian --field=slug`
 		Then STDOUT should be:
@@ -135,7 +142,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		{TERM_ID},cap-guardian
 		"""
 
-	Scenario: A sibling deleted earlier in the run is still logged as already prefixed
+	Scenario: A prefixed sibling is merged and deleted whatever the term ordering
 		When I run `wp term create author "Aaa" --slug=someone --porcelain`
 		And save STDOUT as {BARE_ID}
 		And I run `wp term create author "Zzz" --slug=cap-someone --porcelain`
@@ -144,15 +151,35 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Now migrating up to 2 terms
+		Now migrating up to 1 terms
 		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
 		Term someone ({BARE_ID}) isn't prefixed, adding one
-		Term cap-someone ({PREFIXED_ID}) is already prefixed, skipping
-		Success: All done! Grab a cold one (Affogatto)
+		Success: All done! Grab a cold one (Affogato)
 		"""
 		When I run `wp term list author --fields=term_id,name,slug --format=csv`
 		Then STDOUT should be:
 		"""
 		term_id,name,slug
 		{BARE_ID},Aaa,cap-someone
+		"""
+
+	Scenario: The count reports only the terms that will be migrated
+		When I run `wp term create author alice --slug=cap-alice`
+		And I run `wp term create author bob --slug=cap-bob`
+		And I run `wp term create author someone --porcelain`
+		And save STDOUT as {TERM_ID}
+		And I run `wp co-authors-plus migrate-author-terms`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Now migrating up to 1 terms
+		Term someone ({TERM_ID}) isn't prefixed, adding one
+		Success: All done! Grab a cold one (Affogato)
+		"""
+		When I run `wp term list author --field=slug --orderby=slug --order=asc`
+		Then STDOUT should be:
+		"""
+		cap-alice
+		cap-bob
+		cap-someone
 		"""

--- a/php/cli/class-delete-skip-backfill-postmeta-command.php
+++ b/php/cli/class-delete-skip-backfill-postmeta-command.php
@@ -14,7 +14,7 @@ use WP_CLI;
 /**
  * Removes the postmeta that marks a post as skipped during backfill.
  *
- * Moved here from CoAuthorsPlus_Command unchanged. Behaviour is pinned by
+ * Behaviour is pinned by
  * scenarios in features/create-author-terms-for-posts.feature.
  */
 class Delete_Skip_Backfill_Postmeta_Command {
@@ -48,6 +48,7 @@ class Delete_Skip_Backfill_Postmeta_Command {
 	public function __invoke( array $args, array $assoc_args ): void {
 		global $wpdb;
 
+		$meta_key          = Create_Author_Terms_For_Posts_Command::SKIP_POST_FOR_BACKFILL_META_KEY;
 		$specific_post_ids = isset( $assoc_args['specific-post-ids'] ) ? explode( ',', $assoc_args['specific-post-ids'] ) : array();
 
 		if ( empty( $specific_post_ids ) ) {
@@ -59,19 +60,21 @@ class Delete_Skip_Backfill_Postmeta_Command {
 			$specific_post_ids = $wpdb->get_col(
 				$wpdb->prepare(
 					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s",
-					Create_Author_Terms_For_Posts_Command::SKIP_POST_FOR_BACKFILL_META_KEY
+					$meta_key
 				)
 			);
 		}
 
 		foreach ( $specific_post_ids as $post_id ) {
-			WP_CLI::log( sprintf( 'Deleting postmeta key `%s` for Post ID %d', Create_Author_Terms_For_Posts_Command::SKIP_POST_FOR_BACKFILL_META_KEY, $post_id ) );
-			$result = delete_post_meta( $post_id, Create_Author_Terms_For_Posts_Command::SKIP_POST_FOR_BACKFILL_META_KEY );
+			$post_id = (int) $post_id;
 
-			if ( $result ) {
-				WP_CLI::success( '👍' );
+			// A post that never carried the marker is not a failure, and aborting on one
+			// left every later --specific-post-ids entry unprocessed after earlier
+			// deletions had already succeeded.
+			if ( delete_post_meta( $post_id, $meta_key ) ) {
+				WP_CLI::success( sprintf( 'Deleted `%s` postmeta from post %d.', $meta_key, $post_id ) );
 			} else {
-				WP_CLI::error( '👎' );
+				WP_CLI::warning( sprintf( 'No `%s` postmeta to delete on post %d.', $meta_key, $post_id ) );
 			}
 		}
 	}

--- a/php/cli/class-migrate-author-terms-command.php
+++ b/php/cli/class-migrate-author-terms-command.php
@@ -62,34 +62,45 @@ class Migrate_Author_Terms_Command {
 			array(
 				'taxonomy'   => $coauthors_plus->coauthor_taxonomy,
 				'hide_empty' => false,
-			) 
+			)
 		);
+
+		if ( is_wp_error( $author_terms ) ) {
+			WP_CLI::error( $author_terms->get_error_message() );
+		}
+
+		// Prefixed terms need nothing doing, and counting them made the total wrong.
+		// Dropping them here also keeps the loop off stale term objects, since the only
+		// row it deletes is a prefixed sibling the loop no longer holds.
+		$author_terms = array_filter(
+			$author_terms,
+			static fn ( $author_term ): bool => ! Prefix::slug_has_prefix( $author_term->slug )
+		);
+
 		WP_CLI::log( 'Now migrating up to ' . count( $author_terms ) . ' terms' );
+
 		foreach ( $author_terms as $author_term ) {
-			// Term is already prefixed. We're good.
-			if ( Prefix::slug_has_prefix( $author_term->slug ) ) {
-				WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) is already prefixed, skipping" );
-				continue;
-			}
 			// A prefixed term was accidentally created, and the old term needs to be merged into the new (WordPress.com VIP).
 			$prefixed_term = get_term_by( 'slug', Prefix::prefix_slug( $author_term->slug ), $coauthors_plus->coauthor_taxonomy );
 
 			if ( $prefixed_term ) {
 				WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) has a new term too: $prefixed_term->slug ($prefixed_term->term_id). Merging" );
-				$args = array(
+				$delete_args = array(
 					'default'       => $author_term->term_id,
 					'force_default' => true,
 				);
-				wp_delete_term( $prefixed_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
+				wp_delete_term( $prefixed_term->term_id, $coauthors_plus->coauthor_taxonomy, $delete_args );
 			}
 
-			// Term isn't prefixed, doesn't have a sibling, and should be updated.
+			// Whether or not a sibling was just merged in, this term still holds the
+			// unprefixed slug: the merge reassigns the sibling's posts to THIS term and
+			// deletes the sibling, so re-slugging here is what completes the migration.
 			WP_CLI::log( "Term {$author_term->slug} ({$author_term->term_id}) isn't prefixed, adding one" );
-			$args = array(
+			$update_args = array(
 				'slug' => Prefix::prefix_slug( $author_term->slug ),
 			);
-			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $args );
+			wp_update_term( $author_term->term_id, $coauthors_plus->coauthor_taxonomy, $update_args );
 		}//end foreach
-		WP_CLI::success( 'All done! Grab a cold one (Affogatto)' );
+		WP_CLI::success( 'All done! Grab a cold one (Affogato)' );
 	}
 }


### PR DESCRIPTION
## Summary

`delete-postmeta-that-skip-author-term-backfill` called `WP_CLI::error()` the moment `delete_post_meta()` returned false, and that halts. So given a list of IDs in `--specific-post-ids`, a single entry that never carried the marker aborted the entire run with exit 1 and left every later ID untouched — even though the deletions before it had already gone through. A partial run looked exactly like a total failure, and re-running was the only way to find out which.

That matters because of what this command is for. You reach for it after a backfill has marked posts as unprocessable, typically pasting in a list of IDs from the previous run's output. One stale or mistyped ID in that list and the rest silently do not happen.

A post that never had the marker is now a warning and the loop continues. The run exits 0, and that is the deliberate part rather than an oversight: the command's contract is that the named posts end up without the marker, and after the run they do. `delete_post_meta()` returning false cannot distinguish "never had it" — much the commonest case in a hand-written ID list — from an actual database error, so failing the whole run on that signal was reading far more into it than it carries. If you would rather keep a non-zero exit, the shape would be a counter and one `WP_CLI::error()` after the loop; the cost is that naming an already-clean post makes a scripted run fail, which is why I did not.

The per-post outcome was also a bare `Success: 👍` / `Error: 👎` with no post ID, so a bare run over a few thousand posts produced pages of identical lines telling you nothing. Each line now names the meta key and the post. That turns out to matter beyond readability: the Behat harness splits STDERR back out of the combined stream using `array_diff`, which compares values, so identical emoji lines would all have been removed together — distinct lines are a prerequisite for that split behaving per-line at all.

The pre-emptive `Deleting postmeta key ... for Post ID N` line is dropped, since the outcome line now carries the ID and the pair was pure duplication that doubled the output.

## Worth a reviewer's attention

The scenario that pinned this bug asserted the *second* post still had its meta — proof that the run never reached it. I have inverted that assertion rather than relaxing it, so it now asserts the meta really is gone. That inverted assertion is what fails against the old code, and I ordered the IDs so the clean post comes first specifically to keep it meaningful.

I also found and corrected a catalogue entry that described this command's bare lookup as using `WP_Query` defaults. There is no `WP_Query` in the command any more — it reads the postmeta table directly. The superseding entry was itself inaccurate about how that was fixed. Both were "Noted; not pinned" entries, which is turning into a reliable signal: the entries never exercised against a live run are the ones that turn out to be wrong.

## Test plan

- [x] `features/create-author-terms-for-posts.feature` green at 20 scenarios / 236 steps, covering both this command and the backfill command that shares the file
- [x] PHPCS clean on the changed file by exit code
- [ ] Full Behat suite via CI