### PR TITLE
Sanitise CLI guest author profiles as the admin screen does

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -615,16 +615,31 @@ PHP 8.4) rather than inferred from reading the source.
   that user's author term" (term_id equality + the rewritten description). Note this
   makes the `term-creation-failed` / "The author slug may conflict with an existing
   user" error string unreachable from this path.
-- **No sanitisation at all.** `create_author()` hands `$assoc_args` straight to
-  `create_guest_author()`, so `--display_name="<b>Raw</b> Name"` is stored (and used as
-  `post_title`) verbatim, `--user_login="Raw User!"` is stored verbatim, an unschemed
-  `--website=example.com/raw` is stored as typed, and `--description="<script>x</script>bio"`
-  lands in `cap-description` unfiltered. Only `post_name` is normalised, by
-  `create()`'s own `sanitize_title()` (`cap-raw-user`), which is also what the term
-  slug becomes. This is the exact opposite of `create-guest-authors-from-csv`, which
-  sanitises every cell — a shared `build_guest_author_data()` helper during the split
-  would silently change one command or the other. Pinned in "Field values are stored
-  exactly as given, without sanitisation".
+- ~~**No sanitisation at all.** `create_author()` hands `$assoc_args` straight to
+  the creator, which stores every field verbatim — tags in the display name and
+  login, script tags in the description — while only `post_name` is normalised.~~
+  **FIXED**, and this is also the write-path unification PR #1406 deliberately
+  deferred. `Guest_Author_Service` now exposes its sanitiser as
+  `sanitize_profile()` — each field's declared `sanitize_function`, falling back to
+  `sanitize_text_field`, exactly what the admin edit screen applies — and the shared
+  `Guest_Author_Creator` runs every profile through it BEFORE its duplicate lookups
+  and before `create()`'s collision guard, so both vet the value that will actually
+  be stored. Sanitise-first also closed a live variant of the term hijack: a raw
+  `--user_login="<b>jane</b>"` used to miss the guard's user lookup while still
+  producing the slug `cap-jane`. Deliberate limits, pinned as parity rather than
+  perfection: the website field stays unschemed and the login keeps spaces and
+  punctuation, because the admin fallback keeps them too (declaring `esc_url_raw`
+  on the website field would change the admin screen and is its own follow-up);
+  `avatar` is an attachment ID, not a declared field, and bypasses the sanitiser so
+  it still reaches `set_post_thumbnail()`; and the provenance meta records the login
+  exactly as the source supplied it. One non-idempotency to know about, inherited
+  from the admin screen bug-for-bug: `sanitize_text_field` strips `%xx` octets, so
+  a percent-encoded URL sanitised twice loses them — no pinned fixture contains
+  one. CSV keeps its stricter per-cell layer on top; every second pass over its
+  pinned output was verified to be the identity. This was the exact opposite of
+  `create-guest-authors-from-csv`, which sanitises every cell — a shared `build_guest_author_data()` helper during the split
+  would have silently changed one command or the other. Now pinned in "Field values
+  are sanitised as the admin edit screen would sanitise them".
 - The six `Undefined array key` warnings are now pinned as six separate
   `STDOUT should contain:` steps instead of one ordered `.*`-chained regex: their order
   is just the literal order of the array literal at :1156-1163, so a behaviour-preserving
@@ -778,15 +793,17 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   one placeholder per value. Pinned with `--post-statuses=publish,draft`.
 - The skip-postmeta warning interpolates `$wpdb->users`, which is `wp_users` in
   the wp-env tests container (default prefix). Pinned exactly.
