### PR TITLE
Validate create-author-terms-for-posts parameters and report skips

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -735,6 +735,46 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   leaves the count at 2; after the backfill it is still 2. The feature pins 2 to
   document those semantics (an author term's count survives having every one of
   its relationships removed), not as a guard against the API swap.
+- **Parameter validation and skip reporting, resolved together.**
+  - ~~An invalid ID range throws an uncaught `Exception` from a private SQL builder.
+    The operator gets a doubled PHP stack trace on STDOUT and only WP core's generic
+    "There has been a critical error on this website" on STDERR, so nothing tells
+    them which parameter was wrong — the message even names PHP variables rather
+    than CLI flags.~~ **FIXED.** Validated in `__invoke()` with `WP_CLI::error()`,
+    naming the flags as typed. The `throw` stays in the builder as an unreachable
+    backstop.
+  - ~~`--specific-post-ids` is an `elseif` that short-circuits the range validation,
+    so an invalid range combined with specific IDs is silently ignored.~~ **FIXED**
+    by the same guard, which is now unconditional. The precedence itself is
+    unchanged but no longer silent: combining them warns that the range is ignored.
+  - ~~Posts with `post_author = 0` are excluded by `AND post_author <> 0`, while
+    `list-posts-without-terms` DOES list them, so the two diagnostics disagree about
+    the same site.~~ **FIXED** by dropping the exclusion. `get_user_by( 'id', 0 )`
+    returns false, so such posts take the existing orphan path — warned, marked with
+    the skip meta, and excluded from later batches — rather than needing a new branch.
+  - ~~A post whose author is missing is counted in `Found N posts` but yields
+    `0 records affected`, and the run still ends `Success: Done!` with nothing
+    explaining the gap.~~ **FIXED.** Skips are counted and reported. The new string
+    is pluralised with `_n()` from the outset.
+- STILL OPEN, and parked pending a decision: the raw `$wpdb->insert` into
+  `term_relationships` bypasses `wp_set_object_terms()`, and with it the
+  `set_object_terms` action that CAP hooks at `class-coauthors-plus.php` to clear its
+  own `coauthors_post_<id>` cache — which caches an EMPTY array. On a host with a
+  persistent object cache, which is the environment this command exists for, a
+  backfilled post keeps reporting no co-authors to the front end, template tags and
+  REST until it is saved or the cache is flushed. It also skips dedupe and writes
+  `term_order = 0` where every other path writes the ordered value. The fix is a
+  deletion — use `wp_set_object_terms()`, wrapped in `wp_defer_term_counting()` — but
+  wp-env has no persistent object cache, so neither the bug nor the fix is observable
+  in this suite, and it would ship on reasoning alone.
+- CORRECTION to the earlier note claiming `--specific-post-ids` can loop forever:
+  it cannot. `if ( $count >= $count_of_posts_with_missing_author_terms ) break;`
+  bounds the run, and `$count` increments per record processed whether or not it
+  succeeded. The real symptom is STARVATION — a post that cannot be completed is
+  re-selected by every batch and consumes the budget, so the others are never
+  reached and the progress line repeats for the same post. On a large site that is
+  indistinguishable from a hang, which is probably how it was recorded as a loop.
+
 ## delete-postmeta-that-skip-author-term-backfill
 
 (Calibrated against the live env, 2026-09-01; re-verified green 2026-09-02.)

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -181,10 +181,14 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		0
 		"""
-		When I run `wp co-authors-plus create-author-terms-for-posts --specific-post-ids={POST_A},{POST_B} --above-post-id=10 --below-post-id=5`
+		# A valid range that would exclude both posts, to prove --specific-post-ids still
+		# wins. This used an INVALID range, which now exits 1 — so re-pinning it without
+		# thought would have quietly dropped the precedence coverage altogether.
+		When I run `wp co-authors-plus create-author-terms-for-posts --specific-post-ids={POST_A},{POST_B} --above-post-id={POST_A} --below-post-id={POST_B}`
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
+		Warning: --above-post-id and --below-post-id are ignored when --specific-post-ids is given.
 		Found 1 posts with missing author terms.
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
@@ -284,19 +288,20 @@ Feature: Missing author terms can be backfilled for targeted posts
 		0
 		"""
 
-	Scenario: An uncaught exception is thrown when --above-post-id is not less than --below-post-id
+	Scenario: An invalid ID range is rejected with an error naming the parameters
 		When I try `wp co-authors-plus create-author-terms-for-posts --above-post-id=10 --below-post-id=5`
 		Then the return code should be 1
