### PR TITLE
Report posts whose post_author could not follow the byline

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -76,13 +76,17 @@ PHP 8.4) rather than inferred from reading the source.
   NB `wp post meta update <id> <key> ""` does NOT store an empty string — WP-CLI
   replies `Success: Value passed for custom field '<key>' is unchanged.` and writes
   nothing — so the fixture uses `wp eval 'update_post_meta( ..., "" );'`.
-- Assigning an unlinked guest author sets the author term but leaves
-  `wp_posts.post_author` on the previous user: `add_coauthors()` bails at
-  php/class-coauthors-plus.php:1705-1709 and returns false AFTER
-  `wp_set_post_terms()` has run, and `assign_coauthors()` ignores that return value,
-  still logging `has been assigned` and counting the post as successfully associated.
-  Pinned in "Assign an unlinked guest author from the meta value": term becomes
-  `cap-jane-doe`, `post_author` stays the author1 user ID. Note the value handed to
+- ~~Assigning an unlinked guest author sets the author term but leaves
+  `wp_posts.post_author` on the previous user, and the command ignores
+  `add_coauthors()`'s return value, still logging `has been assigned` and counting
+  the post as successfully associated with no mention of the discrepancy.~~
+  **FIXED** in the caller, not in `add_coauthors()`. The per-post line is unchanged
+  because it was true — the byline really was assigned — but the summary now counts
+  the posts whose `post_author` could not follow. That column is what the admin
+  posts list, `WP_Query`'s `author` parameter and many themes read, so an operator
+  who is not told about it will see the old author still attributed. The scenario
+  already asserted the unchanged `post_author` in state; the command now says it
+  aloud. Note the value handed to
   `add_coauthors()` is `$coauthor->user_nicename`, which for a guest author is
   `sanitize_title( user_login )` (`jane-doe`, NOT the `cap-`-prefixed post_name); the
   prefix is re-added inside `get_post_meta_key()` during the nicename lookup, so a
@@ -152,13 +156,12 @@ PHP 8.4) rather than inferred from reading the source.
   `save_post` hook gives it one) is silently skipped and is not even counted in
   `Found N posts to update.`. There is no `--post_status` flag to opt in. Pinned in
   the same scenario; `assign-coauthors` has the identical restriction.
-- Swapping TO an unlinked guest author leaves `wp_posts.post_author` pointing at the
-  previous WP user indefinitely: `wp_set_post_terms()` has already run by the time
-  `add_coauthors()` bails at php/class-coauthors-plus.php:1705-1709 and returns false,
-  and `swap_coauthors()` ignores that return value — so the byline changes, the log
-  still says `has been assigned` and the command still reports `Success: All done!`.
-  Pinned in "Swap to a guest author with no linked account" (term becomes
-  `cap-jane-doe`, `post_author` stays the author1 user ID).
+- ~~Swapping TO an unlinked guest author leaves `wp_posts.post_author` pointing at
+  the previous WP user indefinitely, and the command ignores `add_coauthors()`'s
+  return value — so the byline changes, the log still says `has been assigned` and
+  the command still reports `Success: All done!`.~~ **FIXED** in the caller, exactly
+  as for `assign-coauthors` above, and deliberately with the same wording so the two
+  commands report the condition identically.
 - NOT a bug — an adversarial-review claim tested live on 2026-09-02 and REJECTED:
   logins whose `user_nicename` differs from the raw login, e.g. `john.doe` (nicename
   `john-doe`, term `cap-john-doe`), ARE swapped correctly even though the tax_query
@@ -191,6 +194,24 @@ PHP 8.4) rather than inferred from reading the source.
   while the terms are visibly there. Decide "did the byline change" from the
   byline itself, not from this return value. Pinned by
   `Coauthor_Assignment_Service` and its regression test.
+- **Decision, and the reason the semantics were left alone.** The obvious tidy-up is
+  to make the return mean "the assignment succeeded". It was rejected: this is
+  de-facto public PHP API, called by the classic metabox, both REST write paths,
+  bulk edit and user-deletion reassignment, and `Coauthor_Assignment_Service`'s
+  regression test pins the current meaning. Instead the two CLI callers that
+  misreported it — `assign-coauthors` and `swap-coauthors` — now read it for what it
+  actually says, which is whether `post_author` was synced, and report that
+  separately from whether the byline changed. Any future caller should do the same;
+  the return is a `post_author` signal, not a success signal, and the method is
+  behaving correctly within its own contract.
+- The two summary lines this added are pluralised with `_n()` from the outset,
+  following `assign-user-to-coauthor`, and both branches are covered by scenarios —
+  one post and two. The general pluralisation sweep across the older strings is
+  still deferred to its own pass, but that is a reason to leave existing strings
+  alone, not a licence to add new broken ones. Note the new strings use `%s` rather
+  than the precedent's `%d`: `number_format_i18n()` returns a thousands-separated
+  string, and `%d` truncates `1,234` to `1`. The precedent has that bug; it is
+  logged here rather than fixed in passing, since it belongs to another command.
 
 ## (shared test environment — affects everyone's calibration)
 

