### PR TITLE
Declare sanitize_url as the website field's sanitiser

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -627,15 +627,18 @@ PHP 8.4) rather than inferred from reading the source.
   be stored. Sanitise-first also closed a live variant of the term hijack: a raw
   `--user_login="<b>jane</b>"` used to miss the guard's user lookup while still
   producing the slug `cap-jane`. Deliberate limits, pinned as parity rather than
-  perfection: the website field stays unschemed and the login keeps spaces and
-  punctuation, because the admin fallback keeps them too (declaring `esc_url_raw`
-  on the website field would change the admin screen and is its own follow-up);
+  perfection: the login keeps spaces and punctuation, because the admin
+  fallback keeps them too (the website field followed on: it now declares
+  `sanitize_url` — `esc_url_raw` is its alias, and the `esc_` name is a WP 2.8-era
+  accident core corrected in 5.9 — which schemes unschemed values and preserves
+  percent-encoding on every write path at once, admin screen included,
+  deliberately);
   `avatar` is an attachment ID, not a declared field, and bypasses the sanitiser so
   it still reaches `set_post_thumbnail()`; and the provenance meta records the login
-  exactly as the source supplied it. One non-idempotency to know about, inherited
-  from the admin screen bug-for-bug: `sanitize_text_field` strips `%xx` octets, so
-  a percent-encoded URL sanitised twice loses them — no pinned fixture contains
-  one. CSV keeps its stricter per-cell layer on top; every second pass over its
+  exactly as the source supplied it. ~~One non-idempotency inherited from the admin screen: `sanitize_text_field`
+  strips `%xx` octets from a percent-encoded URL on a second save.~~ **FIXED** by
+  the website field's `sanitize_url` declaration; pinned by an integration test
+  that fails under the fallback. CSV keeps its stricter per-cell layer on top; every second pass over its
   pinned output was verified to be the identity. This was the exact opposite of
   `create-guest-authors-from-csv`, which sanitises every cell — a shared `build_guest_author_data()` helper during the split
   would have silently changed one command or the other. Now pinned in "Field values

--- a/features/create-author.feature
+++ b/features/create-author.feature
@@ -83,9 +83,10 @@ Feature: A single guest author can be created
 
 	# Sanitised as the admin edit screen sanitises the same values: each declared
 	# sanitiser, falling back to sanitize_text_field. So tags are stripped from the
-	# name and login, the script tag leaves only its text, and — deliberately —
-	# the unschemed website and the login's space and punctuation survive, because
-	# the admin fallback keeps them too. This pins parity, not perfection. The
+	# name and login, the script tag leaves only its text, the website is schemed
+	# by its declared esc_url_raw, and — deliberately — the login's space and
+	# punctuation survive, because the admin fallback keeps them too. This pins
+	# parity, not perfection. The
 	# provenance meta keeps the login exactly as the source supplied it.
 	# Contrast create-guest-authors-from-csv, which layers stricter per-cell
 	# sanitisers (sanitize_email, esc_url_raw) on top before the creator runs.
@@ -105,7 +106,7 @@ Feature: A single guest author can be created
 		{RAW_ID},cap-display_name,"Raw Name"
 		{RAW_ID},cap-user_login,"Raw User!"
 		{RAW_ID},cap-user_email,raw@example.com
