### PR TITLE
Report a missing WordPress Importer instead of fataling

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -445,6 +445,28 @@ PHP 8.4) rather than inferred from reading the source.
   new scenario with two prefixed terms and one bare one exercises the count
   properly; the file previously never held more than two terms.
 
+- ~~A missing wordpress-importer plugin gives an uncaught PHP fatal from the
+  unguarded `require_once`, so an operator is handed a stack trace and WordPress's
+  generic critical-error line instead of being told which dependency to install.~~
+  **FIXED.** The path is checked first and reported with `WP_CLI::error()`. The
+  scenario that pinned the fatal now pins the clean error, and it discriminates: the
+  fixture genuinely uninstalls the plugin, so the guard's failure branch is executed
+  rather than assumed.
+- The importer path also moved from `WP_CONTENT_DIR . '/plugins'` to
+  `WP_PLUGIN_DIR`, which is the constant WordPress provides for exactly this and
+  respects a relocated plugin directory. **Stated plainly: no test discriminates
+  this.** In the default environment the two constants resolve to the same path, and
+  the scenario matches the path with a wildcard, so it passes either way. It ships on
+  the reasoning that a site with `WP_PLUGIN_DIR` set elsewhere would otherwise be
+  told the importer is missing when it is merely somewhere else.
+- STILL OPEN: `Failed to read WXR file.` remains unreachable. A file that is not a
+  WXR still fatals inside wordpress-importer 0.9.6's parser fallback chain rather
+  than returning a `WP_Error`, and the crash happens inside `parse()` before any
+  return value exists to check. Turning that into a clean error means validating the
+  file before handing it over, which is a larger piece of work than a guard. The
+  scenario pinning the fatal records the current behaviour and says why the branch
+  cannot fire.
+
 ## remove-terms-from-revisions
 
 (Calibrated against the live env 2026-09-01; re-verified green 2026-09-02 — 7 scenarios.)

--- a/features/create-guest-authors-from-wxr.feature
+++ b/features/create-guest-authors-from-wxr.feature
@@ -35,14 +35,17 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		Error: Please specify a valid WXR file with the --file arg.
 		"""
 
-	Scenario: Fatal error when the wordpress-importer plugin is not installed
+	Scenario: A clean error when the wordpress-importer plugin is not installed
 		Given I run `wp plugin uninstall wordpress-importer --deactivate`
 		When I try `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`
 		Then the return code should be 1
-		# The container path and PHP's exact wording belong to the runtime, not to CAP,
-		# so only the require_once of the importer's parsers.php is pinned.
-		And STDERR should match #require_once\(.*/wordpress-importer/parsers\.php\)#
-		And STDOUT should match #Failed opening required '.*/wordpress-importer/parsers\.php'#
+		# Previously a PHP fatal from the unguarded require_once, which told an operator
+		# to read a stack trace to discover a missing dependency.
+		And STDOUT should be empty
+		And STDERR should be:
+		"""
+		Error: This command needs the WordPress Importer plugin. Install it with `wp plugin install wordpress-importer`.
+		"""
 		When I run `wp post list --post_type=guest-author --format=count`
 		Then STDOUT should be:
 		"""

--- a/php/cli/class-create-guest-authors-from-wxr-command.php
+++ b/php/cli/class-create-guest-authors-from-wxr-command.php
@@ -72,7 +72,16 @@ class Create_Guest_Authors_From_Wxr_Command {
 		}
 
 		if ( ! class_exists( 'WXR_Parser' ) ) {
-			require_once WP_CONTENT_DIR . '/plugins/wordpress-importer/parsers.php';
+			// WP_PLUGIN_DIR rather than WP_CONTENT_DIR . '/plugins', so a site with a
+			// relocated plugin directory is not told the importer is missing when it is
+			// simply somewhere else.
+			$parser_path = WP_PLUGIN_DIR . '/wordpress-importer/parsers.php';
+
+			if ( ! file_exists( $parser_path ) ) {
+				WP_CLI::error( 'This command needs the WordPress Importer plugin. Install it with `wp plugin install wordpress-importer`.' );
+			}
+
+			require_once $parser_path;
 		}
 
 		$parser      = new WXR_Parser();


### PR DESCRIPTION
## Summary

`create-guest-authors-from-wxr` requires the importer's `parsers.php` without checking it is there. On a site that does not have the WordPress Importer plugin the command dies with an uncaught PHP fatal, so the operator gets a stack trace plus WordPress's generic "There has been a critical error on this website" and has to read both to work out that the answer is simply to install a dependency. It now checks the path first and says which plugin is needed and how to install it.

The path also moves from `WP_CONTENT_DIR . '/plugins'` to `WP_PLUGIN_DIR`, which is the constant WordPress provides for this and respects a relocated plugin directory. Without it, a site with a custom plugin path is told the importer is missing when it is merely somewhere else.

## Coverage, stated honestly

The guard's failure branch **is** exercised. The scenario genuinely uninstalls the plugin, so the new assertion fails if the fix is reverted — it would be the old fatal.

The `WP_PLUGIN_DIR` half is **not** discriminated by any test, and I would rather say so than let it look covered. In the test environment the two constants resolve to the same path, and the scenario matches the path with a wildcard, so it passes either way. It ships on the reasoning that `WP_PLUGIN_DIR` is the constant that exists precisely for this, not on evidence.

## Deliberately left alone

`Failed to read WXR file.` is still unreachable. A file that is not a WXR fatals inside wordpress-importer 0.9.6's parser fallback chain rather than returning a `WP_Error`, and the crash happens inside `parse()` before there is any return value to check. Making that clean means validating the file before handing it over, which is a larger piece of work than a guard and deserves its own change. The scenario pinning that fatal records the current behaviour and explains why the branch cannot fire.

## Test plan

- [x] `features/create-guest-authors-from-wxr.feature` green at 8 scenarios / 119 steps
- [x] The importer-absent scenario asserts an exact error on STDERR and empty STDOUT, replacing two loose regex matches on a PHP fatal
- [x] PHPCS clean by exit code
- [ ] Full Behat suite via CI

Note for anyone running this feature locally: it installs and uninstalls a plugin, so it now exceeds Composer's default 300 second process timeout. `COMPOSER_PROCESS_TIMEOUT=1800` is enough.