-- `--specific-post-ids` takes precedence over `--above-post-id`/`--below-post-id`
-  (elseif at :1235-1239), so an invalid range combined with specific IDs is
-  silently ignored. Noted from source; not pinned.
-- Posts with `post_author = 0` are excluded by the SQL (`post_author <> 0` at
-  :1265) and are therefore invisible to this command, while
-  `list-posts-without-terms` DOES list them. Pinned.
-- `Updating author terms with new counts` is misleading here too:
-  `update_author_term()` only refreshes descriptions; the direct
-  `$wpdb->insert` into term_relationships never updates term counts either.
+- ~~`--specific-post-ids` takes precedence over the range, so an invalid range
+  combined with specific IDs is silently ignored.~~ Duplicate of the entry struck
+  under the resolution block below — fixed by #1419 (unconditional validation plus
+  a stated-precedence warning). This copy predates that block and was missed when
+  it landed; struck now so the catalogue stops disagreeing with itself.
+- ~~Posts with `post_author = 0` are excluded by the SQL and invisible to this
+  command, while `list-posts-without-terms` DOES list them.~~ Duplicate — fixed by
+  #1419 (they now take the orphan path); struck for the same reason as above.
+- ~~`Updating author terms with new counts` is misleading here too.~~ Duplicate —
+  the pass was deleted and the write path replaced by #1425; struck for the same
+  reason as above.
 - Grammar: `Found 1 posts`, `1 records affected` (never pluralised).
 - A post whose author is missing is counted in `Found N posts` but produces
   `0 records affected` after the skip postmeta warning; the run still ends with
@@ -1101,8 +1118,11 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
 
 - Hardened 2026-09-02 after adversarial review: 10 scenarios, all green.
 - **The sanitisation layer is now pinned** (features/fixtures/guest-authors-dirty.csv),
-  because this is the ONLY one of the three commands that sanitises and the difference
-  would otherwise vanish in a refactor. Live results for the row
+  because at the time this was the ONLY one of the three commands that sanitises and
+  the difference would otherwise vanish in a refactor. (The creator now sanitises
+  for all three with the admin fallback; CSV remains the only one layering STRICTER
+  per-cell sanitisers — `sanitize_email`, `esc_url_raw`, non-strict `sanitize_user`
+  — on top, and these pins are what hold that layer in place.) Live results for the row
   `<b>Dirty</b> Name,Dirty Login!,DIRTY@Example.com,example.com/x?a=1&b=2,<script>alert(1)</script><em>Bio</em>,abc,,`:
   - `Processing author Dirty Login! (DIRTY@Example.com)` — the log echoes the RAW
     cells; sanitisation happens after it.

--- a/features/create-author.feature
+++ b/features/create-author.feature
@@ -81,8 +81,16 @@ Feature: A single guest author can be created
 		0
 		"""
 
-	Scenario: Field values are stored exactly as given, without sanitisation
-		When I run `wp co-authors-plus create-author --display_name="<b>Raw</b> Name" --user_login="Raw User!" --user_email=raw@example.com --website=example.com/raw --description="<script>x</script>bio"`
+	# Sanitised as the admin edit screen sanitises the same values: each declared
+	# sanitiser, falling back to sanitize_text_field. So tags are stripped from the
+	# name and login, the script tag leaves only its text, and — deliberately —
+	# the unschemed website and the login's space and punctuation survive, because
+	# the admin fallback keeps them too. This pins parity, not perfection. The
+	# provenance meta keeps the login exactly as the source supplied it.
+	# Contrast create-guest-authors-from-csv, which layers stricter per-cell
+	# sanitisers (sanitize_email, esc_url_raw) on top before the creator runs.
+	Scenario: Field values are sanitised as the admin edit screen would sanitise them
+		When I run `wp co-authors-plus create-author --display_name="<b>Raw</b> Name" --user_login="<b>Raw</b> User!" --user_email=raw@example.com --website=example.com/raw --description="<script>x</script>bio"`
 		Then the return code should be 0
 		And STDOUT should contain:
 		"""
