### PR TITLE
Close the coverage gaps an adversarial review found

### DIFF
--- a/features/assign-user-to-coauthor.feature
+++ b/features/assign-user-to-coauthor.feature
@@ -4,6 +4,15 @@ Feature: Posts can be assigned from a user to a co-author
 		Given a WP installation with the Co-Authors Plus plugin
 		And I run `wp co-authors-plus create-guest-authors`
 
+	Scenario: Error on a missing required --coauthor parameter
+		When I try `wp co-authors-plus assign-user-to-coauthor --user_id=1`
+		Then STDERR should be:
+		"""
+		Error: Parameter errors:
+		 missing --coauthor parameter (The co-author to give the byline to.)
+		"""
+		And the return code should be 1
+
 	Scenario: Error when neither --user_login nor --user_id is supplied
 		When I try `wp co-authors-plus assign-user-to-coauthor --coauthor=admin`
 		Then STDERR should be:

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -364,6 +364,35 @@ Feature: Missing author terms can be backfilled for targeted posts
 		nonexistent_post_author_id
 		"""
 
+	Scenario: The skip tally is pluralised when more than one post is skipped
+		When I run `wp post create --post_title="First nobody post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Second nobody post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		Then STDOUT should be:
+		"""
+		Found 2 posts with missing author terms.
+		Processing post {POST_A} (1/2 or 50.00%)
+		Warning: Post Author ID 0 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
+		Processing post {POST_B} (2/2 or 100.00%)
+		Warning: Post Author ID 0 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
+		0 records affected
+		Warning: 2 posts were skipped and marked with `_cap_skip_backfill`.
+		Updating author terms with new counts
+		Success: Done!
+		"""
+		When I run `wp post meta get {POST_A} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
+		"""
+		When I run `wp post meta get {POST_B} _cap_skip_backfill`
+		Then STDOUT should be:
+		"""
+		nonexistent_post_author_id
+		"""
+
 	Scenario: Batches are re-queried when --records-per-batch is smaller than the total, and a skipped post does not stall progress
 		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
 		And save STDOUT as {ORPHAN_ID}
@@ -470,6 +499,23 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And the return code should be 0
 		# The orphan is named second on purpose: the run used to abort on the first
 		# post and never reach it, so this assertion is what fails without the fix.
+		When I run `wp post meta list {ORPHAN_ID} --keys=_cap_skip_backfill --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+
+	Scenario: A non-numeric entry in --specific-post-ids is ignored with a warning while valid IDs are still processed
+		When I run `wp post create --post_title="Orphan post" --post_status=publish --post_author=999 --porcelain`
+		And save STDOUT as {ORPHAN_ID}
+		And I run `wp co-authors-plus create-author-terms-for-posts`
+		When I run `wp co-authors-plus delete-postmeta-that-skip-author-term-backfill --specific-post-ids=abc,{ORPHAN_ID}`
+		Then STDOUT should be:
+		"""
+		Warning: Ignoring non-numeric post ID `abc` in --specific-post-ids.
+		Success: Deleted `_cap_skip_backfill` postmeta from post {ORPHAN_ID}.
+		"""
+		And the return code should be 0
 		When I run `wp post meta list {ORPHAN_ID} --keys=_cap_skip_backfill --format=count`
 		Then STDOUT should be:
 		"""

--- a/features/create-guest-authors-from-csv.feature
+++ b/features/create-guest-authors-from-csv.feature
@@ -10,9 +10,10 @@ Feature: Guest authors can be created from a CSV file
 	Scenario: Error on a missing required --file parameter
 		When I try `wp co-authors-plus create-guest-authors-from-csv`
 		Then the return code should be 1
-		And STDERR should contain:
+		And STDERR should be:
 		"""
-		missing --file parameter
+		Error: Parameter errors:
+		 missing --file parameter (Path to the CSV file.)
 		"""
 
 	Scenario: Error on a file that cannot be read
@@ -228,6 +229,8 @@ Feature: Guest authors can be created from a CSV file
 
 	Scenario: A row that fails validation is warned about and the import carries on
 		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-invalid-row.csv`
+		# The bulk importers deliberately exit 0 when some rows fail: the drop is
+		# reported through the tally warning below, not as an error.
 		Then the return code should be 0
 		And STDOUT should contain:
 		"""
@@ -244,6 +247,11 @@ Feature: Guest authors can be created from a CSV file
 		And STDOUT should contain:
 		"""
 		Processing author valid-person (valid@example.com)
+		"""
+		# "1 of 2" also pins the sprintf argument order: failed count first, total second.
+		And STDOUT should contain:
+		"""
+		Warning: 1 of 2 authors could not be created.
 		"""
 		And STDOUT should contain:
 		"""

--- a/features/create-guest-authors-from-wxr.feature
+++ b/features/create-guest-authors-from-wxr.feature
@@ -21,9 +21,10 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 	Scenario: Error on a missing required --file parameter
 		When I try `wp co-authors-plus create-guest-authors-from-wxr`
 		Then the return code should be 1
-		And STDERR should contain:
+		And STDERR should be:
 		"""
-		missing --file parameter
+		Error: Parameter errors:
+		 missing --file parameter (Path to the WXR file.)
 		"""
 
 	Scenario: Error on a file that cannot be read