-		And STDOUT should contain:
+		And STDOUT should be empty
+		And STDERR should be:
 		"""
-		Fatal error: Uncaught Exception: The $above_post_id param must be less than the $below_post_id param.
+		Error: --above-post-id must be less than --below-post-id.
 		"""
-		And STDERR should not be empty
 		When I try `wp co-authors-plus create-author-terms-for-posts --above-post-id=5 --below-post-id=5`
 		Then the return code should be 1
-		And STDOUT should contain:
+		And STDOUT should be empty
+		And STDERR should be:
 		"""
-		Fatal error: Uncaught Exception: The $above_post_id param must be less than the $below_post_id param.
+		Error: --above-post-id must be less than --below-post-id.
 		"""
 
 	Scenario: A post whose author does not exist gets skip postmeta instead of a term
@@ -309,6 +314,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
+		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
 		Updating author terms with new counts
 		Success: Done!
 		"""
@@ -326,7 +332,9 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Success: Done!
 		"""
 
-	Scenario: Posts with a post_author of zero are never seen as missing terms
+	# list-posts-without-terms reports these, so excluding them here made the two
+	# diagnostics disagree about the same site. They now take the orphan path.
+	Scenario: Posts with a post_author of zero are marked as unbackfillable
 		When I run `wp post create --post_title="Nobody post" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp post get {POST_ID} --field=post_author`
@@ -342,10 +350,18 @@ Feature: Missing author terms can be backfilled for targeted posts
 		When I run `wp co-authors-plus create-author-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Found 0 posts with missing author terms.
+		Found 1 posts with missing author terms.
+		Processing post {POST_ID} (1/1 or 100.00%)
+		Warning: Post Author ID 0 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
+		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
 		Updating author terms with new counts
 		Success: Done!
+		"""
+		When I run `wp post meta get {POST_ID} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
 		"""
 
 	Scenario: Batches are re-queried when --records-per-batch is smaller than the total, and a skipped post does not stall progress
@@ -370,6 +386,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (3/3 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		2 records affected
+		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
 		Updating author terms with new counts
 		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
@@ -422,6 +439,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
+		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
 		Updating author terms with new counts
 		Success: Done!
 		"""
@@ -495,6 +513,25 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Then the return code should be 0
 		And STDOUT should match #(Success: Deleted[\s\S]*?){11}#
 		When I run `wp post list --meta_key=_cap_skip_backfill --post_status=any --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	# The range check used to sit inside the SQL builder, in a branch only reached
+	# when no --specific-post-ids were given, so this combination was accepted.
+	Scenario: An invalid ID range is rejected even when --specific-post-ids is given
+		When I run `wp post create --post_title="First post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		When I try `wp co-authors-plus create-author-terms-for-posts --specific-post-ids={POST_ID} --above-post-id=10 --below-post-id=5`
+		Then the return code should be 1
+		And STDOUT should be empty
+		And STDERR should be:
+		"""
+		Error: --above-post-id must be less than --below-post-id.
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --format=count`
 		Then STDOUT should be:
 		"""
 		0

