### PR TITLE
Make assign-coauthors idempotent and honest about what it skipped

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -93,6 +93,49 @@ PHP 8.4) rather than inferred from reading the source.
   refactor that "normalised" this to `user_login` (as swap-coauthors does) would
   happen to keep working, whereas one that passed the post_name would double-prefix.
 
+- **Six defects resolved together (one PR), because they all live in one method.**
+  - ~~The `sanitize_title()` fallback is not idempotent: the already-associated check
+    compares the RAW meta value against `user_login` while assignment passes
+    `user_nicename`, so meta `Author One` never matches `author-one` and the post is
+    re-assigned and re-counted on EVERY run — a write storm, per post, for ever.~~
+    **FIXED** by resolving the co-author first and comparing against the resolved
+    login. Note the problem was broader than `sanitize_title()`: `get_user_by()` also
+    retries after stripping a `cap-` prefix, and guest-author lookups sanitise on
+    every call, so meta `cap-author1` was equally non-idempotent. Comparing against
+    the resolved co-author is the only fix that closes all of them.
+  - ~~The already-associated branch `continue`s before `add_coauthors()` is ever
+    called. `get_coauthors()` falls back to the `post_author` user when a post has no
+    author terms, so a post matched only via that fallback is treated as done and
+    never gets a term — invisible to all term-driven tooling afterwards.~~ **FIXED.**
+    Only a real author term now counts as already associated. The `post_author`
+    fallback in `get_coauthors()` is untouched; what changed is that this command no
+    longer reads it as evidence of a byline.
+  - ~~No `post_status` on the query, and no flag to opt in, so drafts carrying the
+    meta key are silently skipped.~~ **FIXED** with `--post-statuses`, defaulting to
+    `publish` — an opt-in rather than a widened default, because this command
+    rewrites a byline per post. Contrast `list-posts-without-terms`, which was
+    widened because it only reports. Naming the status also removes a quirk: the old
+    default was publish PLUS whatever private statuses the current user could read,
+    so scope depended on whether `--user` was passed. That is a NARROWING for anyone
+    running under `--user`, and belongs in the changelog.
+  - ~~An empty meta VALUE is processed rather than skipped, so it joins the missing
+    list and imodes into a dangling comma.~~ **FIXED** with its own counter and
+    message. A counter rather than an `array_filter()` on the missing list, because
+    it buys an invariant: every post reached now increments exactly one counter, so
+    `posts_total > 0` implies at least one summary line — which is what makes the
+    empty-run fix below airtight rather than reintroducible through a side door.
+  - ~~The log echoes the RAW meta value while assigning the sanitised match, saying
+    `assigned "Author One"` while actually assigning `author-one`.~~ **FIXED** on both
+    the assign and the already-associated lines; the catalogue only named the first.
+  - ~~An empty run prints only `All done! Here are your results:` with no counts,
+    because every summary line is truthiness-guarded.~~ **FIXED** — it now says which
+    meta key it found nothing for.
+- TRAP for anyone touching this command: do NOT "normalise" what is passed to
+  `add_coauthors()` from `user_nicename` to `user_login`. It resolves names with
+  `$query_type = 'user_nicename'`, so a login whose nicename differs (`john.doe` vs
+  `john-doe`) would fail that lookup, `update_author_term( false )` returns false,
+  the slug substitution is skipped, and an unprefixed `john.doe` term gets written.
+
 ## swap-coauthors
 
 (Calibrated against the live env 2026-09-01; all scenarios green.)
@@ -155,7 +198,7 @@ PHP 8.4) rather than inferred from reading the source.
   only public statuses match: a DRAFT post carrying the `cap-<from>` term (CAP's
   `save_post` hook gives it one) is silently skipped and is not even counted in
   `Found N posts to update.`. There is no `--post_status` flag to opt in. Pinned in
-  the same scenario; `assign-coauthors` has the identical restriction.
+  the same scenario; `assign-coauthors` had the identical restriction until it gained `--post-statuses`; swap-coauthors is now the only command whose status filter cannot be opted out of.
 - ~~Swapping TO an unlinked guest author leaves `wp_posts.post_author` pointing at
   the previous WP user indefinitely, and the command ignores `add_coauthors()`'s
   return value — so the byline changes, the log still says `has been assigned` and