@@ -150,6 +151,50 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		Then STDOUT should be:
 		"""
 		0
+		"""
+
+	Scenario: An author node that fails validation is warned about and the import carries on
+		When I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors-invalid-author.wxr`
+		# The bulk importers deliberately exit 0 when some authors fail: the drop is
+		# reported through the tally warning below, not as an error.
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Processing author wxr-good-one (wxr-good-one@example.com)
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author wxr-no-display-name (wxr-no-display-name@example.com)
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: -- Failed to create guest author: display_name is a required field
+		"""
+		And STDOUT should contain:
+		"""
+		Processing author wxr-good-two (wxr-good-two@example.com)
+		"""
+		# "1 of 3" also pins the sprintf argument order: failed count first, total second.
+		And STDOUT should contain:
+		"""
+		Warning: 1 of 3 authors could not be created.
+		"""
+		And STDOUT should contain:
+		"""
+		All done!
+		"""
+		# The bad node sits between the two good ones, so both profiles existing
+		# proves the import carried on past the failure.
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		2
+		"""
+		When I run `wp post list --post_type=guest-author --field=post_name --order=asc --orderby=ID`
+		Then STDOUT should be:
+		"""
+		cap-wxr-good-one
+		cap-wxr-good-two
 		"""
 
 	Scenario: Importing the same WXR file twice skips the existing guest authors

--- a/features/create-terms-for-posts.feature
+++ b/features/create-terms-for-posts.feature
@@ -242,3 +242,39 @@ Feature: Author terms can be created for all posts
 		"""
 		cap-admin
 		"""
+
+	Scenario: Several statuses can be targeted at once with a comma separated --post-statuses
+		When I run `wp post create --post_title="Published post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post create --post_title="Draft post" --post_author=1 --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post create --post_title="Pending post" --post_status=pending --post_author=1 --porcelain`
+		And save STDOUT as {POST_C}
+		And I run `wp post term remove {POST_A} author --all`
+		And I run `wp post term remove {POST_B} author --all`
+		And I run `wp post term remove {POST_C} author --all`
+		And I run `wp co-authors-plus create-terms-for-posts --post-statuses=publish,draft`
+		Then STDOUT should be:
+		"""
+		Now inspecting or updating 2 total posts.
+		No co-authors found for post #{POST_A}.
+		1/2) Added - Post #{POST_A} 'Published post' now has this author term: cap-admin
+		No co-authors found for post #{POST_B}.
+		2/2) Added - Post #{POST_B} 'Draft post' now has this author term: cap-admin
+		Success: Done! Of 2 posts, 2 now have author terms.
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp term list author --object_ids={POST_B} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp term list author --object_ids={POST_C} --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""

--- a/features/fixtures/guest-authors-invalid-author.wxr
+++ b/features/fixtures/guest-authors-invalid-author.wxr
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+	<title>Invalid Guest Author Fixture</title>
+	<link>https://example.com</link>
+	<description>WXR fixture with one author node missing its display name</description>
+	<pubDate>Mon, 01 Sep 2025 00:00:00 +0000</pubDate>
+	<language>en-US</language>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://example.com</wp:base_site_url>
+	<wp:base_blog_url>https://example.com</wp:base_blog_url>
+	<wp:author>
+		<wp:author_id>201</wp:author_id>
+		<wp:author_login><![CDATA[wxr-good-one]]></wp:author_login>
+		<wp:author_email><![CDATA[wxr-good-one@example.com]]></wp:author_email>
+		<wp:author_display_name><![CDATA[WXR Good One]]></wp:author_display_name>
+		<wp:author_first_name><![CDATA[WXR]]></wp:author_first_name>
+		<wp:author_last_name><![CDATA[One]]></wp:author_last_name>
+	</wp:author>
+	<wp:author>
+		<wp:author_id>202</wp:author_id>
+		<wp:author_login><![CDATA[wxr-no-display-name]]></wp:author_login>
+		<wp:author_email><![CDATA[wxr-no-display-name@example.com]]></wp:author_email>
+		<wp:author_display_name></wp:author_display_name>
+		<wp:author_first_name></wp:author_first_name>
+		<wp:author_last_name></wp:author_last_name>
+	</wp:author>
+	<wp:author>
+		<wp:author_id>203</wp:author_id>
+		<wp:author_login><![CDATA[wxr-good-two]]></wp:author_login>
+		<wp:author_email><![CDATA[wxr-good-two@example.com]]></wp:author_email>
+		<wp:author_display_name><![CDATA[WXR Good Two]]></wp:author_display_name>
+		<wp:author_first_name><![CDATA[WXR]]></wp:author_first_name>
+		<wp:author_last_name><![CDATA[Two]]></wp:author_last_name>
+	</wp:author>
+</channel>
+</rss>

--- a/features/import-coauthors.feature
+++ b/features/import-coauthors.feature
@@ -6,9 +6,10 @@ Feature: Guest authors and their post assignments can be imported
 
 	Scenario: Error when no file is given
 		When I try `wp co-authors-plus import-coauthors`
-		Then STDERR should contain:
+		Then STDERR should be:
 		"""
-		missing --file parameter
+		Error: Parameter errors:
+		 missing --file parameter (The file to read, as written by export-coauthors.)
 		"""
 		And the return code should be 1
 
@@ -67,6 +68,48 @@ Feature: Guest authors and their post assignments can be imported
 		Then STDOUT should be:
 		"""
 		cap-jane-doe
