### PR TITLE
Stop the guest author importers losing data and faking success

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -540,6 +540,44 @@ PHP 8.4) rather than inferred from reading the source.
   and the term assertion is scoped `--object_ids={GUEST_AUTHOR_ID}`; see the correction
   in the shared test-environment section above.
 
+- **Guest author creator, resolved together (one PR).** The shared
+  `Guest_Author_Creator::create()` now returns a bool, and the three importers act
+  on it:
+  - ~~`_original_author_id` is never written: the guard tests
+    `isset( $author['author_id'] )` while the WXR flow passes the ID under `ID`, and
+    even on a hit it stored `$author['ID']`.~~ **FIXED** — the guard tests the key the
+    callers actually supply, so provenance is recorded again. Nothing inside CAP
+    reads this meta; it exists for downstream migration tooling, so this restores a
+    documented promise rather than changing plugin behaviour.
+  - ~~Unguarded array reads emit `Undefined array key` warnings for every key the
+    caller omits — six per `create-author` run, three per WXR author.~~ **FIXED**
+    with `?? ''` defaults. This is behaviour-neutral for stored meta because
+    `CoAuthors_Guest_Authors::create()` skips fields with `empty()`, which treats
+    `''` and absent alike. Had it used `isset()`, every empty field would have
+    started writing an empty meta row.
+  - ~~`avatar` is warned about on EVERY `create-author` invocation, because that
+    command has no `--avatar` flag at all.~~ **FIXED** as a case of the above, not
+    separately. Adding an `--avatar` flag would be a feature, and is not in scope.
+  - ~~`-- Not found; creating profile.` prints BEFORE `create()` validates, so it
+    appears even when nothing is created.~~ **FIXED** by deleting the line. Making it
+    honest would mean duplicating `create()`'s validation in the helper, and on the
+    success path `Success: -- Created as guest author #N` already says it.
+  - ~~A validation failure is a warning plus an implicit exit 0, so `create-author`
+    with no arguments "succeeds" from a script's point of view.~~ **FIXED** for the
+    single-author command, which now halts with 1. The bulk importers deliberately
+    keep exit 0 — one bad row must not abort a large import — and instead tally
+    failures and report `N of M authors could not be created.` That split is the
+    whole reason the helper returns a bool rather than erroring itself.
+  - ~~Duplicate detection tries `user_email` before `user_login`, so an existing
+    profile with the same email but a different login is reported as "already
+    exists" and the requested login is silently dropped.~~ **FIXED in the message,
+    and the lookup order deliberately left alone.** Reversing it would let a second
+    profile share an email, and `get_guest_author_by( 'user_email', ... )` is a bare
+    `get_var` where the first row wins — that ambiguity would leak into linked
+    accounts and the admin UI, well outside the CLI. Shared editorial addresses are
+    common. The real defect was that the operator asked for one login and was told
+    about a profile without being told which; the warning now names it.
+
 ## create-terms-for-posts
 
 (Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)
@@ -970,6 +1008,17 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   the previous `--slug=cap-jane-doe` assertion was satisfiable by residue from
   create-author.feature (which runs first and uses the same login). See the correction
   in the shared test-environment section.
+
+- ~~A CSV row supplying exactly ONE of `first_name`/`last_name` matches neither
+  branch of the name-splitting logic — the `if` needs both name columns empty AND a
+  space in `display_name`, the `elseif` needs BOTH populated — so the supplied name
+  is silently discarded.~~ **FIXED**, and fixed in the same change as the creator's
+  `Undefined array key` warnings, deliberately. Those warnings were the only
+  operator-visible symptom of this gap, so silencing them alone would have made a
+  data-losing import completely quiet. The condition is now "take whichever name
+  columns the row supplies, and fall back to splitting `display_name` only when it
+  supplies neither", which is both shorter than what it replaced and covers the case
+  that fell through.
 
 ## create-guest-authors-from-wxr
 

--- a/features/create-author.feature
+++ b/features/create-author.feature
@@ -10,14 +10,7 @@ Feature: A single guest author can be created
 	Scenario: Create a guest author with every supported field
 		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com --first_name=Jane --last_name=Doe --website=https://example.com/jane --description="Jane writes about testing"`
 		Then the return code should be 0
-		And STDOUT should contain:
-		"""
-		-- Not found; creating profile.
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "avatar"
-		"""
+		And STDOUT should not match /Undefined array key/
 		And STDOUT should contain:
 		"""
 		Success: -- Created as guest author #
@@ -62,37 +55,10 @@ Feature: A single guest author can be created
 		cap-jane-doe
 		"""
 