-		{RAW_ID},cap-website,example.com/raw
+		{RAW_ID},cap-website,http://example.com/raw
 		{RAW_ID},cap-description,xbio
 		{RAW_ID},_original_author_login,"<b>Raw</b> User!"
 		"""

--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1219,10 +1219,18 @@ class CoAuthors_Guest_Authors {
 				'group' => 'slug',
 			),
 			array(
-				'key'   => 'website',
-				'label' => __( 'Website', 'co-authors-plus' ),
-				'group' => 'contact-info',
-				'input' => 'url',
+				'key'               => 'website',
+				'label'             => __( 'Website', 'co-authors-plus' ),
+				'group'             => 'contact-info',
+				'input'             => 'url',
+				// A URL, so the text fallback is wrong for it: sanitize_text_field kept
+				// unschemed values (invalid in Yoast's sameAs output) and strips %xx
+				// octets from an already-encoded URL on a second save. Declaring the
+				// sanitiser here covers the admin save, the service and the CLI at once.
+				// sanitize_url() is esc_url() in the 'db' context — the storage-side
+				// cleaner, un-deprecated in WP 5.9 as the name for exactly this; the
+				// better-known esc_url_raw() is its alias.
+				'sanitize_function' => 'sanitize_url',
 			),
 			array(
 				'key'               => 'description',

--- a/php/cli/class-create-guest-authors-from-csv-command.php
+++ b/php/cli/class-create-guest-authors-from-csv-command.php
@@ -112,7 +112,7 @@ class Create_Guest_Authors_From_Csv_Command {
 				'display_name' => sanitize_text_field( $author['display_name'] ),
 				'user_login'   => sanitize_user( $author['user_login'] ),
 				'user_email'   => sanitize_email( $author['user_email'] ),
-				'website'      => esc_url_raw( $author['website'] ),
+				'website'      => sanitize_url( $author['website'] ),
 				'description'  => wp_filter_post_kses( $author['description'] ),
 				'avatar'       => absint( $author['avatar'] ),
 			);

--- a/tests/Integration/GuestAuthors/GuestAuthorSaveCapsTest.php
+++ b/tests/Integration/GuestAuthors/GuestAuthorSaveCapsTest.php
@@ -219,4 +219,45 @@ class GuestAuthorSaveCapsTest extends TestCase {
 			'Missing nonce must prevent writes even for authorised users.'
 		);
 	}
+	/**
+	 * The website field declares esc_url_raw, so an unschemed value is stored
+	 * schemed. Under the sanitize_text_field fallback it was stored as typed,
+	 * which Yoast then shipped verbatim as an invalid sameAs URL.
+	 */
+	public function test_save_meta_fields_schemes_the_website_field(): void {
+		wp_set_current_user( $this->admin->ID );
+
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-website']        = 'example.com/raw';
+
+		$post = get_post( $this->guest_author_post_id );
+		$this->_cap->guest_authors->manage_guest_author_save_meta_fields( $this->guest_author_post_id, $post );
+
+		$this->assertSame(
+			'http://example.com/raw',
+			get_post_meta( $this->guest_author_post_id, 'cap-website', true ),
+			'An unschemed website should be stored schemed, as esc_url_raw leaves it.'
+		);
+	}
+
+	/**
+	 * The declared esc_url_raw preserves percent-encoding, where the text fallback stripped
+	 * %xx octets — so a URL that had been encoded once was mangled on the next
+	 * save. This is the assertion that fails under the fallback (ab, not a%20b).
+	 */
+	public function test_save_meta_fields_preserves_percent_encoding_in_website(): void {
+		wp_set_current_user( $this->admin->ID );
+
+		$_POST['guest-author-nonce'] = wp_create_nonce( 'guest-author-nonce' );
+		$_POST['cap-website']        = 'http://example.com/a%20b';
+
+		$post = get_post( $this->guest_author_post_id );
+		$this->_cap->guest_authors->manage_guest_author_save_meta_fields( $this->guest_author_post_id, $post );
+
+		$this->assertSame(
+			'http://example.com/a%20b',
+			get_post_meta( $this->guest_author_post_id, 'cap-website', true ),
+			'Percent-encoded octets must survive a resave.'
+		);
+	}
 }


### PR DESCRIPTION
## Summary

The website field carried no declared sanitiser, so every write path applied the `sanitize_text_field` fallback — the wrong shape for a URL in two ways. An unschemed value (`example.com/raw`) was stored as typed; the front-end links repair that at render through `esc_url()`, but the Yoast integration (`php/integrations/yoast/class-coauthor.php:151`) ships the stored value verbatim into `sameAs` JSON-LD, so it went out as invalid structured data. And `sanitize_text_field` strips `%xx` octets, so a URL percent-encoded on one save was quietly mangled on the next.

The fix is the one-line declaration on the field. Because the write paths were unified in the last PR — the admin save, `Guest_Author_Service` and the CLI creator all apply the declared sanitiser — one declaration now fixes all of them at once, which is precisely the pay-off that unification was for. This is the follow-up that PR flagged by name.

**Changing what the admin screen stores is the point, not a side effect.** Unschemed input is schemed on save from now on; values already stored stay as they are until something resaves them (no migration — the render paths cope either way, and rewriting user data in place is not this PR's business). That makes it a changelog-worthy behaviour change, which is why it did not ride along with the unification.

## Why `sanitize_url()` and not `esc_url_raw()`

Review asked whether `esc_url_raw()` is actually a sanitiser, and the answer decided the spelling. Functionally yes: it is `esc_url()` in the `'db'` context — the storage-side cleaner, not display escaping. Nominally no: the `esc_` prefix is a WP 2.8-era accident, and core corrected it in 5.9 by un-deprecating `sanitize_url()` as the recommended name for exactly this use, leaving `esc_url_raw()` as its alias (verified against the running core: its docblock returns "the cleaned URL after sanitize_url() is run"). A key literally named `sanitize_function` should hold a function that says it sanitises, so the declaration uses `sanitize_url`, and the CSV importer's own call moves to the same name so the plugin has one spelling for one operation. Byte-identical behaviour, established by reading the alias in core rather than assumed.

## Coverage, against the revert standard

Two integration tests on the admin save path — the unschemed value stored as `http://example.com/raw`, and `http://example.com/a%20b` surviving a resave intact. Both were verified to fail with the declaration reverted (`example.com/raw` and `.../ab` respectively), and *only* those two fail. The create-author scenario's website line re-pins as schemed — its old value was deliberately chosen last PR as a fallback fixed point, so it now discriminates this change instead. The CSV feature passes byte-identical, which is the double-sanitisation guard doing its job: its pinned values are already `sanitize_url` output, so the second application must be the identity, and its exact-match assertions prove it.

The comment written into the scenario and the behaviour notes only yesterday — that the unschemed website "deliberately survives" — is corrected in both places rather than left describing a limit that no longer exists.

## Test plan

- [x] Integration: `GuestAuthorSaveCapsTest` 8/8, both new tests confirmed failing under the reverted declaration
- [x] Behat: create-author + CSV features green together at 21 scenarios / 249 steps (run before the alias rename; the rename is byte-identical by core's own definition)
- [x] Unit: 121/274 after the rename
- [x] PHPCS: the god class steady at its 179-error baseline; CSV command and test file exit 0
- [ ] Full Behat suite and integration matrix via CI