### PR TITLE
Backfill author terms through the taxonomy API

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -821,17 +821,30 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
     `0 records affected`, and the run still ends `Success: Done!` with nothing
     explaining the gap.~~ **FIXED.** Skips are counted and reported. The new string
     is pluralised with `_n()` from the outset.
-- STILL OPEN, and parked pending a decision: the raw `$wpdb->insert` into
-  `term_relationships` bypasses `wp_set_object_terms()`, and with it the
-  `set_object_terms` action that CAP hooks at `class-coauthors-plus.php` to clear its
-  own `coauthors_post_<id>` cache — which caches an EMPTY array. On a host with a
-  persistent object cache, which is the environment this command exists for, a
-  backfilled post keeps reporting no co-authors to the front end, template tags and
-  REST until it is saved or the cache is flushed. It also skips dedupe and writes
-  `term_order = 0` where every other path writes the ordered value. The fix is a
-  deletion — use `wp_set_object_terms()`, wrapped in `wp_defer_term_counting()` — but
-  wp-env has no persistent object cache, so neither the bug nor the fix is observable
-  in this suite, and it would ship on reasoning alone.
+- ~~The raw `$wpdb->insert` into `term_relationships` bypasses
+  `wp_set_object_terms()`, and with it the `set_object_terms` action that CAP hooks
+  to clear its own `coauthors_post_<id>` cache — which caches an EMPTY array. On a
+  host with a persistent object cache, the environment this command exists for, a
+  backfilled post kept reporting no co-authors to the front end, template tags and
+  REST until it was saved or the cache flushed.~~ **FIXED** (decision taken
+  2026-09-05: ship on reasoning, with a mechanism proxy). The write goes through
+  `wp_set_object_terms()` — non-append, deliberately, since the query selects only
+  posts with no author terms so set and append coincide — wrapped in
+  `wp_defer_term_counting()` so counting resumes with one recount per term. The
+  cache staleness itself is invisible in wp-env, so the scenario pins the mechanism
+  instead: a `--require` fixture hooks `set_object_terms` and asserts it fires
+  during the backfill, which the raw insert never did. That is the action CAP's
+  invalidation listens to. Two useful discoveries along the way, recorded so they
+  are not re-learnt: `wp_set_object_terms()` only writes `term_order` on NON-append
+  calls, and even then only when its mid-function term lookup is not served from
+  cache (`wp_update_term_count()` cleans term caches without bumping the query
+  salt), so `term_order` is nondeterministic and must not be pinned. A forced-count
+  scenario also guards the deleted "Updating author terms with new counts" pass:
+  counts come from the deferred recount, which the raw insert bypassed entirely.
+  The `update_author_term()` WP_Error dereference that could write a relationship
+  row with no `term_taxonomy_id` is guarded too, and both failure paths now mark
+  the skip meta — which also removes the batch-starvation source, since a post the
+  run cannot complete drops out of the next batch.
 - CORRECTION to the earlier note claiming `--specific-post-ids` can loop forever:
   it cannot. `if ( $count >= $count_of_posts_with_missing_author_terms ) break;`
   bounds the run, and `$count` increments per record processed whether or not it

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -20,8 +20,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (2/2 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		2 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -39,7 +37,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		Found 0 posts with missing author terms.
 		0 records affected
-		Updating author terms with new counts
 		Success: Done!
 		"""
 
@@ -63,9 +60,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (2/2 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author {USER_B} (beta).
 		2 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author {USER_A} (alpha) (50.00%).
-		Success: Updated author term for author {USER_B} (beta) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -88,7 +82,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		Found 0 posts with missing author terms.
 		0 records affected
-		Updating author terms with new counts
 		Success: Done!
 		"""
 		When I run `wp co-authors-plus create-author-terms-for-posts --post-statuses=draft`
@@ -98,8 +91,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_ID} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -124,8 +115,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (2/2 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		2 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 
@@ -138,7 +127,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		Found 0 posts with missing author terms.
 		0 records affected
-		Updating author terms with new counts
 		Success: Done!
 		"""
 		When I run `wp co-authors-plus create-author-terms-for-posts --post-types=page`
@@ -148,8 +136,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {PAGE_ID} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {PAGE_ID} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 
@@ -167,8 +153,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_A} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -193,8 +177,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_B} --field=slug`
@@ -220,8 +202,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --format=count`
@@ -249,8 +229,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --format=count`
@@ -273,8 +251,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_A} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -315,7 +291,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
 		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
-		Updating author terms with new counts
 		Success: Done!
 		"""
 		When I run `wp post meta get {POST_ID} _cap_skip_backfill`
@@ -328,7 +303,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		Found 0 posts with missing author terms.
 		0 records affected
-		Updating author terms with new counts
 		Success: Done!
 		"""
 
@@ -355,7 +329,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Warning: Post Author ID 0 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
 		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
-		Updating author terms with new counts
 		Success: Done!
 		"""
 		When I run `wp post meta get {POST_ID} _cap_skip_backfill`
@@ -379,7 +352,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Warning: Post Author ID 0 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
 		Warning: 2 posts were skipped and marked with `_cap_skip_backfill`.
-		Updating author terms with new counts
 		Success: Done!
 		"""
 		When I run `wp post meta get {POST_A} _cap_skip_backfill`
@@ -416,8 +388,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
 		2 records affected
 		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp post meta get {ORPHAN_ID} _cap_skip_backfill`
@@ -437,8 +407,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_ID} and author 1 (admin).
 		1 records affected
-		Updating author terms with new counts
-		Success: Updated author term for author 1 (admin) (100.00%).
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -469,7 +437,6 @@ Feature: Missing author terms can be backfilled for targeted posts
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
 		Warning: 1 post was skipped and marked with `_cap_skip_backfill`.
-		Updating author terms with new counts
 		Success: Done!
 		"""
 
@@ -582,3 +549,48 @@ Feature: Missing author terms can be backfilled for targeted posts
 		"""
 		0
 		"""
+
+	# Guards the removal of the "Updating author terms with new counts" pass and the
+	# deferred counting: the count is recalculated when counting resumes at the end
+	# of the run, not by a second pass over the authors. The raw insert this command
+	# used to do bypassed the count callback entirely, so this fails against it.
+	Scenario: Backfilling recalculates the term count
+		When I run `wp post create --post_title="Counted post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		And I run `wp eval '$t = get_term_by( "slug", "cap-admin", "author" ); global $wpdb; $wpdb->update( $wpdb->term_taxonomy, array( "count" => 5 ), array( "term_taxonomy_id" => $t->term_taxonomy_id ) );'`
+		And I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		5
+		"""
+		When I run `wp co-authors-plus create-author-terms-for-posts`
+		Then the return code should be 0
+		When I run `wp term list author --field=count`
+		Then STDOUT should be:
+		"""
+		1
+		"""
+
+	# The cache half of this fix cannot be shown in wp-env, which has no persistent
+	# object cache, so this pins the mechanism instead: wp_set_object_terms() fires
+	# the set_object_terms action, which CAP hooks to clear its coauthors_post_<id>
+	# cache. The raw insert this command used to do fired no action at all, so this
+	# scenario fails against it. The hook is planted through a --require file, as
+	# testing.feature does; it sits in wp-content because /tmp does not survive a
+	# fresh container. (A term_order assertion was tried first and abandoned: core
+	# only writes it when its mid-function term query is not served from cache, so
+	# it is not deterministic enough to pin.)
+	Scenario: Backfilling fires the action that clears the co-author cache
+		When I run `wp post create --post_title="Hooked post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post term remove {POST_ID} author --all`
+		And I run `eval 'file_put_contents( "/var/www/html/wp-content/cap-log-set-object-terms.php", base64_decode( "PD9waHAKV1BfQ0xJOjphZGRfd3BfaG9vaygKCSdzZXRfb2JqZWN0X3Rlcm1zJywKCWZ1bmN0aW9uICggJG9iamVjdF9pZCwgJHRlcm1zLCAkdHRfaWRzLCAkdGF4b25vbXkgKSB7CgkJaWYgKCAnYXV0aG9yJyA9PT0gJHRheG9ub215ICkgewoJCQlXUF9DTEk6OmxvZyggInNldF9vYmplY3RfdGVybXMgZmlyZWQgZm9yIHBvc3QgeyRvYmplY3RfaWR9IiApOwoJCX0KCX0sCgkxMCwKCTQKKTsK" ) );'`
+		And I run `--require=/var/www/html/wp-content/cap-log-set-object-terms.php co-authors-plus create-author-terms-for-posts`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		set_object_terms fired for post {POST_ID}
+		"""
+		When I run `eval 'unlink( "/var/www/html/wp-content/cap-log-set-object-terms.php" );'`
+		Then the return code should be 0

--- a/php/cli/class-create-author-terms-for-posts-command.php
+++ b/php/cli/class-create-author-terms-for-posts-command.php
@@ -12,7 +12,7 @@ namespace Automattic\CoAuthorsPlus\CLI;
 use CoAuthors_Plus;
 use Exception;
 use WP_CLI;
-use WP_Query;
+use WP_Term;
 
 /**
  * Backfills author terms for the posts that are missing them.
@@ -157,6 +157,9 @@ class Create_Author_Terms_For_Posts_Command {
 			$below_post_id
 		);
 
+		// One recount per term when counting resumes, rather than one per write.
+		wp_defer_term_counting( true );
+
 		do {
 			foreach ( $posts_with_missing_author_terms as $record ) {
 				$record->post_author = intval( $record->post_author );
@@ -181,23 +184,36 @@ class Create_Author_Terms_For_Posts_Command {
 					$authors[ $record->post_author ] = $author;
 				}
 
-				$author_term                          = ( ! empty( $author_terms[ $record->post_author ] ) ) ?
-					$author_terms[ $record->post_author ] :
-					$coauthors_plus->update_author_term( $author );
+				// ?? rather than ! empty(), so a failed term creation is memoised too and an
+				// unresolvable author is attempted once per run rather than once per post.
+				$author_term                          = $author_terms[ $record->post_author ] ?? $coauthors_plus->update_author_term( $author );
 				$author_terms[ $record->post_author ] = $author_term;
 
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-				$insert_author_term_relationship = $wpdb->insert(
-					$wpdb->term_relationships,
-					array(
-						'object_id'        => $record->post_id,
-						'term_taxonomy_id' => $author_term->term_taxonomy_id,
-						'term_order'       => 0,
-					)
-				);
+				// update_author_term() returns a WP_Error when the term cannot be created.
+				// Dereferencing that used to write a relationship row with no
+				// term_taxonomy_id behind it.
+				if ( ! $author_term instanceof WP_Term ) {
+					WP_CLI::warning( sprintf( 'No author term for user ID %d, marking post %d as skipped.', $record->post_author, $record->post_id ) );
+					$this->skip_backfill_for_post( $record->post_id, 'author_term_not_created' );
+					++$skipped;
+					continue;
+				}
 
-				if ( false === $insert_author_term_relationship ) {
-					WP_CLI::warning( sprintf( 'Failed to insert term relationship for post %d and author %d.', $record->post_id, $record->post_author ) );
+				// wp_set_object_terms() rather than a raw term_relationships insert: core
+				// then does the dedupe, writes term_order, runs the count callback, and
+				// fires set_object_terms — which CAP hooks to clear its own
+				// coauthors_post_<id> cache. The raw insert skipped all of that, so on a
+				// persistent object cache a backfilled post kept reporting no co-authors
+				// until it was next saved.
+				// Not appending, deliberately: the query above selects only posts with no
+				// author terms at all, so set and append coincide, and set is the
+				// operation this backfill actually means.
+				$set_author_term = wp_set_object_terms( $record->post_id, array( $author_term->slug ), $coauthors_plus->coauthor_taxonomy, false );
+
+				if ( is_wp_error( $set_author_term ) ) {
+					WP_CLI::warning( sprintf( 'Failed to set the author term for post %d and author %d, marking it skipped.', $record->post_id, $record->post_author ) );
+					$this->skip_backfill_for_post( $record->post_id, 'author_term_not_set' );
+					++$skipped;
 				} else {
 					WP_CLI::success( sprintf( 'Inserted term relationship for post %d and author %d (%s).', $record->post_id, $record->post_author, $author->user_nicename ) );
 					++$affected;
@@ -231,6 +247,8 @@ class Create_Author_Terms_For_Posts_Command {
 			}
 		} while ( ! empty( $posts_with_missing_author_terms ) );
 
+		wp_defer_term_counting( false );
+
 		WP_CLI::log( sprintf( '%d records affected', $affected ) );
 
 		if ( $skipped > 0 ) {
@@ -249,20 +267,6 @@ class Create_Author_Terms_For_Posts_Command {
 			);
 		}
 
-		WP_CLI::log( 'Updating author terms with new counts' );
-		$count_of_authors = count( $authors );
-		$count            = 0;
-		foreach ( $authors as $author ) {
-			++$count;
-			$result = $coauthors_plus->update_author_term( $author );
-
-			if ( is_wp_error( $result ) || false === $result ) {
-				WP_CLI::warning( sprintf( 'Failed to update author term for author %d (%s).', $author->ID, $author->user_nicename ) );
-			} else {
-				$percentage = $this->get_formatted_complete_percentage( $count, $count_of_authors );
-				WP_CLI::success( sprintf( 'Updated author term for author %d (%s) (%s).', $author->ID, $author->user_nicename, $percentage ) );
-			}
-		}
 
 		WP_CLI::success( 'Done!' );
 	}


### PR DESCRIPTION
## Summary

`create-author-terms-for-posts` wrote each author-term relationship with a raw `$wpdb->insert` into `term_relationships`. That bypassed `wp_set_object_terms()` — and with it the `set_object_terms` action that this plugin hooks *itself*, in `clear_cache_on_terms_set()`, to clear its own `coauthors_post_<id>` cache. That cache stores an **empty array** for a post with no co-authors. So on a host with a persistent object cache — the environment a bulk backfill exists for — a freshly backfilled post kept telling the front end, template tags and REST that it had no co-authors until something else saved the post or flushed the cache. The database was correct and the command reported success, so nothing pointed at the cause.

The write now goes through `wp_set_object_terms()`, wrapped in `wp_defer_term_counting()` so counting resumes with one recount per term rather than one per write, keeping the command fast at the scale it targets. Non-append, deliberately: the selection SQL only ever returns posts with **no** author terms, so set and append coincide, and set is the operation the backfill actually means. Core then also handles the dedupe the raw insert skipped.

Also guarded along the way: `update_author_term()` can return a `WP_Error`, which used to be dereferenced into a relationship row with no `term_taxonomy_id` behind it — a corrupt row the selection subquery could not exclude. Both failure paths now warn and mark the post with the skip meta, which has a second benefit: a post the run cannot complete drops out of the next batch instead of being re-selected by every one, removing the starvation behaviour previously miscatalogued as an infinite loop. And the trailing "Updating author terms with new counts" pass is deleted — the same redundancy removed from its sibling in an earlier PR, except here the message was doubly wrong because the raw insert bypassed the count callback entirely.

## How this is covered, since the cache itself cannot be

wp-env has no persistent object cache, so the staleness is invisible there both before and after — this was the known cost of the decision to ship it. Two scenarios stand in:

- **The mechanism proxy.** A `--require` fixture (the technique #1421 established) hooks the `set_object_terms` action and asserts it fires during the backfill. That is exactly the hook CAP's cache invalidation listens to, and the raw insert never fired it, so the scenario fails against the old code. It is as close to pinning the cache fix as this environment allows.
- **The count guard.** A term count forced to 5 comes back correct after the run, proving the deferred recount maintains counts — which also fails against the raw insert, since that bypassed the callback.

## The proxy that did not survive contact, worth reading

The agreed `term_order` assertion earned its keep and then had to be replaced. It first caught a real slip — I had called `wp_set_object_terms()` with `$append = true`, and core only runs its ordering pass on non-append calls, so the proxy failed and exposed it. Then it *kept* failing at 0, and a probe into core showed why: the ordering pass reads the object's terms through the term-query cache, whose invalidation salt is not bumped mid-function (`wp_update_term_count()` cleans term caches with `$clean_taxonomy = false`), so `term_order` is only written when that lookup happens to miss the cache. It is nondeterministic by core's own design and must not be pinned. That finding is recorded in the behaviour notes so it is not re-learnt, and the action-hook proxy above replaced it — a stronger check in any case, since it observes the invalidation pathway rather than a side effect.

## Test plan

- [x] `features/create-author-terms-for-posts.feature` green at 25 scenarios / 295 steps, up from 21
- [x] The action-hook and forced-count scenarios both fail against the raw-insert write path
- [x] The per-post `Success: Inserted term relationship ...` line is deliberately unchanged, so the bulk of the suite pins the swap without edits
- [x] PHPCS clean by exit code
- [ ] Full Behat suite via CI