-	Scenario: Omitted optional fields raise undefined array key warnings but still create the profile
+	Scenario: Omitted optional fields are defaulted, not warned about
 		When I run `wp co-authors-plus create-author --display_name=Minimal --user_login=minimal`
 		Then the return code should be 0
-		And STDOUT should contain:
-		"""
-		-- Not found; creating profile.
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "user_email"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "first_name"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "last_name"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "website"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "description"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "avatar"
-		"""
+		And STDOUT should not match /Undefined array key/
 		And STDOUT should contain:
 		"""
 		Success: -- Created as guest author #
@@ -200,17 +166,10 @@ Feature: A single guest author can be created
 		"""
 
 	Scenario: A guest author is not created without a display_name
-		When I run `wp co-authors-plus create-author --user_login=no-display-name`
-		Then the return code should be 0
-		And STDOUT should contain:
-		"""
-		-- Not found; creating profile.
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "display_name"
-		"""
-		And STDOUT should contain:
+		When I try `wp co-authors-plus create-author --user_login=no-display-name`
+		Then the return code should be 1
+		And STDOUT should be empty
+		And STDERR should be:
 		"""
 		Warning: -- Failed to create guest author: display_name is a required field
 		"""
@@ -221,17 +180,10 @@ Feature: A single guest author can be created
 		"""
 
 	Scenario: A guest author is not created without a user_login
-		When I run `wp co-authors-plus create-author --display_name="No Login"`
-		Then the return code should be 0
-		And STDOUT should contain:
-		"""
-		-- Not found; creating profile.
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "user_login"
-		"""
-		And STDOUT should contain:
+		When I try `wp co-authors-plus create-author --display_name="No Login"`
+		Then the return code should be 1
+		And STDOUT should be empty
+		And STDERR should be:
 		"""
 		Warning: -- Failed to create guest author: user_login is a required field
 		"""
@@ -241,14 +193,11 @@ Feature: A single guest author can be created
 		0
 		"""
 
-	Scenario: Running without any parameters still attempts creation and warns
-		When I run `wp co-authors-plus create-author`
-		Then the return code should be 0
-		And STDOUT should contain:
-		"""
-		-- Not found; creating profile.
-		"""
-		And STDOUT should contain:
+	Scenario: Running without any parameters fails with a non-zero exit code
+		When I try `wp co-authors-plus create-author`
+		Then the return code should be 1
+		And STDOUT should be empty
+		And STDERR should be:
 		"""
 		Warning: -- Failed to create guest author: display_name is a required field
 		"""
@@ -267,7 +216,7 @@ Feature: A single guest author can be created
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}); skipping.
+		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}, user_login jane-doe); skipping.
 		"""
 		When I run `wp post list --post_type=guest-author --format=count`
 		Then STDOUT should be:
@@ -275,6 +224,9 @@ Feature: A single guest author can be created
 		1
 		"""
 
+	# The requested login is janet-other, the reported one is jane-doe. That contrast
+	# is the point: without the login in the message an operator would reasonably
+	# conclude janet-other now exists, when it does not.
 	Scenario: An existing user_email is matched even when the user_login differs
 		Given I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
 		And I run `wp post list --post_type=guest-author --format=ids`
@@ -283,7 +235,7 @@ Feature: A single guest author can be created
 		When I run `wp co-authors-plus create-author --display_name="Janet Other" --user_login=janet-other --user_email=jane@example.com`
 		Then STDOUT should be:
 		"""
-		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}); skipping.
+		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}, user_login jane-doe); skipping.
 		"""
 		When I run `wp post list --post_type=guest-author --format=count`
 		Then STDOUT should be:
@@ -299,7 +251,7 @@ Feature: A single guest author can be created
 		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=different@example.com`
 		Then STDOUT should be:
 		"""
-		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}); skipping.
+		Warning: -- Author already exists (ID #{GUEST_AUTHOR_ID}, user_login jane-doe); skipping.
 		"""
 		When I run `wp post meta get {GUEST_AUTHOR_ID} cap-user_email`
 		Then STDOUT should be:

--- a/features/create-guest-authors-from-csv.feature
+++ b/features/create-guest-authors-from-csv.feature
@@ -30,13 +30,11 @@ Feature: Guest authors can be created from a CSV file
 		"""
 		Found 2 authors in CSV
 		Processing author jane-doe (jane@example.com)
-		-- Not found; creating profile.
 		Success: -- Created as guest author #
 		"""
 		And STDOUT should contain:
 		"""
 		Processing author bob-builder (bob@example.com)
-		-- Not found; creating profile.
 		Success: -- Created as guest author #
 		"""
 		And STDOUT should contain:
@@ -102,7 +100,9 @@ Feature: Guest authors can be created from a CSV file
 		Builder
 		"""
 
-	Scenario: Name columns are dropped when neither splitting branch matches
+	# A display_name with no space and no name columns still yields no name meta,
+	# which is correct — there is nothing to split and nothing supplied.
+	Scenario: A single-word display name yields no first or last name
 		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-single-name.csv`
 		Then the return code should be 0
 		And STDOUT should contain:
@@ -111,16 +111,9 @@ Feature: Guest authors can be created from a CSV file
 		"""
 		And STDOUT should contain:
 		"""
-		Undefined array key "first_name"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "last_name"
-		"""
-		And STDOUT should contain:
-		"""
 		Success: -- Created as guest author #
 		"""
+		And STDOUT should not match /Undefined array key/
 		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=prince --format=ids`
 		And save STDOUT as {PRINCE_ID}
 		And I run `wp post meta list {PRINCE_ID} --format=csv`
@@ -134,19 +127,12 @@ Feature: Guest authors can be created from a CSV file
 		{PRINCE_ID},cap-description,"Single name artist"
 		{PRINCE_ID},_original_author_login,prince
 		"""
-		# A row with exactly ONE of first_name/last_name filled matches neither branch
-		# either, so the supplied "Halfy" is silently discarded even though the display
-		# name does contain a space.
+		# A row supplying exactly ONE of first_name/last_name used to match neither
+		# branch, so the supplied "Halfy" was discarded. Whichever column is filled is
+		# now kept, and the empty one simply writes no meta.
 		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-half-named.csv`
 		Then the return code should be 0
-		And STDOUT should contain:
-		"""
-		Undefined array key "first_name"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "last_name"
-		"""
+		And STDOUT should not match /Undefined array key/
 		When I run `wp post list --post_type=guest-author --meta_key=cap-user_login --meta_value=half-named --format=ids`
 		And save STDOUT as {HALF_ID}
 		And I run `wp post meta list {HALF_ID} --format=csv`
@@ -154,6 +140,7 @@ Feature: Guest authors can be created from a CSV file
 		"""
 		post_id,meta_key,meta_value
 		{HALF_ID},cap-display_name,"Half Named"
+		{HALF_ID},cap-first_name,Halfy
 		{HALF_ID},cap-user_login,half-named
 		{HALF_ID},cap-user_email,half@example.com
 		{HALF_ID},_original_author_login,half-named
@@ -301,9 +288,9 @@ Feature: Guest authors can be created from a CSV file
 		"""
 		Found 2 authors in CSV
 		Processing author jane-doe (jane@example.com)
-		Warning: -- Author already exists (ID #{JANE_ID}); skipping.
+		Warning: -- Author already exists (ID #{JANE_ID}, user_login jane-doe); skipping.
 		Processing author bob-builder (bob@example.com)
-		Warning: -- Author already exists (ID #{BOB_ID}); skipping.
+		Warning: -- Author already exists (ID #{BOB_ID}, user_login bob-builder); skipping.
 		All done!
 		"""
 		When I run `wp post list --post_type=guest-author --format=count`

--- a/features/create-guest-authors-from-wxr.feature
+++ b/features/create-guest-authors-from-wxr.feature
@@ -59,27 +59,14 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 	Scenario: Create guest authors from the author nodes of a WXR file
 		When I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`
 		Then the return code should be 0
+		And STDOUT should not match /Undefined array key/
 		And STDOUT should contain:
 		"""
 		Processing author wxr-jane (wxr-jane@example.com)
-		-- Not found; creating profile.
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "website"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "description"
-		"""
-		And STDOUT should contain:
-		"""
-		Undefined array key "avatar"
 		"""
 		And STDOUT should contain:
 		"""
 		Processing author wxr-bob (wxr-bob@example.com)
-		-- Not found; creating profile.
 		"""
 		And STDOUT should contain:
 		"""
@@ -112,15 +99,16 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		{JANE_ID},cap-last_name,Jane
 		{JANE_ID},cap-user_login,wxr-jane
 		{JANE_ID},cap-user_email,wxr-jane@example.com
+		{JANE_ID},_original_author_id,101
 		{JANE_ID},_original_author_login,wxr-jane
 		"""