--- a/features/assign-coauthors.feature
+++ b/features/assign-coauthors.feature
@@ -97,7 +97,10 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		cap-author1
 		"""
 
-	Scenario: Do not backfill the author term for a post whose author already matches
+	# get_coauthors() falls back to the post_author user when a post has no author
+	# terms. Treating that as already associated left the post with no term at all,
+	# invisible to every term-driven query — this plugin's own included.
+	Scenario: Backfill the author term for a post reachable only through post_author
 		When I run `wp user create author1 author1@example.com --role=author --porcelain`
 		And save STDOUT as {AUTHOR1_ID}
 		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Own post" --post_status=publish --porcelain`
@@ -112,17 +115,17 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		And I run `wp co-authors-plus assign-coauthors`
 		Then STDOUT should be:
 		"""
-		1: Post #{POST_ID} already has "author1" associated as a co-author
+		1: Post #{POST_ID} has been assigned "author1" as the author
 		All done! Here are your results:
-		- 1 posts already had the co-author assigned
+		- 1 posts now have the proper co-author
 		"""
-		When I run `wp term list author --object_ids={POST_ID} --format=count`
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
 		"""
-		0
+		cap-author1
 		"""
 
-	Scenario: Report missing co-author profiles once each in the summary
+	Scenario: Report missing co-author profiles once each and skip empty meta values
 		When I run `wp post create --post_title="Ghost post one" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID_1}
 		And I run `wp post meta update {POST_ID_1} _original_import_author ghostwriter`
@@ -141,10 +144,11 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		1: Post #{POST_ID_1} does not have "ghostwriter" associated as a co-author but there is not a co-author profile
 		2: Post #{POST_ID_2} does not have "ghostwriter" associated as a co-author but there is not a co-author profile
 		3: Post #{POST_ID_3} does not have "phantom" associated as a co-author but there is not a co-author profile
-		4: Post #{POST_ID_4} does not have "" associated as a co-author but there is not a co-author profile
+		4: Post #{POST_ID_4} has an empty _original_import_author value
 		All done! Here are your results:
-		- 4 posts reference co-authors that don't exist. These are:
-		  ghostwriter, phantom,
+		- 3 posts reference co-authors that don't exist. These are:
+		  ghostwriter, phantom
+		- 1 post has an empty _original_import_author value
 		"""
 		When I run `wp term list author --object_ids={POST_ID_1},{POST_ID_2},{POST_ID_3},{POST_ID_4} --format=count`
 		Then STDOUT should be:
@@ -233,7 +237,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		And I run `wp co-authors-plus assign-coauthors`
 		Then STDOUT should be:
 		"""
-		All done! Here are your results:
+		No posts found with the "_original_import_author" meta key.
 		"""
 		When I run `wp co-authors-plus assign-coauthors --post_type=page`
 		Then STDOUT should be:
@@ -248,7 +252,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		cap-author1
 		"""
 
-	Scenario: Fall back to a sanitised meta value, re-assigning on every run
+	Scenario: Fall back to a sanitised meta value and re-run safely
 		When I run `wp user create author-one author-one@example.com --role=author --porcelain`
 		And I run `wp post create --post_title="Display name import" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID}
@@ -256,16 +260,19 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		And I run `wp co-authors-plus assign-coauthors`
 		Then STDOUT should be:
 		"""
-		1: Post #{POST_ID} has been assigned "Author One" as the author
+		1: Post #{POST_ID} has been assigned "author-one" as the author
 		All done! Here are your results:
 		- 1 posts now have the proper co-author
 		"""
+		# The raw meta value is "Author One"; the resolved login is "author-one". The
+		# comparison used to be against the raw value, so it never matched what had just
+		# been assigned and every run re-wrote the byline afresh.
 		When I run the previous command again
 		Then STDOUT should be:
 		"""
