### PR TITLE
Refuse a guest author login that belongs to a WordPress user

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -566,9 +566,25 @@ PHP 8.4) rather than inferred from reading the source.
     either. Pinned with an exact `wp post meta list --format=csv` assertion.
 
 - Hardened 2026-09-02 after adversarial review: 11 scenarios, all green.
-- **Silent author-term hijack (new, and the most significant finding here).** A
-  `--user_login` that matches an existing WP USER is accepted and the guest author is
-  created, sharing that user's author term. `create_guest_author()` only dedupes
+- ~~**Silent author-term hijack.** A `--user_login` that matches an existing WP
+  USER is accepted and the guest author is created, sharing that user's author
+  term.~~ **FIXED** (decision taken 2026-09-05). `create()`'s guard now matches its
+  own comment and rejects the collision with the existing `duplicate-field` error —
+  with one deliberate allowance: the collision is permitted when the profile is
+  being created as that user's linked account (`linked_account` equals the found
+  user's actual login). That allowance is NOT optional and is not new semantics: it
+  mirrors the guard `manage_guest_author_filter_post_data()` has always applied on
+  the edit screen, and without it `create_guest_author_from_user_id()` — and
+  therefore `wp co-authors-plus create-guest-authors`, the users-list "Create
+  Profile" action, and every test factory user — would break for any user whose
+  display_name equals their login, which is WordPress's default (including
+  `admin`). Three integration tests pin the boundary: the rejection (fails against
+  the old guard), the linked-account allowance (exists to fail against an
+  over-tightened guard), and `linked_account` not bypassing the guest-author
+  duplicate check. The refusal scenario asserts the user's term survives with its
+  description unrewritten. Historical detail preserved below.
+- The original finding, for the record: the guest author was created sharing that
+  user's author term. `create_guest_author()` only dedupes
   against guest-author posts (:1136-1141) and `Guest_Authors::create()` only rejects a
   collision when the existing co-author's `type` is `guest-author`
   (php/class-coauthors-guest-authors.php:1402-1406), while `get_author_term()` matches

--- a/features/create-author.feature
+++ b/features/create-author.feature
@@ -120,7 +120,13 @@ Feature: A single guest author can be created
 		cap-raw-user
 		"""
 
-	Scenario: A user_login that collides with an existing user reuses that user's author term
+	# get_author_term() matches on the cap-<nicename> slug alone, so a profile
+	# sharing a real user's login would adopt that user's author term and rewrite
+	# its description — the user's own posts then resolve to the guest author. The
+	# guard's comment always said logins must not collide with existing users; now
+	# the code agrees, unless the profile is being created as that user's linked
+	# account, which is the allowance the edit screen has always made.
+	Scenario: A user_login that collides with an existing user is refused
 		Given I run `wp user create jane-doe jane-user@example.com --display_name="Jane Doe" --role=author --porcelain`
 		And save STDOUT as {USER_ID}
 		And I run `wp post create --post_title="Post by Jane" --post_author={USER_ID} --post_status=publish --porcelain`
@@ -128,29 +134,26 @@ Feature: A single guest author can be created
 		And I run `wp term list author --object_ids={POST_ID} --field=term_id`
 		And save STDOUT as {USER_TERM_ID}
 		And STDOUT should not be empty
-		When I run `wp co-authors-plus create-author --display_name="Jane Guest" --user_login=jane-doe --user_email=jane-guest@example.com`
-		Then the return code should be 0
-		And STDOUT should contain:
+		When I try `wp co-authors-plus create-author --display_name="Jane Guest" --user_login=jane-doe --user_email=jane-guest@example.com`
+		Then the return code should be 1
+		And STDOUT should be empty
+		And STDERR should be:
 		"""
