### PR TITLE
Tell swap-coauthors operators about posts it cannot see

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -188,9 +188,19 @@ PHP 8.4) rather than inferred from reading the source.
   convention, `--dry-run=0` and `--no-dry-run` remain real swaps, since flag
   values use PHP truthiness and `--no-<flag>` is the documented negation; both
   are pinned in "Treat --dry-run=0 and --no-dry-run as a real swap".
-- The command is TERM-driven, not `post_author`-driven. A post whose only link to the
-  `from` author is `wp_posts.post_author` (its `cap-<from>` term removed) is reported
-  as `Found 0 posts to update.` / `Success: All done!` and left untouched — unlike
+- ~~The command is TERM-driven, not `post_author`-driven, and silent about it. A post
+  whose only link to the `from` author is `wp_posts.post_author` was reported as
+  `Found 0 posts to update.` and nothing more — a clean no-op on exactly the shape a
+  plain-WordPress migration produces.~~ **Decision taken 2026-09-05: report, don't
+  widen.** The command now counts publish posts whose `post_author` is the from
+  user's account but which carry no `cap-` term, and warns that the swap does not
+  touch them. It still writes nothing new — actually swapping those posts would
+  widen the command's write scope, which stays a separate decision (an opt-in flag
+  is the likely shape if anyone asks). The count query passes `suppress_filters`,
+  because CAP's own author-query rewrite would add term matches and defeat the
+  point; both `_n()` branches and the unlinked-guest-author (no user ID) branch are
+  covered by scenarios. The original wording of this entry continues below for the
+  record: it was reported as `Found 0 posts to update.` / `Success: All done!` and left untouched — unlike
   `assign-user-to-coauthor` and `get_coauthors()`, which both fall back to
   `post_author`. Sites migrating from plain WordPress authorship therefore get a
   silent no-op. Pinned in "Ignore posts the swap query cannot reach".