--- a/features/assign-coauthors.feature
+++ b/features/assign-coauthors.feature
@@ -273,6 +273,10 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		cap-author-one
 		"""
 
+	# The byline is written, but post_author still names the previous user, because
+	# a guest author with no linked account cannot be put in that column. The
+	# summary has to say so: anything reading post_author directly, such as the
+	# admin author column, still shows the old user.
 	Scenario: Assign an unlinked guest author from the meta value
 		When I run `wp user create author1 author1@example.com --role=author --porcelain`
 		And save STDOUT as {AUTHOR1_ID}
@@ -286,6 +290,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		1: Post #{POST_ID} has been assigned "jane-doe" as the author
 		All done! Here are your results:
 		- 1 posts now have the proper co-author
+		- 1 post kept its original post_author, because no co-author assigned to it has a WordPress account
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -297,3 +302,26 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		{AUTHOR1_ID}
 		"""
+
+	# Two posts, so the plural form of the summary line is exercised as well as the
+	# singular above. Without this the _n() plural branch is never run.
+	Scenario: Several posts keeping their original post_author are counted together
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="First import" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post meta update {POST_A} _original_import_author jane-doe`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Second import" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post meta update {POST_B} _original_import_author jane-doe`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_A} has been assigned "jane-doe" as the author
+		2: Post #{POST_B} has been assigned "jane-doe" as the author
+		All done! Here are your results:
+		- 2 posts now have the proper co-author
+		- 2 posts kept their original post_author, because no co-author assigned to them has a WordPress account
+		"""
+		And the return code should be 0

--- a/features/swap-coauthors.feature
+++ b/features/swap-coauthors.feature
@@ -361,6 +361,8 @@ Feature: One co-author can be swapped with another on their posts
 		{AUTHOR1_ID}
 		"""
 
+	# As above: the term swaps, but post_author cannot follow a guest author who has
+	# no WordPress account, so the run reports how many posts that applied to.
 	Scenario: Swap to a guest author with no linked account
 		When I run `wp user create author1 author1@example.com --role=author --porcelain`
 		And save STDOUT as {AUTHOR1_ID}
@@ -373,6 +375,7 @@ Feature: One co-author can be swapped with another on their posts
 		Swapping authorship from author1 to jane-doe
 		Found 1 posts to update.
 		1: Post #{POST_ID} has been assigned "jane-doe" as a co-author