+		"""
+
+	# The byline order here is deliberately neither alphabetical nor the order
+	# the profiles were created in, so only the recorded positions can restore
+	# it. The probe reads term_order the same way the plugin's own read path
+	# does.
+	Scenario: A multi-author byline comes back in its original order
+		When I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Alice Smith", "user_login" => "alice-smith" ) );'`
+		And I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Bob Jones", "user_login" => "bob-jones" ) );'`
+		And I run `wp eval 'echo $GLOBALS["coauthors_plus"]->guest_authors->create( array( "display_name" => "Carol King", "user_login" => "carol-king" ) );'`
+		And I run `wp post create --post_status=publish --post_title="Hello" --post_name=hello --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval 'wp_set_post_terms( {POST_ID}, array( "cap-carol-king", "cap-alice-smith", "cap-bob-jones" ), "author" );'`
+		When I run `wp eval 'echo implode( ",", wp_list_pluck( wp_get_object_terms( {POST_ID}, "author", array( "orderby" => "term_order" ) ), "slug" ) );'`
+		Then STDOUT should be:
+		"""
+		cap-carol-king,cap-alice-smith,cap-bob-jones
+		"""
+
+		When I run `wp co-authors-plus export-coauthors --file=/tmp/cap-order.json`
+		Then STDOUT should be:
+		"""
+		Success: Exported 3 guest authors to /tmp/cap-order.json
+		"""
+
+		# Wipe the site clean: profiles, author terms and the post itself.
+		When I run `wp eval 'foreach ( get_posts( array( "post_type" => "guest-author", "post_status" => "any", "numberposts" => -1 ) ) as $p ) { wp_delete_post( $p->ID, true ); }'`
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+		And I run `wp post delete {POST_ID} --force`
+		And I run `wp post create --post_status=publish --post_title="Hello" --post_name=hello --porcelain`
+		And save STDOUT as {NEW_POST_ID}
+
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-order.json`
+		Then STDOUT should be:
+		"""
+		Success: Created 3 profiles and linked 3 posts.
+		"""
+		And the return code should be 0
+		When I run `wp eval 'echo implode( ",", wp_list_pluck( wp_get_object_terms( {NEW_POST_ID}, "author", array( "orderby" => "term_order" ) ), "slug" ) );'`
+		Then STDOUT should be:
+		"""
+		cap-carol-king,cap-alice-smith,cap-bob-jones
 		"""
 
 	Scenario: A dry run reports what it would do and writes nothing

--- a/features/reassign-terms.feature
+++ b/features/reassign-terms.feature
@@ -132,6 +132,38 @@ Feature: Author terms can be reassigned between co-authors
 		cap-newuser
 		"""
 
+	# The self-reassignment guard compares resolved term IDs, not the raw inputs:
+	# here the same co-author is named two ways, so an implementation comparing
+	# input strings would take the merge path and delete the term onto itself.
+	Scenario: A numeric --new-term resolving to the old term's own user is skipped as a self-reassignment
+		When I run `wp user create olduser olduser@example.com --role=author --porcelain`
+		And save STDOUT as {OLDUSER_ID}
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp post create --post_title="Owned post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term add {POST_ID} author cap-olduser`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term={OLDUSER_ID}`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Warning: Term 'olduser' is already 'olduser', skipping
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 0 authors had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-olduser
+		"""
+		When I run `wp term list author --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		cap-olduser
+		"""
+
 	Scenario: A numeric --new-term for an unknown user id is skipped
 		When I run `wp user create olduser olduser@example.com --role=author`
 		And I run `wp co-authors-plus create-guest-authors`

--- a/php/cli/class-delete-skip-backfill-postmeta-command.php
+++ b/php/cli/class-delete-skip-backfill-postmeta-command.php
@@ -66,6 +66,16 @@ class Delete_Skip_Backfill_Postmeta_Command {
 		}
 
 		foreach ( $specific_post_ids as $post_id ) {
+			// A stray non-numeric entry used to be cast to 0 and reported as
+			// "post 0", which reads as a real post. Name it and move on, so the
+			// valid IDs in the same list are still processed. Checked here rather
+			// than before the empty() fallback: emptying the user's list there
+			// would silently widen the run to every marker on the site.
+			if ( ! is_numeric( $post_id ) ) {
+				WP_CLI::warning( sprintf( 'Ignoring non-numeric post ID `%s` in --specific-post-ids.', $post_id ) );
+				continue;
+			}
+
 			$post_id = (int) $post_id;
 
 			// A post that never carried the marker is not a failure, and aborting on one
@@ -76,6 +86,6 @@ class Delete_Skip_Backfill_Postmeta_Command {
 			} else {
 				WP_CLI::warning( sprintf( 'No `%s` postmeta to delete on post %d.', $meta_key, $post_id ) );
 			}
-		}
+		}//end foreach
 	}
 }