-		1: Post #{POST_ID} has been assigned "Author One" as the author
+		1: Post #{POST_ID} already has "author-one" associated as a co-author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 posts already had the co-author assigned
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -323,5 +330,55 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		All done! Here are your results:
 		- 2 posts now have the proper co-author
 		- 2 posts kept their original post_author, because no co-author assigned to them has a WordPress account
+		"""
+		And the return code should be 0
+
+	# Drafts carrying the meta key are outside the default scope, because this command
+	# rewrites a byline per post. --post-statuses is the opt-in, as on
+	# create-terms-for-posts.
+	Scenario: Cover drafts only when asked with --post-statuses
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And I run `wp post create --post_title="Draft import" --post_status=draft --porcelain`
+		And save STDOUT as {DRAFT_ID}
+		And I run `wp post meta update {DRAFT_ID} _original_import_author author1`
+		And I run `wp post create --post_title="Pending import" --post_status=pending --porcelain`
+		And save STDOUT as {PENDING_ID}
+		And I run `wp post meta update {PENDING_ID} _original_import_author author1`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		No posts found with the "_original_import_author" meta key.
+		"""
+		# Comma-separated, so the explode() is exercised rather than just a single value.
+		When I run `wp co-authors-plus assign-coauthors --post-statuses=draft,pending`
+		Then STDOUT should be:
+		"""
+		1: Post #{DRAFT_ID} has been assigned "author1" as the author
+		2: Post #{PENDING_ID} has been assigned "author1" as the author
+		All done! Here are your results:
+		- 2 posts now have the proper co-author
+		"""
+		When I run `wp term list author --object_ids={DRAFT_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author1
+		"""
+
+	# Two empty values, so the plural form of the summary line is exercised as well as
+	# the singular above. Without this the _n() plural branch never runs.
+	Scenario: Several empty meta values are counted together
+		When I run `wp post create --post_title="First" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp eval 'update_post_meta( {POST_A}, "_original_import_author", "" );'`
+		And I run `wp post create --post_title="Second" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp eval 'update_post_meta( {POST_B}, "_original_import_author", "" );'`
+		And I run `wp co-authors-plus assign-coauthors`
+		Then STDOUT should be:
+		"""
+		1: Post #{POST_A} has an empty _original_import_author value
+		2: Post #{POST_B} has an empty _original_import_author value
+		All done! Here are your results:
+		- 2 posts have an empty _original_import_author value
 		"""
 		And the return code should be 0

--- a/php/cli/class-assign-coauthors-command.php
+++ b/php/cli/class-assign-coauthors-command.php
@@ -53,6 +53,9 @@ class Assign_Coauthors_Command {
 	 * [--post_type=<post-type>]
 	 * : Limit to one post type. Defaults to post.
 	 *
+	 * [--post-statuses=<post-statuses>]
+	 * : Comma-separated post statuses to cover. Defaults to publish.
+	 *
 	 * [--append_coauthors]
 	 * : Add to the existing byline rather than replacing it.
 	 *
@@ -88,11 +91,20 @@ class Assign_Coauthors_Command {
 		$append_coauthors = $parsed_args['append_coauthors'];
 		unset( $parsed_args['append_coauthors'] );
 
+		// Named explicitly rather than left to WP_Query's default, which is publish
+		// plus whatever private statuses the current user can read — so the scope of a
+		// run would otherwise depend on whether --user was passed. Drafts are opted
+		// into rather than included by default, as on create-terms-for-posts, because
+		// this command rewrites a byline per post.
+		$parsed_args['post_status'] = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : array( 'publish' );
+		unset( $parsed_args['post-statuses'] );
+
 		$posts_total              = 0;
 		$posts_already_associated = 0;
 		$posts_missing_coauthor   = 0;
 		$posts_associated         = 0;
 		$posts_keeping_author     = 0;
+		$posts_missing_meta_value = 0;
 		$missing_coauthors        = array();
 
 		$posts = new WP_Query( $parsed_args );
@@ -101,25 +113,22 @@ class Assign_Coauthors_Command {
 			foreach ( $posts->posts as $single_post ) {
 				$posts_total++;
 
-				// See if the value in the post meta field is the same as any of the existing co-authors.
-				$original_author    = get_post_meta( $single_post->ID, $parsed_args['meta_key'], true );
-				$existing_coauthors = get_coauthors( $single_post->ID );
-				$already_associated = false;
-				foreach ( $existing_coauthors as $existing_coauthor ) {
-					if ( $original_author == $existing_coauthor->user_login ) {
-						$already_associated = true;
-						break;
-					}
-				}
-				if ( $already_associated ) {
-					$posts_already_associated++;
-					WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' already has "' . $original_author . '" associated as a co-author' );
+				$original_author = get_post_meta( $single_post->ID, $parsed_args['meta_key'], true );
+
+				// The query matches on the key existing, so the value can still be empty. An
+				// empty value names no co-author, so it is not a missing profile and must not
+				// join the missing list, where it imploded into a dangling comma.
+				if ( '' === $original_author ) {
+					$posts_missing_meta_value++;
+					WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' has an empty ' . $parsed_args['meta_key'] . ' value' );
 					continue;
 				}
 
-				// Make sure this original author exists as a co-author. The.
-				// meta value is tried as given and then as a slug, which is.
-				// how it is stored once an importer has been through it.
+				// Resolve the co-author before deciding anything. The meta value is tried as
+				// given and then as a slug, which is how it is stored once an importer has
+				// been through it. Everything below then works from the resolved co-author
+				// rather than the raw value, so a second run recognises its own work and the
+				// log names who was really assigned.
 				$coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $original_author );
 
 				if ( ! $coauthor ) {
@@ -133,11 +142,29 @@ class Assign_Coauthors_Command {
 					continue;
 				}
 
+				// Only a real author term counts as already associated. get_coauthors() falls
+				// back to the post_author user when a post has no terms, and treating that as
+				// done left the post with no term at all — invisible to every term-driven
+				// query, this plugin's own included.
+				$existing_coauthors = cap_get_coauthor_terms_for_post( $single_post->ID ) ? get_coauthors( $single_post->ID ) : array();
+				$already_associated = false;
+				foreach ( $existing_coauthors as $existing_coauthor ) {
+					if ( $coauthor->user_login === $existing_coauthor->user_login ) {
+						$already_associated = true;
+						break;
+					}
+				}
+				if ( $already_associated ) {
+					$posts_already_associated++;
+					WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' already has "' . $coauthor->user_login . '" associated as a co-author' );
+					continue;
+				}
+
 				// Assign the co-author to the post. The byline is written either way; a
 				// false return means only that post_author could not be pointed at a
 				// WordPress user, which is the norm for a guest author with no account.
 				$post_author_synced = $coauthors_plus->add_coauthors( $single_post->ID, array( $coauthor->user_nicename ), $append_coauthors );
-				WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' has been assigned "' . $original_author . '" as the author' );
+				WP_CLI::log( $posts_total . ': Post #' . $single_post->ID . ' has been assigned "' . $coauthor->user_login . '" as the author' );
 				$posts_associated++;
 
 				if ( ! $post_author_synced ) {
@@ -151,6 +178,12 @@ class Assign_Coauthors_Command {
 			$posts = new WP_Query( $parsed_args );
 		}//end while
 
+		if ( 0 === $posts_total ) {
+			WP_CLI::log( sprintf( 'No posts found with the "%s" meta key.', $parsed_args['meta_key'] ) );
+
+			return;
+		}
+
 		WP_CLI::log( 'All done! Here are your results:' );
 		if ( $posts_already_associated ) {
 			WP_CLI::log( "- {$posts_already_associated} posts already had the co-author assigned" );
@@ -158,6 +191,21 @@ class Assign_Coauthors_Command {
 		if ( $posts_missing_coauthor ) {
 			WP_CLI::log( "- {$posts_missing_coauthor} posts reference co-authors that don't exist. These are:" );
 			WP_CLI::log( '  ' . implode( ', ', array_unique( $missing_coauthors ) ) );
+		}
+		if ( $posts_missing_meta_value ) {
+			WP_CLI::log(
+				'- ' . sprintf(
+					/* translators: 1: Count of posts. 2: Post meta key. */
+					_n(
+						'%1$s post has an empty %2$s value',
+						'%1$s posts have an empty %2$s value',
+						$posts_missing_meta_value,
+						'co-authors-plus'
+					),
+					number_format_i18n( $posts_missing_meta_value ),
+					$parsed_args['meta_key']
+				)
+			);
 		}
 		if ( $posts_associated ) {
 			WP_CLI::log( "- {$posts_associated} posts now have the proper co-author" );


### PR DESCRIPTION
## Summary

Six faults in one method, all variations on the same theme: the command acted on the raw meta value rather than on the co-author it had actually resolved.

**The worst is a write storm.** The already-associated check compared the raw meta value against an existing co-author's `user_login`, while assignment passed the resolved `user_nicename`. Meta of `Author One` assigns `author-one`; the next run compares `Author One` against `author-one`, never matches, and assigns again. Every such post has its byline rewritten on every run, indefinitely — and the scenario covering it was pinned as intended behaviour, which is how it survived.

Resolving the co-author before deciding anything closes it, and closes more than the catalogue described. `CoAuthors_Plus::get_user_by()` also retries after stripping a `cap-` prefix, and guest-author lookups sanitise on every call, so meta of `cap-author1` was non-idempotent by exactly the same mechanism. Patching the comparison to also try `sanitize_title()` would have fixed one case and left the other; comparing against the resolved co-author catches both.

**The already-associated branch also returned before any term was written.** `get_coauthors()` falls back to the `post_author` user when a post has no author terms, so a post reachable only that way was declared done and left with no term at all — invisible to every term-driven query, this plugin's own included. Only a real author term counts now. The fallback in `get_coauthors()` is untouched; what changed is that this command no longer reads it as evidence of a byline.

**An empty meta value was treated as a missing co-author profile**, which it is not, and imploded into a dangling comma in the summary. It gets its own counter and message. A counter rather than filtering the missing list, because it buys an invariant worth having: every post reached now increments exactly one counter, so a non-empty run always prints at least one figure.

That matters for the last one. **A run matching nothing printed the results header and not a single number**, because every summary line is count-guarded. It now names the meta key it found nothing for — and without the empty-value counter above, a run over nothing but empty-meta posts would have reintroduced the bare header through a side door.

**Drafts carrying the meta key were invisible, with no way in** — `--post_status` is rejected outright by WP-CLI's synopsis check, so this was not a default but the only available behaviour.

## Judgement calls

**`--post-statuses` opts in rather than widening the default.** This command rewrites a byline per post, so widening would silently rewrite every draft on the site the next time someone ran a script they already had. That is the opposite of the call on `list-posts-without-terms`, where widening only ever surfaces more rows and hid nothing dangerous. Same flag name and default as `create-terms-for-posts`, which is the closest analogue.

Worth flagging for the changelog: naming the status explicitly is a **narrowing** for anyone running `wp --user=admin co-authors-plus assign-coauthors` today, whose private posts are currently swept in by `WP_Query`'s logged-in default. Deliberate — scope should not depend on who you impersonate — but a real behaviour change, and no scenario covers it.

**What I deliberately did not do:** normalise what is passed to `add_coauthors()` from `user_nicename` to `user_login`. It looks like the tidier finish and it is a trap. `add_coauthors()` resolves names with `$query_type = 'user_nicename'`, so a login whose nicename differs — `john.doe` against `john-doe` — would fail that lookup, `update_author_term( false )` returns false, the slug substitution is skipped, and an unprefixed `john.doe` term gets written. That is now recorded in the behaviour notes as a trap rather than left to be rediscovered.

## Test plan

- [x] `features/assign-coauthors.feature` green at 12 scenarios / 175 steps, up from 11
- [x] Four scenarios failed against the patched code before re-pinning, exactly the predicted set
- [x] The idempotence scenario now prints *different* text on its two runs, where before both printed the same line — so it discriminates where it previously could not
- [x] PHPCS clean by exit code
- [ ] Full Behat suite via CI