@@ -94,21 +102,20 @@ Feature: A single guest author can be created
 		Then STDOUT should be:
 		"""
 		post_id,meta_key,meta_value
-		{RAW_ID},cap-display_name,"<b>Raw</b> Name"
+		{RAW_ID},cap-display_name,"Raw Name"
 		{RAW_ID},cap-user_login,"Raw User!"
 		{RAW_ID},cap-user_email,raw@example.com
 		{RAW_ID},cap-website,example.com/raw
-		{RAW_ID},cap-description,<script>x</script>bio
-		{RAW_ID},_original_author_login,"Raw User!"
+		{RAW_ID},cap-description,xbio
+		{RAW_ID},_original_author_login,"<b>Raw</b> User!"
 		"""
 		When I run `wp post get {RAW_ID} --field=post_title`
 		Then STDOUT should be:
 		"""
-		<b>Raw</b> Name
+		Raw Name
 		"""
-		# Only the post_name (and hence the term slug) is sanitised, by
-		# CoAuthors_Guest_Authors::create() itself. Contrast
-		# create-guest-authors-from-csv, which sanitises every cell before storing it.
+		# The slug lands where it always did: sanitize_title strips the same tags, so
+		# sanitising the login does not move the post_name or the term slug.
 		When I run `wp post get {RAW_ID} --field=post_name`
 		Then STDOUT should be:
 		"""

--- a/php/cli/class-guest-author-creator.php
+++ b/php/cli/class-guest-author-creator.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\CoAuthorsPlus\CLI;
 
+use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
 use CoAuthors_Plus;
 use WP_CLI;
 
@@ -35,12 +36,21 @@ class Guest_Author_Creator {
 	private $coauthors_plus;
 
 	/**
+	 * Sanitises profile fields the way the admin edit screen does.
+	 *
+	 * @var Guest_Author_Service
+	 */
+	private $profiles;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param CoAuthors_Plus $coauthors_plus Plugin instance.
+	 * @param CoAuthors_Plus       $coauthors_plus Plugin instance.
+	 * @param Guest_Author_Service $profiles       Sanitises profile fields.
 	 */
-	public function __construct( CoAuthors_Plus $coauthors_plus ) {
+	public function __construct( CoAuthors_Plus $coauthors_plus, Guest_Author_Service $profiles ) {
 		$this->coauthors_plus = $coauthors_plus;
+		$this->profiles       = $profiles;
 	}
 
 	/**
@@ -57,14 +67,31 @@ class Guest_Author_Creator {
 	public function create( array $author ): bool {
 		$coauthors_plus = $this->coauthors_plus;
 
+		// Sanitised exactly as the admin edit screen would sanitise the same values,
+		// before the duplicate lookups and the collision guard inside
+		// CoAuthors_Guest_Authors::create() run, so both vet the value that will
+		// actually be stored. $author itself stays unsanitised: the provenance meta
+		// below records the login exactly as the source supplied it.
+		$profile = $this->profiles->sanitize_profile(
+			array(
+				'display_name' => (string) ( $author['display_name'] ?? '' ),
+				'user_login'   => (string) ( $author['user_login'] ?? '' ),
+				'user_email'   => (string) ( $author['user_email'] ?? '' ),
+				'first_name'   => (string) ( $author['first_name'] ?? '' ),
+				'last_name'    => (string) ( $author['last_name'] ?? '' ),
+				'website'      => (string) ( $author['website'] ?? '' ),
+				'description'  => (string) ( $author['description'] ?? '' ),
+			)
+		);
+
 		$guest_author = false;
 
-		if ( ! empty( $author['user_email'] ) ) {
-			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_email', $author['user_email'], true );
+		if ( ! empty( $profile['user_email'] ) ) {
+			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_email', $profile['user_email'], true );
 		}
 
-		if ( ! $guest_author && ! empty( $author['user_login'] ) ) {
-			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', $author['user_login'], true );
+		if ( ! $guest_author && ! empty( $profile['user_login'] ) ) {
+			$guest_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', $profile['user_login'], true );
 		}
 
 		if ( $guest_author ) {
@@ -80,17 +107,10 @@ class Guest_Author_Creator {
 			return true;
 		}
 
+		// avatar is an attachment ID, not a declared profile field, so it bypasses
+		// the sanitiser and keeps reaching set_post_thumbnail().
 		$guest_author_id = $coauthors_plus->guest_authors->create(
-			array(
-				'display_name' => $author['display_name'] ?? '',
-				'user_login'   => $author['user_login'] ?? '',
-				'user_email'   => $author['user_email'] ?? '',
-				'first_name'   => $author['first_name'] ?? '',
-				'last_name'    => $author['last_name'] ?? '',
-				'website'      => $author['website'] ?? '',
-				'description'  => $author['description'] ?? '',
-				'avatar'       => $author['avatar'] ?? '',
-			)
+			array_merge( $profile, array( 'avatar' => $author['avatar'] ?? '' ) )
 		);
 
 		if ( is_wp_error( $guest_author_id ) ) {

--- a/php/cli/register-commands.php
+++ b/php/cli/register-commands.php
@@ -162,9 +162,9 @@ add_action(
 			return;
 		}
 
-		$creator       = new Guest_Author_Creator( $coauthors_plus );
 		$assignments   = new Coauthor_Assignment_Service( $coauthors_plus );
 		$guest_authors = new Guest_Author_Service( $coauthors_plus->guest_authors );
+		$creator       = new Guest_Author_Creator( $coauthors_plus, $guest_authors );
 
 		WP_CLI::add_command(
 			'co-authors-plus export-coauthors',

--- a/php/services/class-guest-author-service.php
+++ b/php/services/class-guest-author-service.php
@@ -95,6 +95,20 @@ class Guest_Author_Service {
 	 * @return int|WP_Error New guest author ID, or an error.
 	 */
 	public function create( array $profile ) {
+		return $this->guest_authors->create( $this->sanitize_profile( $profile ) );
+	}
+
+	/**
+	 * Sanitise a profile the way the admin save does.
+	 *
+	 * Each declared field's sanitize_function is applied, falling back to
+	 * sanitize_text_field. Keys that are not declared fields are dropped, and
+	 * absent fields stay absent rather than becoming empty strings.
+	 *
+	 * @param array<string, string> $profile Field key => raw value.
+	 * @return array<string, string> Field key => sanitised value.
+	 */
+	public function sanitize_profile( array $profile ): array {
 		$args = array();
 
 		foreach ( $this->fields() as $field ) {
@@ -107,7 +121,7 @@ class Guest_Author_Service {
 			$args[ $key ] = $this->sanitize( $field, $profile[ $key ] );
 		}
 
-		return $this->guest_authors->create( $args );
+		return $args;
 	}
 
 	/**

--- a/tests/Unit/Cli/GuestAuthorCreatorTest.php
+++ b/tests/Unit/Cli/GuestAuthorCreatorTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * WordPress-free unit tests for the shared guest author creator's sanitisation.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Cli;
+
+use Automattic\CoAuthorsPlus\CLI\Guest_Author_Creator;
+use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_CLI;
+use WP_CLI\Loggers\Execution;
+
+/**
+ * The creator sanitises the way the admin edit screen does, before its own
+ * duplicate lookups and before CoAuthors_Guest_Authors::create() runs its
+ * collision guard, so both vet the value that will actually be stored — while
+ * the provenance meta keeps the login exactly as the source supplied it.
+ *
+ * @covers \Automattic\CoAuthorsPlus\CLI\Guest_Author_Creator::create
+ */
+final class GuestAuthorCreatorTest extends TestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+
+		WP_CLI::set_logger( new Execution() );
+	}
+
+	public function tear_down(): void {
+		WP_CLI::set_logger( null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * One mocked guest authors instance backs both the service and the creator.
+	 *
+	 * @return array{0: Guest_Author_Creator, 1: \Mockery\MockInterface}
+	 */
+	private function creator(): array {
+		$guest_authors = Mockery::mock( 'CoAuthors_Guest_Authors' );
+		$guest_authors->shouldReceive( 'get_guest_author_fields' )->andReturn(
+			array(
+				array(
+					'key'   => 'display_name',
+					'group' => 'name',
+				),
+				array(
+					'key'   => 'user_login',
+					'group' => 'slug',
+				),
+				array(
+					'key'   => 'user_email',
+					'group' => 'contact-info',
+				),
+			)
+		);
+
+		$coauthors_plus                = Mockery::mock( 'CoAuthors_Plus' );
+		$coauthors_plus->guest_authors = $guest_authors;
+
+		return array(
+			new Guest_Author_Creator( $coauthors_plus, new Guest_Author_Service( $guest_authors ) ),
+			$guest_authors,
+		);
+	}
+
+	/**
+	 * Fails against the unsanitised creator: without the sanitise pass the
+	 * clean: prefixes disappear from every expectation below, the duplicate
+	 * lookups receive the raw values, and the provenance assertion flips.
+	 */
+	public function test_it_sanitises_before_deduping_and_creating_but_keeps_raw_provenance(): void {
+		list( $creator, $guest_authors ) = $this->creator();
+
+		Functions\expect( 'sanitize_text_field' )->times( 3 )->andReturnUsing(
+			static function ( $value ) {
+				return 'clean:' . $value;
+			}
+		);
+
+		$guest_authors->shouldReceive( 'get_guest_author_by' )
+			->once()
+			->with( 'user_email', 'clean:jane@example.com', true )
+			->andReturn( false );
+		$guest_authors->shouldReceive( 'get_guest_author_by' )
+			->once()
+			->with( 'user_login', 'clean:<b>Jane</b>', true )
+			->andReturn( false );
+
+		// avatar is not a declared field, so it must arrive untouched.
+		$guest_authors->shouldReceive( 'create' )
+			->once()
+			->with(
+				array(
+					'display_name' => 'clean:Jane Doe',
+					'user_login'   => 'clean:<b>Jane</b>',
+					'user_email'   => 'clean:jane@example.com',
+					'avatar'       => 123,
+				)
+			)
+			->andReturn( 42 );
+
+		Functions\expect( 'is_wp_error' )->once()->andReturn( false );
+		Functions\expect( 'esc_html__' )->andReturnFirstArg();
+		Functions\expect( 'update_post_meta' )
+			->once()
+			->with( 42, '_original_author_login', '<b>Jane</b>' );
+
+		$this->assertTrue(
+			$creator->create(
+				array(
+					'display_name' => 'Jane Doe',
+					'user_login'   => '<b>Jane</b>',
+					'user_email'   => 'jane@example.com',
+					'avatar'       => 123,
+				)
+			)
+		);
+	}
+}

--- a/tests/Unit/Services/GuestAuthorServiceTest.php
+++ b/tests/Unit/Services/GuestAuthorServiceTest.php
@@ -192,4 +192,28 @@ final class GuestAuthorServiceTest extends TestCase {
 
 		$this->assertSame( $expected, $service->find_by( 'user_login', 'jane-doe' ) );
 	}
+	/**
+	 * The sanitiser is exposed on its own so the CLI creator can share it. An
+	 * absent key stays absent — unlike profile(), which fills gaps with empty
+	 * strings — so a caller can distinguish "not supplied" from "cleared".
+	 */
+	public function test_sanitize_profile_skips_absent_keys_and_drops_undeclared_ones(): void {
+		list( $service ) = $this->service();
+
+		Functions\expect( 'sanitize_text_field' )->once()->andReturnUsing(
+			static function ( $value ) {
+				return 'clean:' . $value;
+			}
+		);
+
+		$this->assertSame(
+			array( 'display_name' => 'clean:Jane Doe' ),
+			$service->sanitize_profile(
+				array(
+					'display_name' => 'Jane Doe',
+					'linked_account' => 'jane-doe',
+				)
+			)
+		);
+	}
 }


### PR DESCRIPTION
## Summary

`create-author` stored every field exactly as typed — tags in the display name and login, script tags in the description — with only the `post_name` normalised. Meanwhile the admin edit screen, the CSV importer and the Phase 1 service all sanitise on write. The CLI creator was the last write path with rules of its own, and this is the reconciliation #1406 explicitly deferred ("the service sanitises each field on the way in, while this helper writes whatever it is handed... reconciling them deserves its own change") and the `create()` follow-up promised on PR #1341.

The mechanism is one implementation, shared: `Guest_Author_Service` exposes its existing sanitiser as `sanitize_profile()` — each declared field's `sanitize_function`, falling back to `sanitize_text_field`, which is precisely what `manage_guest_author_save_meta_fields()` applies — and the shared `Guest_Author_Creator` runs every profile through it. That covers all three import commands at once, and it runs **before** the creator's duplicate lookups and before `create()`'s collision guard, so both vet the value that will actually be stored.

That ordering is not incidental. Sanitise-first closes a live variant of the term hijack fixed in #1426: `--user_login="<b>jane</b>"` used to sail past the guard's user lookup (no user has that literal login) while still producing the slug `cap-jane` — adopting user `jane`'s term through the side door the guard had just closed at the front. Sanitised, the guard sees `jane` and refuses.

## Deliberate limits — parity, not perfection

Every sanitiser output in this PR was verified by executing the real core functions, not recalled, and three things deliberately do **not** change:

- The **website field stays unschemed** and logins keep spaces and punctuation, because the admin fallback (`sanitize_text_field`) keeps them too. Declaring `esc_url_raw` on the website field would change the admin screen as well — its own follow-up, not a stowaway here. One inherited wart to know about, bug-for-bug with the admin screen: `sanitize_text_field` strips `%xx` octets, so a percent-encoded URL sanitised twice loses them. No pinned fixture contains one.
- The **avatar bypasses the sanitiser**. It is an attachment ID, not a declared profile field; full delegation to the service was rejected for exactly this reason, since the service's field loop would have silently dropped it before `set_post_thumbnail()`.
- **Provenance stays raw.** `_original_author_login` records the login exactly as the source supplied it — the scenario now pins `<b>Raw</b> User!` there beside the sanitised `Raw User!` in `cap-user_login`, so the raw/sanitised boundary is itself discriminated.

The CSV importer keeps its stricter per-cell layer (`sanitize_email`, `esc_url_raw`, non-strict `sanitize_user`) on top. Every second-pass application over its pinned fixture values was verified to be the identity, and its feature file passes untouched — those pins are what hold the stricter layer in place now that the creator sanitises for everyone.

## Coverage, against the revert standard

The inverted scenario's login fixture changed to `<b>Raw</b> User!` specifically so the login assertion discriminates — the old `Raw User!` is a `sanitize_text_field` fixed point and would have passed either way. Display name, login, description, `post_title` and the provenance line all flip on revert; the email and website lines pin the fallback being *no stricter* than the admin's. The new creator unit test was mutation-checked at the behaviour level — neutering just the `sanitize_profile()` call, leaving the wiring intact — and fails on the sanitised dedupe lookups, the sanitised `create()` args and the raw provenance write. The slug assertions stay identical on both sides, deliberately: `sanitize_title` strips the same tags, so sanitising the login never moved the slug, and the scenario now says so.

Also included: three stale catalogue duplicates struck — entries still describing defects fixed in #1419 and #1425, left behind because their resolutions landed as consolidated blocks instead of hunting every copy of each entry. The catalogue was disagreeing with itself, which is the exact failure its own "not pinned entries are the ones to distrust" rule warns about.

## Test plan

- [x] Unit: 121 tests / 274 assertions, including the new `sanitize_profile()` and creator tests; creator test verified failing under a behaviour-level mutation
- [x] Behat: all three import features green together at 29 scenarios / 368 steps; CSV and WXR byte-identical to before
- [x] PHPCS exit 0 on all five touched PHP files
- [ ] Full Behat suite and integration matrix via CI