--- a/php/services/class-coauthor-assignment-service.php
+++ b/php/services/class-coauthor-assignment-service.php
@@ -102,7 +102,9 @@ class Coauthor_Assignment_Service {
 	 * add_coauthors(), whose return value does not mean what it appears to: it
 	 * returns false when replacing a byline that resolves to no WordPress user,
 	 * which is every byline made up only of guest authors without linked
-	 * accounts, having written the terms perfectly well.
+	 * accounts, having written the terms perfectly well. A false is therefore
+	 * ambiguous, so it is settled by re-reading the terms: if the co-author is
+	 * now on the post the write landed, and if not it genuinely failed.
 	 *
 	 * @param int    $post_id  Post ID.
 	 * @param string $nicename user_nicename to add.
@@ -118,8 +120,10 @@ class Coauthor_Assignment_Service {
 
 		array_splice( $nicenames, min( $position, count( $nicenames ) ), 0, array( $nicename ) );
 
-		$this->assign( $post_id, $nicenames );
+		if ( $this->assign( $post_id, $nicenames ) ) {
+			return true;
+		}
 
-		return true;
+		return in_array( $nicename, $this->nicenames_for_post( $post_id ), true );
 	}
 }

--- a/src/__tests__/co-authors.test.js
+++ b/src/__tests__/co-authors.test.js
@@ -187,6 +187,31 @@ describe( 'CoAuthors author search', () => {
 	it( 'empties the dropdown when the search matches nobody', async () => {
 		await renderPanel();
 
+		// A first search fills the dropdown, so the emptying below is a real
+		// state change rather than [] staying [].
+		apiFetch.mockResolvedValue( [
+			{
+				id: 5,
+				termId: 42,
+				displayName: 'Ada Lovelace',
+				userNicename: 'ada',
+				email: 'ada@example.com',
+				userType: 'wpuser',
+			},
+		] );
+
+		act( () => {
+			comboboxProps.onFilterValueChange( 'ada' );
+		} );
+
+		await act( async () => {
+			jest.advanceTimersByTime( 500 );
+		} );
+
+		expect( comboboxProps.options ).not.toHaveLength( 0 );
+
+		apiFetch.mockResolvedValue( [] );
+
 		act( () => {
 			comboboxProps.onFilterValueChange( 'nobody' );
 		} );

--- a/tests/Integration/Admin/ClassicEditorAssetsTest.php
+++ b/tests/Integration/Admin/ClassicEditorAssetsTest.php
@@ -29,25 +29,38 @@ class ClassicEditorAssetsTest extends TestCase {
 		parent::set_up();
 
 		wp_set_current_user( $this->create_editor( 'assets_editor' )->ID );
-
-		// enqueue_scripts() bails unless it is on a whitelisted admin page for a
-		// post type that supports co-authors.
-		$GLOBALS['pagenow'] = 'post.php';
-		set_current_screen( 'post.php' );
-
-		$this->_cap->enqueue_scripts( 'post.php' );
 	}
 
 	public function tear_down() {
-		unset( $GLOBALS['pagenow'] );
+		// The dependency registries are process globals, so an enqueue made by
+		// one test would leak into the next and defeat the not-enqueued
+		// assertions. Unsetting them makes wp_scripts()/wp_styles() rebuild.
+		unset( $GLOBALS['pagenow'], $GLOBALS['wp_scripts'], $GLOBALS['wp_styles'] );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Run the enqueue callback as if on the given admin page.
+	 *
+	 * The enqueue_scripts() callback bails unless it is on a whitelisted admin
+	 * page for a post type that supports co-authors.
+	 *
+	 * @param string $pagenow The admin page filename, e.g. 'post.php'.
+	 */
+	private function enqueue_on( string $pagenow ): void {
+		$GLOBALS['pagenow'] = $pagenow;
+		set_current_screen( $pagenow );
+
+		$this->_cap->enqueue_scripts( $pagenow );
 	}
 
 	/**
 	 * The plugin's own script and style are enqueued.
 	 */
 	public function test_enqueues_the_co_authors_assets(): void {
+		$this->enqueue_on( 'post.php' );
+
 		$this->assertTrue( wp_script_is( 'co-authors-plus-js', 'enqueued' ) );
 		$this->assertTrue( wp_style_is( 'co-authors-plus-css', 'enqueued' ) );
 		$this->assertTrue( wp_script_is( 'jquery-ui-sortable', 'enqueued' ) );
@@ -62,6 +75,8 @@ class ClassicEditorAssetsTest extends TestCase {
 	 * other plugins would break.
 	 */
 	public function test_jquery_is_resolved_into_the_head_group(): void {
+		$this->enqueue_on( 'post.php' );
+
 		$scripts = wp_scripts();
 		$scripts->all_deps( $scripts->queue, true, 0 );
 
@@ -72,10 +87,26 @@ class ClassicEditorAssetsTest extends TestCase {
 	 * JQuery actually appears in the printed head scripts.
 	 */
 	public function test_jquery_is_printed_in_the_head(): void {
+		$this->enqueue_on( 'post.php' );
+
 		ob_start();
 		wp_print_head_scripts();
 		$head = (string) ob_get_clean();
 
 		$this->assertStringContainsString( 'jquery', $head );
+	}
+
+	/**
+	 * Nothing is enqueued on an admin page the plugin does not touch.
+	 *
+	 * The dashboard is not in the _pages_whitelist that is_valid_page() checks,
+	 * so the callback must bail before enqueueing anything.
+	 */
+	public function test_enqueues_nothing_on_an_unrelated_admin_page(): void {
+		$this->enqueue_on( 'index.php' );
+
+		$this->assertFalse( wp_script_is( 'co-authors-plus-js', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'co-authors-plus-css', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'jquery-ui-sortable', 'enqueued' ) );
 	}
 }

--- a/tests/Integration/Blocks/BlockCoAuthorsTemplateTest.php
+++ b/tests/Integration/Blocks/BlockCoAuthorsTemplateTest.php
@@ -42,6 +42,11 @@ class BlockCoAuthorsTemplateTest extends TestCase {
 	 * A parsed block whose inner content carries the line breaks and padding
 	 * the render pipeline is expected to strip.
 	 *
+	 * The newline between the two spans is deliberate: trim() only touches the
+	 * string's edges, so an interior line break is only removed by the
+	 * str_replace() step of the pipeline. Removing that step must fail these
+	 * tests.
+	 *
 	 * `core/null` is what get_block_as_template() substitutes for the real
 	 * block name, so rendering concatenates the inner content rather than
 	 * dispatching to a render callback.
@@ -54,12 +59,15 @@ class BlockCoAuthorsTemplateTest extends TestCase {
 			'attrs'        => array(),
 			'innerBlocks'  => array(),
 			'innerHTML'    => '',
-			'innerContent' => array( "\n\t<span>Byline</span>\n" ),
+			'innerContent' => array( "\n\t<span>By</span>\n<span>line</span>\n" ),
 		);
 	}
 
 	/**
 	 * Each author is wrapped, its line breaks removed and its edges trimmed.
+	 *
+	 * The expected markup has no newline between the spans and no leading tab:
+	 * the interior newline proves the str_replace() step, the edges prove trim().
 	 */
 	public function test_renders_each_author_trimmed_and_wrapped(): void {
 		$blocks = Block_CoAuthors::render_coauthors_blocks_with_template(
@@ -68,7 +76,7 @@ class BlockCoAuthorsTemplateTest extends TestCase {
 		);
 
 		$this->assertSame(
-			array( '<div class="wp-block-co-authors-plus-coauthor"><span>Byline</span></div>' ),
+			array( '<div class="wp-block-co-authors-plus-coauthor"><span>By</span><span>line</span></div>' ),
 			$blocks
 		);
 	}

--- a/tests/Integration/Bylines/AddCoauthorsTest.php
+++ b/tests/Integration/Bylines/AddCoauthorsTest.php
@@ -951,6 +951,71 @@ class AddCoauthorsTest extends TestCase {
 	}
 
 	/**
+	 * A failed author term must not drop the author from the byline.
+	 *
+	 * When wp_insert_term() fails, update_author_term() returns a WP_Error.
+	 * A WP_Error is an object too, so without the is_wp_error() guard in
+	 * add_coauthors(), reading `$term->slug` from it blanks the author name
+	 * and the author silently vanishes from the byline.
+	 *
+	 * The guard's actual contract: the raw name is kept and passed to
+	 * wp_set_post_terms(), which creates an *unprefixed* term for it (the
+	 * `cap-` prefix is only applied by update_author_term(), which is the
+	 * call that failed). get_coauthors() strips an optional `cap-` prefix
+	 * when resolving slugs, so the author still resolves and survives via
+	 * that unprefixed term. This test asserts exactly that behaviour.
+	 *
+	 * @covers ::add_coauthors
+	 */
+	public function test_author_is_not_lost_when_author_term_creation_fails(): void {
+		$post_id = $this->factory()->post->create(
+			array(
+				'post_author' => $this->author1->ID,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		/*
+		 * Fail term insertion only for author2's prefixed slug. Only
+		 * update_author_term() passes a slug argument, so the later insert
+		 * from within wp_set_post_terms() (no slug, unprefixed name) is
+		 * unaffected — that is the path the guard preserves.
+		 */
+		$failing_slug = 'cap-' . $this->author2->user_nicename;
+		$filter       = function ( $term, $taxonomy = '', $args = array() ) use ( $failing_slug ) {
+			if ( isset( $args['slug'] ) && $failing_slug === $args['slug'] ) {
+				return new \WP_Error( 'forced-term-failure', 'Simulated term insertion failure.' );
+			}
+			return $term;
+		};
+		add_filter( 'pre_insert_term', $filter, 10, 3 );
+
+		try {
+			$result = $this->_cap->add_coauthors(
+				$post_id,
+				array( $this->author1->user_login, $this->author2->user_login )
+			);
+		} finally {
+			remove_filter( 'pre_insert_term', $filter );
+		}
+
+		$this->assertTrue( $result );
+
+		// Both authors are still on the byline, in order.
+		$this->assertSame(
+			array( $this->author1->user_login, $this->author2->user_login ),
+			$this->get_coauthor_logins( $post_id )
+		);
+
+		// The survival route: author1 has the usual prefixed term, while
+		// author2 rode through wp_set_post_terms() as an unprefixed term.
+		$slugs = wp_list_pluck( wp_get_post_terms( $post_id, $this->_cap->coauthor_taxonomy ), 'slug' );
+		$this->assertContains( 'cap-' . $this->author1->user_nicename, $slugs );
+		$this->assertContains( $this->author2->user_nicename, $slugs );
+	}
+
+	/**
 	 * Returns the user_login of each of a post's co-authors, in byline order.
 	 *
 	 * @param int $post_id Post to read.

--- a/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
+++ b/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
@@ -150,9 +150,10 @@ class CreateGuestAuthorTest extends TestCase {
 	/**
 	 * Checks that creating a guest author via the create() method works end-to-end.
 	 *
-	 * Guest author posts have empty title/content (their data lives in post meta),
-	 * so this also guards that core does not reject them as "empty" — which holds
-	 * because the post type supports none of editor/title/excerpt.
+	 * Note: create() copies the display name into post_title, so the post it
+	 * inserts is never empty and core's "empty content" check cannot fire on
+	 * this path. The guard against re-adding title/editor/excerpt post type
+	 * support lives in test_empty_guest_author_post_is_not_rejected_as_empty().
 	 *
 	 * @covers CoAuthors_Guest_Authors::create()
 	 */
@@ -175,5 +176,41 @@ class CreateGuestAuthorTest extends TestCase {
 		$guest_author = $guest_author_obj->get_guest_author_by( 'ID', $guest_author_id );
 		$this->assertInstanceOf( \stdClass::class, $guest_author );
 		$this->assertEquals( 'Test Empty Content Author', $guest_author->display_name );
+	}
+
+	/**
+	 * A completely empty guest author post must not be rejected by core.
+	 *
+	 * Core's wp_insert_post() only refuses a post whose title, content and excerpt
+	 * are all empty when the post type supports all three of 'title',
+	 * 'editor' and 'excerpt' (the $maybe_empty check). The guest-author post
+	 * type deliberately supports only 'thumbnail', so a meta-only post with
+	 * nothing in those fields always saves — which is why the old
+	 * filter_wp_insert_post_empty_content() escape hatch could be deleted.
+	 *
+	 * This is the tripwire for that reasoning: if title, editor and excerpt
+	 * support are ever all re-added to the guest-author post type,
+	 * wp_insert_post() starts returning WP_Error( 'empty_content' ) here and
+	 * this test fails, flagging that empty guest author posts would again be
+	 * rejected without a replacement for the deleted filter.
+	 *
+	 * @covers CoAuthors_Guest_Authors::register_hooks()
+	 */
+	public function test_empty_guest_author_post_is_not_rejected_as_empty(): void {
+
+		global $coauthors_plus;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => $coauthors_plus->guest_authors->post_type,
+				'post_title'   => '',
+				'post_content' => '',
+				'post_excerpt' => '',
+			),
+			true
+		);
+
+		$this->assertIsInt( $post_id, 'An empty guest-author post should insert, not be rejected as empty content.' );
+		$this->assertGreaterThan( 0, $post_id );
 	}
 }

--- a/tests/Integration/Queries/CoauthorTaxonomyQueryGuardTest.php
+++ b/tests/Integration/Queries/CoauthorTaxonomyQueryGuardTest.php
@@ -120,11 +120,14 @@ class CoauthorTaxonomyQueryGuardTest extends TestCase {
 	/**
 	 * Create a published post of the given type and run an author query for it.
 	 *
-	 * @param string $post_type Post type to create and query.
-	 * @param string $shape     Author query shape.
+	 * @param string      $post_type       Post type to create, and to query unless overridden.
+	 * @param string      $shape           Author query shape.
+	 * @param string|null $query_post_type Optional post_type query var to use instead of
+	 *                                     $post_type. Pass 'any' or '' to exercise the
+	 *                                     guard's expansion and empty branches.
 	 * @return WP_Query
 	 */
-	private function query_for( string $post_type, string $shape ): WP_Query {
+	private function query_for( string $post_type, string $shape, ?string $query_post_type = null ): WP_Query {
 		$post_id = $this->factory()->post->create(
 			array(
 				'post_type'   => $post_type,
@@ -134,16 +137,16 @@ class CoauthorTaxonomyQueryGuardTest extends TestCase {
 			)
 		);
 
-		// Give the control post a real co-author term, so the rewrite it is
-		// meant to demonstrate has something to join against.
-		if ( self::SUPPORTED_TYPE === $post_type ) {
+		// Give a taxonomy-supported post a real co-author term, so the rewrite
+		// it is meant to demonstrate has something to join against.
+		if ( is_object_in_taxonomy( $post_type, $this->_cap->coauthor_taxonomy ) ) {
 			$this->_cap->add_coauthors( $post_id, array( $this->author->user_login ) );
 		}
 
 		return new WP_Query(
 			array_merge(
 				array(
-					'post_type'      => $post_type,
+					'post_type'      => $query_post_type ?? $post_type,
 					'posts_per_page' => 10,
 				),
 				$this->author_vars( $shape )
@@ -191,6 +194,45 @@ class CoauthorTaxonomyQueryGuardTest extends TestCase {
 	 */
 	public function test_still_rewrites_a_supported_post_type( string $shape ): void {
 		$query = $this->query_for( self::SUPPORTED_TYPE, $shape );
+
+		$this->assertStringContainsString( 'term_relationships', $query->request );
+		$this->assertCount( 1, $query->posts );
+	}
+
+	/**
+	 * A post_type => 'any' query still gets the co-author rewrite.
+	 *
+	 * The guard cannot ask the taxonomy about the literal string 'any', so it
+	 * expands it to the searchable post types first. 'post' is registered
+	 * against the author taxonomy, so the SQL must be rewritten exactly as it
+	 * is for a concrete supported type — without the expansion branch the
+	 * lookup fails and every 'any' author query silently loses its co-authors.
+	 *
+	 * @dataProvider data_author_query_shapes
+	 *
+	 * @param string $shape Author query shape.
+	 */
+	public function test_still_rewrites_an_any_post_type_query( string $shape ): void {
+		$query = $this->query_for( 'post', $shape, 'any' );
+
+		$this->assertStringContainsString( 'term_relationships', $query->request );
+		$this->assertCount( 1, $query->posts );
+	}
+
+	/**
+	 * A query with no post type set still gets the co-author rewrite.
+	 *
+	 * At filter time an author archive query can carry an empty post_type
+	 * query var. WordPress has not narrowed the query to anything the
+	 * taxonomy could exclude, so the guard must treat it as participating and
+	 * leave the rewrite in place.
+	 *
+	 * @dataProvider data_author_query_shapes
+	 *
+	 * @param string $shape Author query shape.
+	 */
+	public function test_still_rewrites_an_empty_post_type_query( string $shape ): void {
+		$query = $this->query_for( 'post', $shape, '' );
 
 		$this->assertStringContainsString( 'term_relationships', $query->request );
 		$this->assertCount( 1, $query->posts );

--- a/tests/Unit/Cli/ClearObjectCacheTest.php
+++ b/tests/Unit/Cli/ClearObjectCacheTest.php
@@ -32,6 +32,21 @@ use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
 final class ClearObjectCacheTest extends TestCase {
 
 	/**
+	 * Commands that process posts in batches and must flush the object cache
+	 * between batches.
+	 *
+	 * When adding a command that loops over a large result set, add its file
+	 * here so the flush cannot be dropped unnoticed.
+	 */
+	private const BATCHING_COMMANDS = array(
+		'class-assign-coauthors-command.php',
+		'class-create-terms-for-posts-command.php',
+		'class-list-posts-without-terms-command.php',
+		'class-swap-coauthors-command.php',
+		'class-update-author-terms-command.php',
+	);
+
+	/**
 	 * Absolute path to a file in the plugin root.
 	 *
 	 * @param string $relative Path relative to the repository root.
@@ -75,21 +90,31 @@ final class ClearObjectCacheTest extends TestCase {
 
 		$this->assertNotEmpty( $sources, 'The command classes must be readable for this check to mean anything.' );
 
-		$combined = '';
-
 		foreach ( $sources as $source ) {
 			$contents = (string) file_get_contents( $source );
 
 			$this->assertStringNotContainsString( 'stop_the_insanity', $contents, basename( $source ) );
 			$this->assertStringNotContainsString( 'memcache_debug', $contents, basename( $source ) );
-
-			$combined .= $contents;
 		}
+	}
 
-		$this->assertStringContainsString(
-			'\WP_CLI\Utils\wp_clear_object_cache();',
-			$combined,
-			'The long-running commands should still flush the object cache between batches.'
-		);
+	/**
+	 * Every batching command still flushes the object cache between batches.
+	 *
+	 * Checked per file, not across the directory as a whole, so one command
+	 * dropping its flush cannot hide behind another that kept it.
+	 */
+	public function test_each_batching_command_flushes_the_object_cache(): void {
+		foreach ( self::BATCHING_COMMANDS as $command ) {
+			$source = $this->path( 'php/cli/' . $command );
+
+			$this->assertFileExists( $source, "$command is listed as a batching command but does not exist. Update BATCHING_COMMANDS." );
+
+			$this->assertStringContainsString(
+				'\WP_CLI\Utils\wp_clear_object_cache();',
+				(string) file_get_contents( $source ),
+				"$command no longer flushes the object cache between batches. A long run would exhaust memory on a real site."
+			);
+		}
 	}
 }

--- a/tests/Unit/Cli/MigrateAuthorTermsCommandTest.php
+++ b/tests/Unit/Cli/MigrateAuthorTermsCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * WordPress-free unit tests for the migrate-author-terms command's error guard.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Cli;
+
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Automattic\CoAuthorsPlus\CLI\Migrate_Author_Terms_Command;
+use Brain\Monkey\Functions;
+use WP_CLI;
+use WP_CLI\ExitException;
+use WP_CLI\Loggers\Execution;
+
+/**
+ * The command halts when the taxonomy lookup itself fails.
+ *
+ * A get_terms() call returns a WP_Error when the taxonomy is not registered (for
+ * example when the command runs before init, or on a site where the plugin did
+ * not load). Without the guard the WP_Error fell through into array_filter()
+ * and the migration loop. The Behat suite cannot reach this branch — the
+ * taxonomy is always registered there — so it is pinned here with Brain Monkey.
+ *
+ * The real WP_CLI class is used (Composer loads it eagerly, so it cannot be
+ * alias-mocked): its Execution logger captures output in memory, and its own
+ * $capture_exit switch — the one runcommand() flips — makes error() throw
+ * ExitException instead of exiting the test process.
+ *
+ * @covers \Automattic\CoAuthorsPlus\CLI\Migrate_Author_Terms_Command::__invoke
+ */
+final class MigrateAuthorTermsCommandTest extends TestCase {
+
+	/**
+	 * In-memory logger capturing what the command writes.
+	 *
+	 * @var Execution
+	 */
+	private $logger;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->logger = new Execution();
+		WP_CLI::set_logger( $this->logger );
+		$this->set_capture_exit( true );
+	}
+
+	public function tear_down(): void {
+		$this->set_capture_exit( false );
+		WP_CLI::set_logger( null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Flip WP_CLI's private $capture_exit switch so error() throws instead of exiting.
+	 *
+	 * @param bool $capture Whether exits should be captured as ExitException.
+	 */
+	private function set_capture_exit( bool $capture ): void {
+		$property = new \ReflectionProperty( WP_CLI::class, 'capture_exit' );
+		$property->setAccessible( true );
+		$property->setValue( null, $capture );
+	}
+
+	/**
+	 * A failed term lookup is reported through WP_CLI::error() and nothing runs after it.
+	 */
+	public function test_invoke_errors_out_when_get_terms_fails(): void {
+		$error = \Mockery::mock( 'WP_Error' );
+		$error->shouldReceive( 'get_error_message' )->andReturn( 'Invalid taxonomy.' );
+
+		Functions\when( 'get_terms' )->justReturn( $error );
+		Functions\when( 'is_wp_error' )->alias(
+			static fn ( $thing ): bool => $thing instanceof \WP_Error
+		);
+
+		$command = new Migrate_Author_Terms_Command( \Mockery::mock( \CoAuthors_Plus::class ) );
+
+		try {
+			$command( array(), array() );
+			$this->fail( 'WP_CLI::error() should have halted the command when get_terms() failed.' );
+		} catch ( ExitException $e ) {
+			$this->assertSame( 1, $e->getCode(), 'The command should halt with exit code 1.' );
+		}
+
+		$this->assertStringContainsString( 'Invalid taxonomy.', $this->logger->stderr );
+		$this->assertSame( '', $this->logger->stdout, 'Nothing should be logged once the guard has fired.' );
+	}
+}

--- a/tests/Unit/Services/CoauthorAssignmentServiceTest.php
+++ b/tests/Unit/Services/CoauthorAssignmentServiceTest.php
@@ -133,7 +133,11 @@ final class CoauthorAssignmentServiceTest extends TestCase {
 	public function test_it_reports_a_change_even_when_add_coauthors_returns_false(): void {
 		list( $service, $coauthors_plus ) = $this->service();
 
-		Functions\when( 'wp_get_object_terms' )->justReturn( array() );
+		// Empty before the write, carrying the term after it: the false from
+		// add_coauthors() hid a successful write.
+		Functions\expect( 'wp_get_object_terms' )
+			->twice()
+			->andReturn( array(), $this->terms( array( 'cap-carol' ) ) );
 		Functions\when( 'is_wp_error' )->justReturn( false );
 
 		$coauthors_plus->shouldReceive( 'add_coauthors' )
@@ -142,6 +146,25 @@ final class CoauthorAssignmentServiceTest extends TestCase {
 			->andReturn( false );
 
 		$this->assertTrue( $service->add_at_position( 7, 'carol', 0 ) );
+	}
+
+	/**
+	 * When add_coauthors() returns false AND the re-read shows the co-author
+	 * never landed on the post, the write genuinely failed, and saying so is
+	 * what stops an import counting the post as linked.
+	 */
+	public function test_it_reports_failure_when_the_write_does_not_land(): void {
+		list( $service, $coauthors_plus ) = $this->service();
+
+		Functions\when( 'wp_get_object_terms' )->justReturn( array() );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		$coauthors_plus->shouldReceive( 'add_coauthors' )
+			->once()
+			->with( 7, array( 'carol' ), false )
+			->andReturn( false );
+
+		$this->assertFalse( $service->add_at_position( 7, 'carol', 0 ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

An adversarial re-review of the recent CLI audit and fix work traced every test change against the pre-fix code, asking one question of each: would this fail if the fix it accompanies were reverted? Most would. This PR closes the exceptions — guards that could not trip, and branches nothing exercised — plus two small production defects the review surfaced along the way.

The first production fix is in the import service: `add_at_position()` returned true unconditionally after writing a byline, so a failed term write was still counted as a linked post. The false from `add_coauthors()` cannot simply be propagated — it also reports false after successfully writing a guest-author-only byline — so on a false return the service now re-reads the post's terms and reports whether the co-author actually landed. The second is in the backfill postmeta deleter, where `(int)` casting turned a non-numeric `--specific-post-ids` entry into post 0; such entries now warn by name and are skipped while the valid entries in the same list are processed.

On the test side, five checks existed but could not fail for what they claimed. The guest author empty-content tripwire could never fire because `create()` copies the display name into `post_title`; a truly empty `wp_insert_post()` now pins core's rejection condition, and the misleading comment is corrected. The "matches nobody" dropdown test asserted an empty list stayed empty; it now populates first, then clears. The cache-flush check accepted one call anywhere in the concatenated command files; each batching command is now asserted individually, with failures naming the file. The block template fixture's newlines sat only at the edges, where `trim` masks the line-break removal; an interior newline now pins it. And the classic editor asset tests never visited an admin page the plugin ignores, so the bail-out path was unproven.

The rest is coverage for branches nothing reached: the `is_wp_error()` guard that stops `add_coauthors()` dropping an author when the term write fails (failure injected via `pre_insert_term`, scoped to the one insert), the `'any'` and empty post-type branches of the author query guard, the migrate command's `WP_Error` bail (unit-tested with WP-CLI's own logger capture), the importer failure tallies via a bad row mid-file in both the CSV and WXR features, the plural skip tally, comma-separated `--post-statuses`, a numeric `--new-term` resolving to the old term's own user, byline order surviving an export and import round trip on a real database, and the missing-parameter synopsis errors that were still loose contains-checks.

## Test plan

- [x] Unit suite: 129 tests pass locally
- [x] Integration suite via wp-env: 354 tests pass locally
- [x] JS suite: 85 tests pass locally
- [x] All eight touched Behat feature files pass locally
- [ ] CI matrix