--- a/php/cli/class-create-author-terms-for-posts-command.php
+++ b/php/cli/class-create-author-terms-for-posts-command.php
@@ -112,6 +112,18 @@ class Create_Author_Terms_For_Posts_Command {
 		$above_post_id     = $assoc_args['above-post-id'] ?? null;
 		$below_post_id     = $assoc_args['below-post-id'] ?? null;
 
+		// Validated here rather than in the SQL builder, which was only reached when
+		// no --specific-post-ids were given, and threw an uncaught Exception when it
+		// was — so the operator saw a stack trace and a generic critical-error line
+		// rather than being told which parameter was wrong.
+		if ( null !== $above_post_id && null !== $below_post_id && (int) $below_post_id <= (int) $above_post_id ) {
+			WP_CLI::error( '--above-post-id must be less than --below-post-id.' );
+		}
+
+		if ( ! empty( $specific_post_ids ) && ( null !== $above_post_id || null !== $below_post_id ) ) {
+			WP_CLI::warning( '--above-post-id and --below-post-id are ignored when --specific-post-ids is given.' );
+		}
+
 		global $wpdb;
 
 		$coauthors_plus = $this->coauthors_plus;
@@ -131,6 +143,7 @@ class Create_Author_Terms_For_Posts_Command {
 		$author_terms = array();
 		$count        = 0;
 		$affected     = 0;
+		$skipped      = 0;
 		$page         = 1;
 
 		$posts_with_missing_author_terms = $this->get_posts_with_missing_terms(
@@ -161,6 +174,7 @@ class Create_Author_Terms_For_Posts_Command {
 						// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- This is just trying to convey where the root problem should be resolved.
 						WP_CLI::warning( sprintf( 'Post Author ID %d does not exist in %s table, inserting skip postmeta (`%s`).', $record->post_author, $wpdb->users, self::SKIP_POST_FOR_BACKFILL_META_KEY ) );
 						$this->skip_backfill_for_post( $record->post_id, 'nonexistent_post_author_id' );
+						++$skipped;
 						continue;
 					}
 
@@ -218,6 +232,22 @@ class Create_Author_Terms_For_Posts_Command {
 		} while ( ! empty( $posts_with_missing_author_terms ) );
 
 		WP_CLI::log( sprintf( '%d records affected', $affected ) );
+
+		if ( $skipped > 0 ) {
+			WP_CLI::warning(
+				sprintf(
+					/* translators: 1: Count of posts. 2: Post meta key. */
+					_n(
+						'%1$s post was skipped and marked with `%2$s`.',
+						'%1$s posts were skipped and marked with `%2$s`.',
+						$skipped,
+						'co-authors-plus'
+					),
+					number_format_i18n( $skipped ),
+					self::SKIP_POST_FOR_BACKFILL_META_KEY
+				)
+			);
+		}
 
 		WP_CLI::log( 'Updating author terms with new counts' );
 		$count_of_authors = count( $authors );
@@ -297,7 +327,6 @@ class Create_Author_Terms_For_Posts_Command {
 			FROM $from
 			WHERE post_type IN ( $post_types_placeholder )
 			  AND post_status IN ( $post_status_placeholder )
-			  AND post_author <> 0
 			  AND ID NOT IN (
 			  	SELECT
 			  	    tr.object_id


### PR DESCRIPTION
## Summary

Four ways this backfill command left an operator without the information they needed.

**An invalid ID range threw an uncaught `Exception`** from a private SQL builder. The result is a doubled PHP stack trace on STDOUT and only WordPress's generic "There has been a critical error on this website" on STDERR — so anyone reading STDERR, which is where you look, learns nothing about what was wrong. The exception message names PHP variables rather than the flags the operator typed, so even the trace does not help. Validation now happens in `__invoke()` and errors cleanly naming `--above-post-id` and `--below-post-id`. The `throw` stays in the builder as an unreachable backstop.

**That validation sat in a branch only reached when no `--specific-post-ids` were given**, so combining an invalid range with specific IDs was accepted and silently ignored. The same guard fixes it by being unconditional. The precedence itself is unchanged — specific IDs still win — but it is now stated rather than silent, with a warning that the range is being ignored.

**Posts with `post_author` of 0 were excluded outright** by `AND post_author <> 0`, while `list-posts-without-terms` reports them happily. Two diagnostics, one site, contradictory answers. Dropping the exclusion sends them down the path that already exists: `get_user_by( 'id', 0 )` returns false, so they are warned about, marked with the skip meta and dropped from later batches, with no new branch needed.

**And a post skipped that way was counted in `Found N posts` but never in `records affected`**, with the run still ending `Success: Done!` and nothing accounting for the difference. Skips are now tallied and reported, with the new string pluralised via `_n()` from the outset.

## Worth a reviewer's attention

The discrimination trap fired again, and this one was predicted in advance. The scenario proving `--specific-post-ids` takes precedence did so **using an invalid range** — which now exits 1. Simply re-pinning its output would have left it passing while testing nothing, because the precedence would never be exercised. It now uses a *valid* range that would still exclude both posts, so the precedence is genuinely proved, and there is a separate new scenario for the invalid combination.

## Deliberately not included

The raw `$wpdb->insert` into `term_relationships` is untouched. It bypasses `wp_set_object_terms()` and with it the `set_object_terms` action CAP hooks to clear its own `coauthors_post_<id>` cache — which caches an *empty* array — so on a host with a persistent object cache a backfilled post keeps reporting no co-authors until it is saved. The fix is a deletion rather than an addition, but wp-env has no persistent object cache, so neither the bug nor the fix is observable in this suite and it would ship on reasoning alone. That wants deciding rather than assuming.

I have also corrected the catalogue's claim that this command can loop forever. It cannot — there is a `break` on the processed count. The real symptom is **starvation**: a post that cannot be completed is re-selected by every batch and consumes the budget, so the others are never reached and the progress line repeats for the same post. On a large site that is indistinguishable from a hang, which is presumably how it came to be recorded as a loop.

## Test plan

- [x] `features/create-author-terms-for-posts.feature` green at 21 scenarios / 250 steps, up from 20
- [x] Six scenarios failed against the patched code before re-pinning, matching the predicted set
- [x] PHPCS clean by exit code
- [ ] Full Behat suite via CI