-		Success: -- Created as guest author #
+		Warning: -- Failed to create guest author: user_login cannot duplicate existing guest author or mapped user
 		"""
-		# The duplicate guards only look at guest authors, and get_author_term() matches
-		# on the `cap-<nicename>` slug alone, so the new profile ADOPTS the existing
-		# user's term rather than getting one of its own.
-		When I run `wp post list --post_type=guest-author --format=ids`
-		And save STDOUT as {GUEST_AUTHOR_ID}
-		And I run `wp term list author --object_ids={GUEST_AUTHOR_ID} --field=term_id`
+		When I run `wp post list --post_type=guest-author --format=count`
+		Then STDOUT should be:
+		"""
+		0
+		"""
+		# The user's term survives untouched: same term, description not rewritten.
+		When I run `wp term list author --object_ids={POST_ID} --field=term_id`
 		Then STDOUT should be:
 		"""
 		{USER_TERM_ID}
 		"""
-		# The shared term's description (what CAP searches on) is rewritten with the
-		# guest author's values, so the real user's post now points at the guest author.
 		When I run `wp term list author --object_ids={POST_ID} --field=description`
-		Then STDOUT should contain:
-		"""
-		Jane Guest
-		"""
+		Then STDOUT should not match /Jane Guest/
 
 	Scenario: The avatar field used when creating a profile is not exposed as a parameter
 		When I try `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe --avatar=5`

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1405,11 +1405,18 @@ class CoAuthors_Guest_Authors {
 
 			// The user login field shouldn't collide with any existing users
 			if ( 'user_login' == $field['key'] && $existing_coauthor = $coauthors_plus->get_coauthor_by( 'user_login', $args['user_login'], true ) ) {
-				if ( 'guest-author' == $existing_coauthor->type ) {
+				// A matching WordPress user is only allowed when this profile is being
+				// created as that user's linked account, mirroring the allowance
+				// manage_guest_author_filter_post_data() makes on the edit screen.
+				// Anything else silently adopted the user's author term and rewrote
+				// its description, so the user's own posts resolved to the new
+				// guest author.
+				$linked_account = isset( $args['linked_account'] ) ? $args['linked_account'] : '';
+				if ( 'guest-author' === $existing_coauthor->type || $existing_coauthor->user_login !== $linked_account ) {
 					return new WP_Error( 'duplicate-field', __( 'user_login cannot duplicate existing guest author or mapped user', 'co-authors-plus' ) );
-				}
+				}//end if
 			}
-		}
+		}//end foreach
 
 		// Create the primary post object
 		$new_post = array(

--- a/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
+++ b/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
@@ -213,4 +213,105 @@ class CreateGuestAuthorTest extends TestCase {
 		$this->assertIsInt( $post_id, 'An empty guest-author post should insert, not be rejected as empty content.' );
 		$this->assertGreaterThan( 0, $post_id );
 	}
+	/**
+	 * A user_login matching an existing WordPress user is refused, so the new
+	 * profile cannot adopt the user's author term and rewrite its description.
+	 *
+	 * Fails against the old guard, which only rejected guest author matches:
+	 * create() then returns an int and the description gains "Jane Guest".
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_rejects_user_login_of_existing_wp_user(): void {
+
+		global $coauthors_plus;
+
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_login'   => 'jane-doe',
+				'display_name' => 'Jane Doe',
+				'role'         => 'author',
+			)
+		);
+
+		$term = $coauthors_plus->update_author_term( $user );
+		$this->assertInstanceOf( \WP_Term::class, $term );
+
+		$response = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => 'Jane Guest',
+				'user_login'   => 'jane-doe',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'duplicate-field', $response->get_error_code() );
+
+		$description = get_term( $term->term_id, $coauthors_plus->coauthor_taxonomy )->description;
+		$this->assertStringNotContainsString( 'Jane Guest', $description, 'The rejected profile must not rewrite the term description.' );
+	}
+
+	/**
+	 * The one allowed collision: the profile is being created as the matching
+	 * user's linked account, which is how create_guest_author_from_user_id()
+	 * works for every user whose display name equals their login.
+	 *
+	 * This passes today too. Its job is to fail against an over-tightened guard
+	 * that rejects every user collision, which would break create-guest-authors
+	 * for the stock admin user among others.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_allows_collision_for_linked_account(): void {
+
+		global $coauthors_plus;
+
+		self::factory()->user->create(
+			array(
+				'user_login'   => 'jane-doe',
+				'display_name' => 'Jane Doe',
+				'role'         => 'author',
+			)
+		);
+
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name'   => 'Jane Doe',
+				'user_login'     => 'jane-doe',
+				'linked_account' => 'jane-doe',
+			)
+		);
+
+		$this->assertIsInt( $guest_author_id );
+	}
+
+	/**
+	 * The linked_account value must not open the door for a guest author
+	 * duplicate: the guest-author half of the guard wins whatever it claims.
+	 *
+	 * @covers ::create
+	 */
+	public function test_linked_account_does_not_bypass_guest_author_duplicates(): void {
+
+		global $coauthors_plus;
+
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => 'Solo Guest',
+				'user_login'   => 'solo-guest',
+			)
+		);
+		$this->assertIsInt( $guest_author_id );
+
+		$response = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name'   => 'Impostor',
+				'user_login'     => 'solo-guest',
+				'linked_account' => 'solo-guest',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'duplicate-field', $response->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Summary

The collision guard in `CoAuthors_Guest_Authors::create()` carries the comment *"The user login field shouldn't collide with any existing users"* — and only rejected the collision when the match was itself a guest author. A matching WordPress **user** slipped straight through. Because `get_author_term()` matches on the `cap-{nicename}` slug alone, the new profile then adopted that user's author term, and `update_author_term()` rewrote the term's description with the guest author's search values — so the user's own published posts resolved to the guest author. Data corruption, reported as `Success:`.

The guard now does what its comment says, returning the existing `duplicate-field` error on the same code and message as every other rejection.

## The allowance, which is the part that needed the investigation

There is one deliberate exception: the collision is permitted when the profile is being created **as that user's linked account** — the supplied `linked_account` equals the found user's actual login. This is not optional, and it is not new semantics.

Not optional: WordPress defaults `display_name` to `user_login`, and for such users — including the stock `admin`, and every factory-created test user — `create_guest_author_from_user_id()` deliberately generates the user's own login and records the link. A plain "reject any user collision" guard would have broken `wp co-authors-plus create-guest-authors` outright, killed the users-list "Create Profile" row action, and failed a large slice of the integration suite. I recommended exactly that plain guard before investigating; the investigation is what caught it.

Not new semantics: `manage_guest_author_filter_post_data()` has always made precisely this allowance on the edit screen (*"if user has selected to link account to matching user we don't have to bail"*). This brings `create()` into line with the plugin's existing rule rather than inventing one.

Comparing against the *found user's* actual login means a bogus `linked_account` value opens nothing, and the guest-author half of the guard runs first, so `linked_account` cannot bypass duplicate detection either. Both properties are pinned by tests.

## Coverage, against the revert test

- `test_create_rejects_user_login_of_existing_wp_user` **fails against the old guard** — verified by reverting the patch and running it: `create()` returns an int and the term description gains "Jane Guest". It also asserts the description is *not* rewritten, which is the corruption itself.
- `test_create_allows_collision_for_linked_account` passes on both sides by design — its job is to fail against an **over-tightened** future guard, the mistake this PR nearly was.
- `test_linked_account_does_not_bypass_guest_author_duplicates` pins the other edge.
- The Behat scenario that pinned the hijack ("...reuses that user's author term") is rewritten as a refusal, asserting exit 1, no profile created, the same term id on the user's post, and its description unrewritten.
- `features/create-guest-author.feature` passes unchanged — that is the linked-account flow for `admin` working end to end.
- An existing integration test's comment, which already claimed `create()` refuses these collisions, becomes true without modification.

PHPCS: this file carries 180 pre-existing errors on `develop` and cannot go clean here; the patched file measures **179** — the hunk adds nothing and retires one auto-fixable complaint its own length triggered.

## Test plan

- [x] Integration: 8 tests / 20 assertions green in `CreateGuestAuthorTest`, including the three new ones; rejection test confirmed failing against the reverted guard
- [x] Behat: `create-author.feature` and `create-guest-author.feature` green together at 15 scenarios / 147 steps
- [ ] Full Behat suite and integration matrix via CI