@@ -224,6 +234,11 @@ PHP 8.4) rather than inferred from reading the source.
   --format=count`), and without that cleanup an orphan `cap-author2` term left by any
   other feature — guest-author terms are never cleaned up at all — would fail the dry
   scenario with an unrelated "dry run created a term" message.
+
+- ~~The `--to must not be empty` guard ran after the `--from` lookup, so an invalid
+  `--from` with an empty `--to` reported the missing co-author instead of the
+  missing parameter.~~ **FIXED** — the usage error is validated before any lookup.
+  The scenario that pinned the old order is inverted and renamed.
 
 ## CoAuthors_Plus::add_coauthors() return value
 

--- a/features/swap-coauthors.feature
+++ b/features/swap-coauthors.feature
@@ -47,11 +47,14 @@ Feature: One co-author can be swapped with another on their posts
 		And STDOUT should be empty
 		And the return code should be 1
 
-	Scenario: Validate --from before an empty --to
+	# The empty --to is a usage error, so it is reported before any co-author lookup.
+	# It used to surface only after --from had resolved, so this pairing complained
+	# about the co-author instead of the missing parameter.
+	Scenario: Report an empty --to before looking up --from
 		When I try `wp co-authors-plus swap-coauthors --from=not-a-user --to=`
 		Then STDERR should be:
 		"""
-		Error: No co-author found for not-a-user
+		Error: --to param must not be empty
 		"""
 		And STDOUT should be empty
 		And the return code should be 1
@@ -314,7 +317,7 @@ Feature: One co-author can be swapped with another on their posts
 		{AUTHOR2_ID}
 		"""
 
-	Scenario: Ignore posts the swap query cannot reach
+	Scenario: Report posts linked only through post_author instead of ignoring them silently
 		When I run `wp user create author1 author1@example.com --role=author --porcelain`
 		And save STDOUT as {AUTHOR1_ID}
 		And I run `wp user create author2 author2@example.com --role=author --porcelain`
@@ -338,6 +341,7 @@ Feature: One co-author can be swapped with another on their posts
 		"""
 		Swapping authorship from author1 to author2
 		Found 0 posts to update.
+		Warning: 1 post has author1 as its post_author but does not carry the cap-author1 term, so this swap does not touch it.
 		Success: All done!
 		"""
 		When I run `wp term list author --object_ids={DRAFT_ID} --field=slug`
@@ -387,4 +391,48 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		{AUTHOR1_ID}
+		"""
+
+	# Two termless posts, so the plural branch of the new warning runs as well as the
+	# singular above.
+	Scenario: Several posts linked only through post_author are counted together
+		When I run `wp user create author1 author1@example.com --role=author --porcelain`
+		And save STDOUT as {AUTHOR1_ID}
+		And I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="First termless" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post term remove {POST_A} author cap-author1 --by=slug`
+		And I run `wp post create --post_author={AUTHOR1_ID} --post_title="Second termless" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term remove {POST_B} author cap-author1 --by=slug`
+		And I run `wp co-authors-plus swap-coauthors --from=author1 --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from author1 to author2
+		Found 0 posts to update.
+		Warning: 2 posts have author1 as their post_author but do not carry the cap-author1 term, so this swap does not touch them.
+		Success: All done!
+		"""
+		And the return code should be 0
+
+	# A guest author with no linked account has no user ID for post_author to hold,
+	# so the check has nothing to count and must stay silent rather than fatal.
+	Scenario: Swapping from an unlinked guest author reports no post_author-only posts
+		When I run `wp user create author2 author2@example.com --role=author --porcelain`
+		And I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --user_email=jane@example.com`
+		And I run `wp post create --post_title="Ghost written" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval '$GLOBALS["coauthors_plus"]->add_coauthors( {POST_ID}, array( "jane-doe" ) );'`
+		And I run `wp co-authors-plus swap-coauthors --from=jane-doe --to=author2`
+		Then STDOUT should be:
+		"""
+		Swapping authorship from jane-doe to author2
+		Found 1 posts to update.
+		1: Post #{POST_ID} has been assigned "author2" as a co-author
+		Success: All done!
+		"""
+		When I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-author2
 		"""

--- a/php/cli/class-swap-coauthors-command.php
+++ b/php/cli/class-swap-coauthors-command.php
@@ -13,6 +13,7 @@ use CoAuthors\Prefix;
 use CoAuthors_Plus;
 use WP_CLI;
 use WP_Query;
+use WP_User;
 
 /**
  * Swaps one co-author for another across the posts they share.
@@ -102,14 +103,17 @@ class Swap_Coauthors_Command {
 		$from_userlogin = $assoc_args['from'];
 		$to_userlogin   = $assoc_args['to'];
 
+		// A usage error, so it is reported before any lookup: an empty --to used to
+		// surface only after --from had resolved, so "--from=nobody --to=" complained
+		// about the co-author rather than the missing parameter.
+		if ( ! $to_userlogin ) {
+			WP_CLI::error( '--to param must not be empty' );
+		}
+
 		$orig_coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $from_userlogin );
 
 		if ( ! $orig_coauthor ) {
 			WP_CLI::error( "No co-author found for $from_userlogin" );
-		}
-
-		if ( ! $to_userlogin ) {
-			WP_CLI::error( '--to param must not be empty' );
 		}
 
 		$to_coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $to_userlogin );
@@ -157,6 +161,64 @@ class Swap_Coauthors_Command {
 		$posts_keeping_author = 0;
 
 		WP_CLI::log( "Found $posts->found_posts posts to update." );
+
+		// This command is term-driven. A post whose only link to the from author is
+		// wp_posts.post_author carries no cap- term, matches nothing above, and used to
+		// vanish into a clean "Found 0 posts" — the likeliest shape on a site migrating
+		// from plain WordPress authorship. Saying so is deliberate; actually swapping
+		// those posts would widen what the command writes, which is a separate decision.
+		$from_user = null;
+
+		if ( $orig_coauthor instanceof WP_User ) {
+			$from_user = $orig_coauthor;
+		} elseif ( isset( $orig_coauthor->wp_user ) && $orig_coauthor->wp_user instanceof WP_User ) {
+			$from_user = $orig_coauthor->wp_user;
+		}
+
+		if ( $from_user ) {
+			$post_author_only = new WP_Query(
+				array(
+					'post_type'        => $assoc_args['post_type'],
+					// The main query above sets no status, so an unauthenticated CLI run
+					// sees publish only; this count matches that scope explicitly.
+					'post_status'      => 'publish',
+					// author__in rather than author: identical for one ID, and the source-grep
+					// guard in CoauthorTaxonomyUsageTest rightly cannot tell a literal 'author'
+					// query key from the taxonomy name it exists to keep out of these files.
+					'author__in'       => array( $from_user->ID ),
+					'posts_per_page'   => 1,
+					'fields'           => 'ids',
+					// CAP itself rewrites author queries to include term matches, which
+					// would defeat the point of this count. CLI-only, one query per run.
+					'suppress_filters' => true, // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters
+					'tax_query'        => array(
+						array(
+							'taxonomy' => $coauthors_plus->coauthor_taxonomy,
+							'field'    => 'slug',
+							'terms'    => array( $from_userlogin_prefixed ),
+							'operator' => 'NOT IN',
+						),
+					),
+				)
+			);
+
+			if ( $post_author_only->found_posts > 0 ) {
+				WP_CLI::warning(
+					sprintf(
+						/* translators: 1: Count of posts. 2: Co-author login. 3: Author term slug. */
+						_n(
+							'%1$s post has %2$s as its post_author but does not carry the %3$s term, so this swap does not touch it.',
+							'%1$s posts have %2$s as their post_author but do not carry the %3$s term, so this swap does not touch them.',
+							$post_author_only->found_posts,
+							'co-authors-plus'
+						),
+						number_format_i18n( $post_author_only->found_posts ),
+						$from_userlogin,
+						$from_userlogin_prefixed
+					)
+				);
+			}
+		}//end if
 
 		$previous_first_post_id = null;
 


### PR DESCRIPTION
## Summary

`swap-coauthors` is term-driven: it finds posts by their `cap-<from>` author term. A post whose only link to the from author is `wp_posts.post_author` carries no term, matches nothing, and vanished into a clean `Found 0 posts to update.` with exit 0. That is the likeliest shape on a site migrating from plain WordPress authorship — much of the audience for a byline swap — and the command handed them a convincing no-op.

Per the decision on this one: **report, don't widen.** The command now counts publish posts whose `post_author` is the from author's user account but which carry no author term, and warns that the swap does not touch them. It still writes nothing new. Actually swapping those posts would widen the command's write scope, and that remains open — an opt-in flag is the likely shape if the warning shows people are hitting it.

Two implementation points worth a look. The count query passes `suppress_filters`, with a phpcs ignore naming the reason: CAP itself rewrites author queries to include term matches, which would defeat the point of asking how many posts *only* `post_author` knows about. And the from co-author is resolved to a `WP_User` through the same two shapes `add_coauthors()` uses — a `WP_User` directly, or a linked guest author's `wp_user` — with `use WP_User;` imported, since in this namespace an unimported class name would make the `instanceof` silently false, which is the exact trap the Phase 2 split hit.

Also in here: the empty `--to` check moves above the `--from` lookup. It is a usage error, and reporting it only after a co-author lookup meant `--from=nobody --to=` complained about the co-author rather than the missing parameter. The scenario pinning the old order is inverted.

## Coverage, against the revert test

- The termless-post scenario previously pinned the silent `Found 0` output; it now pins the warning, and fails without the fix.
- The plural branch of the new `_n()` string has its own two-post scenario.
- A new scenario swaps *from* an unlinked guest author, which has no user ID to count against. Stated honestly: it does not discriminate this fix — its output is identical either way — it guards the null branch against a future fatal, and says so in its comment.
- Every other scenario passes unchanged, confirming the warning appears only when there is something to warn about.

## Test plan

- [x] `features/swap-coauthors.feature` green at 17 scenarios / 221 steps, up from 15
- [x] PHPCS clean by exit code
- [ ] Full Behat suite via CI