+		1 post kept its original post_author, because no co-author assigned to it has a WordPress account
 		Success: All done!
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`

--- a/php/cli/class-assign-coauthors-command.php
+++ b/php/cli/class-assign-coauthors-command.php
@@ -92,6 +92,7 @@ class Assign_Coauthors_Command {
 		$posts_already_associated = 0;
 		$posts_missing_coauthor   = 0;
 		$posts_associated         = 0;
+		$posts_keeping_author     = 0;
 		$missing_coauthors        = array();
 
 		$posts = new WP_Query( $parsed_args );
@@ -132,10 +133,16 @@ class Assign_Coauthors_Command {
 					continue;
 				}
 
-				// Assign the co-author to the post.
-				$coauthors_plus->add_coauthors( $single_post->ID, array( $coauthor->user_nicename ), $append_coauthors );
+				// Assign the co-author to the post. The byline is written either way; a
+				// false return means only that post_author could not be pointed at a
+				// WordPress user, which is the norm for a guest author with no account.
+				$post_author_synced = $coauthors_plus->add_coauthors( $single_post->ID, array( $coauthor->user_nicename ), $append_coauthors );
 				WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' has been assigned "' . $original_author . '" as the author' );
 				$posts_associated++;
+
+				if ( ! $post_author_synced ) {
+					$posts_keeping_author++;
+				}
 				clean_post_cache( $single_post->ID );
 			}//end foreach
 
@@ -154,6 +161,20 @@ class Assign_Coauthors_Command {
 		}
 		if ( $posts_associated ) {
 			WP_CLI::log( "- {$posts_associated} posts now have the proper co-author" );
+		}
+		if ( $posts_keeping_author ) {
+			WP_CLI::log(
+				'- ' . sprintf(
+					/* translators: Count of posts. */
+					_n(
+						'%s post kept its original post_author, because no co-author assigned to it has a WordPress account',
+						'%s posts kept their original post_author, because no co-author assigned to them has a WordPress account',
+						$posts_keeping_author,
+						'co-authors-plus'
+					),
+					number_format_i18n( $posts_keeping_author )
+				)
+			);
 		}
 	}
 }

--- a/php/cli/class-swap-coauthors-command.php
+++ b/php/cli/class-swap-coauthors-command.php
@@ -153,7 +153,8 @@ class Swap_Coauthors_Command {
 
 		$posts = new WP_Query( $query_args );
 
-		$posts_total = 0;
+		$posts_total          = 0;
+		$posts_keeping_author = 0;
 
 		WP_CLI::log( "Found $posts->found_posts posts to update." );
 
@@ -203,9 +204,16 @@ class Swap_Coauthors_Command {
 					$coauthors[] = $to_userlogin;
 
 					// By not passing $append = false as the 3rd param, we replace all existing co-authors.
-					$coauthors_plus->add_coauthors( $post->ID, $coauthors );
+					// The byline is written either way; a false return means only that post_author
+					// could not be pointed at a WordPress user, which is the norm when the swap
+					// targets a guest author with no account.
+					$post_author_synced = $coauthors_plus->add_coauthors( $post->ID, $coauthors );
 
 					WP_CLI::log( $posts_total . ': Post #' . $post->ID . ' has been assigned "' . $to_userlogin . '" as a co-author' );
+
+					if ( ! $post_author_synced ) {
+						$posts_keeping_author++;
+					}
 
 					clean_post_cache( $post->ID );
 				} else {
@@ -222,6 +230,21 @@ class Swap_Coauthors_Command {
 
 			$posts = new WP_Query( $query_args );
 		}//end while
+
+		if ( $posts_keeping_author ) {
+			WP_CLI::log(
+				sprintf(
+					/* translators: Count of posts. */
+					_n(
+						'%s post kept its original post_author, because no co-author assigned to it has a WordPress account',
+						'%s posts kept their original post_author, because no co-author assigned to them has a WordPress account',
+						$posts_keeping_author,
+						'co-authors-plus'
+					),
+					number_format_i18n( $posts_keeping_author )
+				)
+			);
+		}
 
 		WP_CLI::success( 'All done!' );
 	}


### PR DESCRIPTION
## Summary

`assign-coauthors` and `swap-coauthors` both discarded `add_coauthors()`'s return value, and so both reported unqualified success on the one case that is completely ordinary for this plugin: assigning a guest author who has no linked WordPress account.

That return value does not mean what it looks like. By the time it is reached, `wp_set_post_terms()` has already written the byline. `false` says only that `post_author` could not be pointed at a WordPress user, because none of the assigned co-authors is one. So the byline was correct and the per-post log line was true — but `wp_posts.post_author` still named the previous author and nothing mentioned it. That column is what the admin posts list, `WP_Query`'s `author` parameter and a good many themes read, so the site carries on attributing the old author while the command reports it is finished.

Both commands now count those posts and report them in the summary. The per-post lines are untouched, because they were not the part that was wrong — narrowing the change to the summary keeps the honest half honest.

## On fixing it in the callers

Having implemented it, I think this is right for a reason beyond blast radius. Changing `add_coauthors()` to return "the assignment succeeded" would be rewriting a method that is de-facto public PHP API — called from the classic metabox, both REST write paths, bulk edit and user-deletion reassignment, with `Coauthor_Assignment_Service`'s regression test pinning the present meaning. But more to the point, the method is behaving correctly inside its own contract. It is a `post_author` signal. Only these two callers were reading it as a success signal, which it never claimed to be.

The behaviour notes now record that as a decision with its reasoning, so the next person to meet a `false` here reads it correctly rather than rediscovering the trap. It is the same one that bit the Phase 1 import service.

## Pluralisation

The new summary line is pluralised with `_n()` from the outset, following the pattern already in `assign-user-to-coauthor`, and both commands share a single translatable string rather than two near-identical msgids — the bullet prefix that `assign-coauthors` needs sits outside it. Both branches are covered: the existing guest-author scenarios exercise the singular, and a new two-post scenario exercises the plural. Swap the `_n()` arguments and one of the two fails, which is the point of covering both.

These commands do still contain older unpluralised strings, and those remain for the dedicated sweep. That sweep is a reason to leave existing strings alone, not a licence to add new broken ones.

One deliberate deviation from the precedent: the new strings use `%s` where `assign-user-to-coauthor` uses `%d`. `number_format_i18n()` returns a thousands-separated string, and `%d` truncates `1,234` to `1` — so the precedent has a latent bug above a thousand posts. I have logged that in the behaviour notes rather than fixing it in passing, since it belongs to a different command.

## Worth a reviewer's attention

Both originally-affected scenarios **already asserted the unchanged `post_author` in state** — they had documented the discrepancy all along, while the command stayed silent about it. So this change does not add a new fact; it makes the command say something the suite already knew. That is also why only two of the pre-existing scenarios moved: the fix touches exactly the guest-author-without-account path and nothing else.

Amended rather than added as a follow-up commit, since this repo merges without squashing and a trailing "pluralise the strings I just added" commit would sit in `develop` permanently.

## Test plan

- [x] `features/assign-coauthors.feature` and `features/swap-coauthors.feature` green together at 25 scenarios / 347 steps, then 11 / 164 for the assign feature with the new plural scenario
- [x] Only the two guest-author scenarios changed, confirming the new summary line appears on exactly the path it describes
- [x] Singular and plural forms both pinned by scenarios
- [x] PHPCS clean on both changed files by exit code
- [ ] Full Behat suite via CI