### PR TITLE
Keep term commands registered when guest authors are disabled

### DIFF
--- a/features/testing.feature
+++ b/features/testing.feature
@@ -11,6 +11,9 @@
 
   # Add every new subcommand here. This guard is what fails first if one stops
   # being registered, so a command missing from the list is silently unguarded.
+  # A name that is a substring of a longer command name (create-author inside
+  # create-author-terms-for-posts, say) must use an anchored regex, or its
+  # entry passes vacuously while the command is missing.
   Scenario: All expected subcommands remain registered
     Given a WP installation with the Co-Authors Plus plugin
 
@@ -23,18 +26,12 @@
       """
       assign-user-to-coauthor
       """
-    And STDOUT should contain:
-      """
-      create-author
-      """
+    And STDOUT should match /^\s+create-author\s/m
     And STDOUT should contain:
       """
       create-author-terms-for-posts
       """
-    And STDOUT should contain:
-      """
-      create-guest-authors
-      """
+    And STDOUT should match /^\s+create-guest-authors\s/m
     And STDOUT should contain:
       """
       create-guest-authors-from-csv
@@ -91,3 +88,43 @@
       """
       update-author-terms
       """
+
+  # Guest authors can be switched off with the coauthors_guest_authors_enabled
+  # filter. Only the commands that read or write guest author profiles should
+  # disappear with them; the term-based commands must stay registered. The
+  # filter is planted through a --require file, which WP-CLI loads before
+  # WordPress, so it is in place when the plugin decides what to register. The
+  # file sits in wp-content because /tmp does not survive a fresh container.
+  # Anchored regexes, because several names are substrings of longer ones.
+  Scenario: Term-based commands stay registered when guest authors are disabled
+    Given a WP installation with the Co-Authors Plus plugin
+
+    When I run `eval 'file_put_contents( "/var/www/html/wp-content/cap-disable-guest-authors.php", base64_decode( "PD9waHAKV1BfQ0xJOjphZGRfd3BfaG9vayggJ2NvYXV0aG9yc19ndWVzdF9hdXRob3JzX2VuYWJsZWQnLCAnX19yZXR1cm5fZmFsc2UnICk7Cg==" ) );'`
+    And I run `--require=/var/www/html/wp-content/cap-disable-guest-authors.php co-authors-plus --help`
+    Then STDOUT should contain:
+      """
+      Manage co-authors and guest authors.
+      """
+    And STDOUT should match /^\s+assign-coauthors\s/m
+    And STDOUT should match /^\s+assign-user-to-coauthor\s/m
+    And STDOUT should match /^\s+create-author-terms-for-posts\s/m
+    And STDOUT should match /^\s+create-terms-for-posts\s/m
+    And STDOUT should match /^\s+delete-postmeta-that-skip-author-term-backfill\s/m
+    And STDOUT should match /^\s+list-authors\s/m
+    And STDOUT should match /^\s+list-posts-without-terms\s/m
+    And STDOUT should match /^\s+migrate-author-terms\s/m
+    And STDOUT should match /^\s+reassign-terms\s/m
+    And STDOUT should match /^\s+remove-terms-from-revisions\s/m
+    And STDOUT should match /^\s+rename-coauthor\s/m
+    And STDOUT should match /^\s+swap-coauthors\s/m
+    And STDOUT should match /^\s+update-author-terms\s/m
+    And STDOUT should not match /^\s+create-author\s/m
+    And STDOUT should not match /^\s+create-guest-authors\s/m
+    And STDOUT should not match /^\s+create-guest-authors-from-csv\s/m
+    And STDOUT should not match /^\s+create-guest-authors-from-wxr\s/m
+    And STDOUT should not match /^\s+export-coauthors\s/m
+    And STDOUT should not match /^\s+import-coauthors\s/m
+
+    When I run `eval 'unlink( "/var/www/html/wp-content/cap-disable-guest-authors.php" );'`
+    And I run `co-authors-plus --help`
+    Then STDOUT should match /^\s+create-guest-authors\s/m

--- a/php/cli/register-commands.php
+++ b/php/cli/register-commands.php
@@ -77,26 +77,14 @@ add_action(
 	static function (): void {
 		global $coauthors_plus;
 
-		// Guest authors can be switched off, in which case the plugin never
-		// builds the instance and there is nothing for these commands to act
-		// on. The rest of the guest author functionality is loaded on the same
-		// condition, so leaving them unregistered is consistent with it.
-		if ( ! $coauthors_plus instanceof CoAuthors_Plus || ! $coauthors_plus->guest_authors instanceof CoAuthors_Guest_Authors ) {
+		if ( ! $coauthors_plus instanceof CoAuthors_Plus ) {
 			return;
 		}
 
-		$creator       = new Guest_Author_Creator( $coauthors_plus );
-		$assignments   = new Coauthor_Assignment_Service( $coauthors_plus );
-		$guest_authors = new Guest_Author_Service( $coauthors_plus->guest_authors );
-
-		WP_CLI::add_command(
-			'co-authors-plus export-coauthors',
-			new Export_Coauthors_Command(
-				$coauthors_plus,
-				new Coauthor_Export_Service( $coauthors_plus, $guest_authors, $assignments )
-			)
-		);
-
+		// Most commands work on author terms and bylines, which exist whether
+		// or not guest authors are enabled, so they are registered whenever the
+		// plugin is loaded. Only the commands that read or write guest author
+		// profiles are withheld when the feature is switched off, further down.
 		WP_CLI::add_command(
 			'co-authors-plus migrate-author-terms',
 			new Migrate_Author_Terms_Command( $coauthors_plus )
@@ -115,26 +103,6 @@ add_action(
 		WP_CLI::add_command(
 			'co-authors-plus rename-coauthor',
 			new Rename_Coauthor_Command( $coauthors_plus )
-		);
-
-		WP_CLI::add_command(
-			'co-authors-plus create-author',
-			new Create_Author_Command( $creator )
-		);
-
-		WP_CLI::add_command(
-			'co-authors-plus create-guest-authors',
-			new Create_Guest_Authors_Command( $coauthors_plus )
-		);
-
-		WP_CLI::add_command(
-			'co-authors-plus create-guest-authors-from-csv',
-			new Create_Guest_Authors_From_Csv_Command( $creator )
-		);
-
-		WP_CLI::add_command(
-			'co-authors-plus create-guest-authors-from-wxr',
-			new Create_Guest_Authors_From_Wxr_Command( $creator )
 		);
 
 		WP_CLI::add_command(
@@ -184,6 +152,46 @@ add_action(
 		WP_CLI::add_command(
 			'co-authors-plus swap-coauthors',
 			new Swap_Coauthors_Command( $coauthors_plus )
+		);
+
+		// Guest authors can be switched off, in which case the plugin never
+		// builds the instance and there is nothing for these commands to act
+		// on. The rest of the guest author functionality is loaded on the same
+		// condition, so leaving them unregistered is consistent with it.
+		if ( ! $coauthors_plus->guest_authors instanceof CoAuthors_Guest_Authors ) {
+			return;
+		}
+
+		$creator       = new Guest_Author_Creator( $coauthors_plus );
+		$assignments   = new Coauthor_Assignment_Service( $coauthors_plus );
+		$guest_authors = new Guest_Author_Service( $coauthors_plus->guest_authors );
+
+		WP_CLI::add_command(
+			'co-authors-plus export-coauthors',
+			new Export_Coauthors_Command(
+				$coauthors_plus,
+				new Coauthor_Export_Service( $coauthors_plus, $guest_authors, $assignments )
+			)
+		);
+
+		WP_CLI::add_command(
+			'co-authors-plus create-author',
+			new Create_Author_Command( $creator )
+		);
+
+		WP_CLI::add_command(
+			'co-authors-plus create-guest-authors',
+			new Create_Guest_Authors_Command( $coauthors_plus )
+		);
+
+		WP_CLI::add_command(
+			'co-authors-plus create-guest-authors-from-csv',
+			new Create_Guest_Authors_From_Csv_Command( $creator )
+		);
+
+		WP_CLI::add_command(
+			'co-authors-plus create-guest-authors-from-wxr',
+			new Create_Guest_Authors_From_Wxr_Command( $creator )
 		);
 
 		WP_CLI::add_command(


### PR DESCRIPTION
## Summary

Splitting the monolithic WP-CLI class into per-command classes moved registration into `php/cli/register-commands.php`, whose init callback returned early whenever `$coauthors_plus->guest_authors` was not a `CoAuthors_Guest_Authors` instance. That instance is never built on sites that filter `coauthors_guest_authors_enabled` to false — so disabling guest authors now removed every one of the nineteen commands, where the old `CoAuthorsPlus_Command` class was registered unconditionally and its term and assignment commands worked fine with the feature off.

The gate now covers only the six commands that genuinely dereference the guest authors instance: `export-coauthors` and `import-coauthors` (their services type-hint `CoAuthors_Guest_Authors` in the constructor, so building them would fatal) and the four guest author creators (`create-author`, `create-guest-authors`, `create-guest-authors-from-csv`, `create-guest-authors-from-wxr`). The remaining thirteen commands, and the namespace declaration, register unconditionally; each was checked for runtime dereferences and either touches only terms and taxonomy, or self-guards the guest author path (`get_coauthor_by()`, `update-author-terms`' own `instanceof` check, `rename-coauthor`'s type branch).

A new scenario in `features/testing.feature` pins the split: it installs the disabling filter through a WP-CLI `--require` file (loaded before WordPress, so it is live when registration decides), asserts the term commands remain and the guest author commands are gone, then removes the file and confirms full registration returns. The same file's registration guard also had two entries that could never fail on their own — `create-author` and `create-guest-authors` are substrings of longer command names, so a plain contains-check matched those instead. Both now use line-anchored matches, with a comment warning future additions about the trap.

## Test plan

- [x] `features/testing.feature` passes via Behat locally (3 scenarios, including the new disabled-guest-authors scenario)
- [x] Unit suite (119 tests) and integration suite (354 tests) pass locally
- [ ] CI Behat matrix