-		# Stated explicitly as well as implied by the block above: the `_original_author_id`
-		# guard tests `isset( $author['author_id'] )` while this flow passes the WXR
-		# author ID under the key `ID`, so the meta is never written.
-		When I run `wp post meta list {JANE_ID} --keys=_original_author_id --format=count`
+		# The importers pass the source author ID under the `ID` key. The guard used to
+		# test `author_id`, which no caller sets, so this meta was never written and the
+		# documented provenance was lost.
+		When I run `wp post meta get {JANE_ID} _original_author_id`
 		Then STDOUT should be:
 		"""
-		0
+		101
 		"""
 		# Scoped to the profile just created, not to the slug: a term-slug lookup would
 		# pass on residue from an earlier feature or an earlier run.
@@ -142,6 +130,7 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		{BOB_ID},cap-last_name,Bob
 		{BOB_ID},cap-user_login,wxr-bob
 		{BOB_ID},cap-user_email,wxr-bob@example.com
+		{BOB_ID},_original_author_id,102
 		{BOB_ID},_original_author_login,wxr-bob
 		"""
 		When I run `wp term list author --object_ids={BOB_ID} --field=slug`
@@ -176,9 +165,9 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		And STDOUT should be:
 		"""
 		Processing author wxr-jane (wxr-jane@example.com)
-		Warning: -- Author already exists (ID #{JANE_ID}); skipping.
+		Warning: -- Author already exists (ID #{JANE_ID}, user_login wxr-jane); skipping.
 		Processing author wxr-bob (wxr-bob@example.com)
-		Warning: -- Author already exists (ID #{BOB_ID}); skipping.
+		Warning: -- Author already exists (ID #{BOB_ID}, user_login wxr-bob); skipping.
 		All done!
 		"""
 		When I run `wp post list --post_type=guest-author --format=count`

--- a/php/cli/class-create-author-command.php
+++ b/php/cli/class-create-author-command.php
@@ -76,6 +76,10 @@ class Create_Author_Command {
 	 * @return void
 	 */
 	public function __invoke( array $args, array $assoc_args ): void {
-		$this->creator->create( $assoc_args );
+		if ( ! $this->creator->create( $assoc_args ) ) {
+			// The creator has already explained why; this only makes the failure
+			// visible to a script, which a warning and exit 0 did not.
+			WP_CLI::halt( 1 );
+		}
 	}
 }

--- a/php/cli/class-create-guest-authors-from-csv-command.php
+++ b/php/cli/class-create-guest-authors-from-csv-command.php
@@ -103,6 +103,8 @@ class Create_Guest_Authors_From_Csv_Command {
 
 		WP_CLI::log( 'Found ' . count( $authors ) . ' authors in CSV' );
 
+		$failed = 0;
+
 		foreach ( $authors as $author ) {
 			WP_CLI::log( sprintf( 'Processing author %s (%s)', $author['user_login'], $author['user_email'] ) );
 
@@ -117,19 +119,29 @@ class Create_Guest_Authors_From_Csv_Command {
 
 			$display_name_space_pos = strpos( $author['display_name'], ' ' );
 
-			if ( false !== $display_name_space_pos && empty( $author['first_name'] ) && empty( $author['last_name'] ) ) {
+			// Take whichever name columns the row supplies, and fall back to splitting
+			// display_name only when it supplies neither. Requiring BOTH columns meant a
+			// row carrying just one matched no branch at all and had its name discarded.
+			if ( ! empty( $author['first_name'] ) || ! empty( $author['last_name'] ) ) {
+				$guest_author_data['first_name'] = sanitize_text_field( $author['first_name'] );
+				$guest_author_data['last_name']  = sanitize_text_field( $author['last_name'] );
+			} elseif ( false !== $display_name_space_pos ) {
 				$first_name = substr( $author['display_name'], 0, $display_name_space_pos );
 				$last_name  = substr( $author['display_name'], ( $display_name_space_pos + 1 ) );
 
 				$guest_author_data['first_name'] = sanitize_text_field( $first_name );
 				$guest_author_data['last_name']  = sanitize_text_field( $last_name );
-			} elseif ( ! empty( $author['first_name'] ) && ! empty( $author['last_name'] ) ) {
-				$guest_author_data['first_name'] = sanitize_text_field( $author['first_name'] );
-				$guest_author_data['last_name']  = sanitize_text_field( $author['last_name'] );
 			}
 
-			$this->creator->create( $guest_author_data );
+			if ( ! $this->creator->create( $guest_author_data ) ) {
+				++$failed;
+			}
 		}//end foreach
+
+		if ( $failed > 0 ) {
+			// A bad row does not abort the import, so say how many were dropped.
+			WP_CLI::warning( sprintf( '%d of %d authors could not be created.', $failed, count( $authors ) ) );
+		}
 
 		WP_CLI::log( 'All done!' );
 	}

--- a/php/cli/class-create-guest-authors-from-wxr-command.php
+++ b/php/cli/class-create-guest-authors-from-wxr-command.php
@@ -84,6 +84,7 @@ class Create_Guest_Authors_From_Wxr_Command {
 
 		// Get author nodes.
 		$authors = $import_data['authors'];
+		$failed  = 0;
 
 		foreach ( $authors as $author ) {
 			WP_CLI::log( sprintf( 'Processing author %s (%s)', $author['author_login'], $author['author_email'] ) );
@@ -97,7 +98,14 @@ class Create_Guest_Authors_From_Wxr_Command {
 				'ID'           => $author['author_id'],
 			);
 
-			$this->creator->create( $guest_author_data );
+			if ( ! $this->creator->create( $guest_author_data ) ) {
+				++$failed;
+			}
+		}
+
+		if ( $failed > 0 ) {
+			// A bad author node does not abort the import, so say how many were dropped.
+			WP_CLI::warning( sprintf( '%d of %d authors could not be created.', $failed, count( $authors ) ) );
 		}
 
 		WP_CLI::log( 'All done!' );

--- a/php/cli/class-guest-author-creator.php
+++ b/php/cli/class-guest-author-creator.php
@@ -18,12 +18,12 @@ use WP_CLI;
  * Three commands import guest authors — from a CSV, from a WXR file, and one at
  * a time from the command line — and all three need the same thing: look for an
  * existing profile by email and then by login, create one if neither matches,
- * and record where it came from. This was a private helper on
- * CoAuthorsPlus_Command and moves here unchanged so those commands can share it
- * once they are classes of their own.
+ * and record where it came from.
  *
- * It reports through WP_CLI rather than returning, which is how it behaved
- * before; giving it a return value would change what the commands print.
+ * Progress is reported through WP_CLI, because the bulk importers interleave it
+ * with their own per-row logging. The return value says only whether the caller
+ * should treat this author as a failure, which the single-author command turns
+ * into an exit code and the importers tally.
  */
 class Guest_Author_Creator {
 
@@ -46,10 +46,15 @@ class Guest_Author_Creator {
 	/**
 	 * Create a guest author, unless one already exists for it.
 	 *
+	 * Every field other than display_name and user_login is optional; an absent
+	 * key is treated the same as an empty value. An `ID` key, where the source
+	 * has one, is recorded as `_original_author_id`.
+	 *
 	 * @param array<string, mixed> $author Author args. Requires display_name and user_login.
-	 * @return void
+	 * @return bool True when a profile exists for this author afterwards, whether it
+	 *              was created now or was already there. False when creation failed.
 	 */
-	public function create( array $author ): void {
+	public function create( array $author ): bool {
 		$coauthors_plus = $this->coauthors_plus;
 
 		$guest_author = false;
@@ -63,33 +68,41 @@ class Guest_Author_Creator {
 		}
 
 		if ( $guest_author ) {
-			/* translators: Guest Author ID. */
-			WP_CLI::warning( sprintf( esc_html__( '-- Author already exists (ID #%s); skipping.', 'co-authors-plus' ), $guest_author->ID ) );
-			return;
-		}
+			WP_CLI::warning(
+				sprintf(
+					/* translators: 1: Guest author ID. 2: Guest author user_login. */
+					esc_html__( '-- Author already exists (ID #%1$s, user_login %2$s); skipping.', 'co-authors-plus' ),
+					$guest_author->ID,
+					$guest_author->user_login
+				)
+			);
 
-		WP_CLI::log( esc_html__( '-- Not found; creating profile.', 'co-authors-plus' ) );
+			return true;
+		}
 
 		$guest_author_id = $coauthors_plus->guest_authors->create(
 			array(
-				'display_name' => $author['display_name'],
-				'user_login'   => $author['user_login'],
-				'user_email'   => $author['user_email'],
-				'first_name'   => $author['first_name'],
-				'last_name'    => $author['last_name'],
-				'website'      => $author['website'],
-				'description'  => $author['description'],
-				'avatar'       => $author['avatar'],
+				'display_name' => $author['display_name'] ?? '',
+				'user_login'   => $author['user_login'] ?? '',
+				'user_email'   => $author['user_email'] ?? '',
+				'first_name'   => $author['first_name'] ?? '',
+				'last_name'    => $author['last_name'] ?? '',
+				'website'      => $author['website'] ?? '',
+				'description'  => $author['description'] ?? '',
+				'avatar'       => $author['avatar'] ?? '',
 			)
 		);
 
 		if ( is_wp_error( $guest_author_id ) ) {
 			/* translators: The error message. */
 			WP_CLI::warning( sprintf( esc_html__( '-- Failed to create guest author: %s', 'co-authors-plus' ), $guest_author_id->get_error_message() ) );
-			return;
+
+			return false;
 		}
 
-		if ( isset( $author['author_id'] ) ) {
+		// The importers supply the source author's ID under `ID`. The guard used to
+		// test `author_id`, which no caller sets, so this never ran.
+		if ( isset( $author['ID'] ) ) {
 			update_post_meta( $guest_author_id, '_original_author_id', $author['ID'] );
 		}
 
@@ -97,5 +110,7 @@ class Guest_Author_Creator {
 
 		/* translators: Guest Author ID. */
 		WP_CLI::success( sprintf( esc_html__( '-- Created as guest author #%s', 'co-authors-plus' ), $guest_author_id ) );
+
+		return true;
 	}
 }


### PR DESCRIPTION
## Summary

`Guest_Author_Creator` is shared by `create-author`, the CSV importer and the WXR importer, and it had accumulated several ways of being untruthful. They are fixed together because they share three feature files, and because one of them cannot safely be fixed on its own.

**`_original_author_id` was never recorded.** The guard tested `isset( $author['author_id'] )` while the WXR flow passes the source ID under `ID` — and even had it matched, it stored a different key from the one it checked. Nothing inside CAP reads that meta; it exists for downstream migration tooling, so this restores a documented promise rather than changing plugin behaviour.

**Absent optional fields were read unguarded**, so a `create-author` run emitted six `Undefined array key` warnings and a WXR import three per author. Defaulting them changes no stored meta, because `CoAuthors_Guest_Authors::create()` skips fields using `empty()`, which treats `''` and absent alike. Worth noting that this is only behaviour-neutral by luck: had `create()` used `isset()`, every empty field would have started writing an empty meta row and every exact meta assertion in all three features would have moved.

**`-- Not found; creating profile.` printed before `create()` validated**, announcing work that then did not happen. Deleted rather than moved, because on the success path the very next line already says it.

**A validation failure warned and exited 0**, so `create-author` with no arguments at all looked like success to a script. It now halts with 1. The bulk importers deliberately keep exit 0 — one bad row must not abort a large import — and instead tally failures and report `N of M authors could not be created.` That split is precisely why the helper now returns a bool rather than erroring itself.

## Two judgement calls worth your eye

**The duplicate-detection order is deliberately unchanged.** The obvious reading is that trying `user_email` before `user_login` is backwards, since an existing profile with the same email but a different login is reported as "already exists" and the requested login is dropped. Reversing it is worse: you would then create a second profile sharing an email address, and `get_guest_author_by( 'user_email', ... )` is a bare `get_var` where the first row silently wins — that ambiguity would leak into linked accounts and the admin UI, well outside the CLI. Shared editorial addresses across bylines are common. The actual defect was that an operator asking for `janet-other` was told a profile existed without being told it was `jane-doe`. The warning now names it, which makes that scenario *more* discriminating rather than less.

**The CSV name-splitting gap is fixed here rather than in its own PR.** A row supplying only a first *or* only a last name matched neither branch — the `if` needs both name columns empty **and** a space in `display_name`, the `elseif` needs **both** populated — so the supplied name was silently discarded. That is data loss on import, and its only operator-visible symptom was the `Undefined array key` warnings this PR removes. Fixing the warnings alone would have left a data-losing import completely silent, so the two had to move together. The replacement condition — take whichever name columns the row supplies, fall back to splitting `display_name` only when it supplies neither — is shorter than what it replaced and covers the case that fell through.

## Test plan

- [x] All three features green together at 28 scenarios / 349 steps, run as one invocation because they share guest-author state
- [x] `create-author` 11/127, CSV 10/120, WXR 7/102 individually
- [x] The `_original_author_id` assertion changed from "count is 0" to the actual value, so it now proves the fix rather than recording its absence
- [x] PHPCS clean on all four changed files by exit code
- [ ] Full Behat suite via CI