### PR TITLE
Load the importer's toolkit so a bad WXR errors instead of fataling

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -474,13 +474,20 @@ PHP 8.4) rather than inferred from reading the source.
   the scenario matches the path with a wildcard, so it passes either way. It ships on
   the reasoning that a site with `WP_PLUGIN_DIR` set elsewhere would otherwise be
   told the importer is missing when it is merely somewhere else.
-- STILL OPEN: `Failed to read WXR file.` remains unreachable. A file that is not a
-  WXR still fatals inside wordpress-importer 0.9.6's parser fallback chain rather
-  than returning a `WP_Error`, and the crash happens inside `parse()` before any
-  return value exists to check. Turning that into a clean error means validating the
-  file before handing it over, which is a larger piece of work than a guard. The
-  scenario pinning the fatal records the current behaviour and says why the branch
-  cannot fire.
+- ~~`Failed to read WXR file.` is unreachable: a file that is not a WXR fatals
+  inside wordpress-importer 0.9.6's parser fallback chain rather than returning a
+  `WP_Error`.~~ **FIXED**, and the earlier framing of the fix was wrong twice over.
+  It is not "validate the file first" and not the importer's bug: the fallback
+  parser (`WXR_Parser_XML_Processor`) needs the importer's bundled php-toolkit,
+  which only the importer's own bootstrap loads — CAP half-loaded the parser by
+  requiring `parsers.php` alone, breaking the parser's error contract. Loading the
+  toolkit under the exact guard the bootstrap uses
+  (`class_exists( 'WordPress\XML\XMLProcessor' )`, plus `file_exists` so older
+  importers without a toolkit keep their self-contained chain) makes garbage return
+  `WP_Error( 'WXR_parse_error', ... )` — verified live before patching — and the
+  dead branch both reachable and pinned. Valid files are untouched: SimpleXML still
+  returns first, confirmed against the good fixture. The error now appends the
+  parser's reason after CAP's own prefix; only CAP's half is pinned.
 
 ## remove-terms-from-revisions
 
@@ -1203,16 +1210,12 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   `Fatal error: Uncaught Error: Failed opening required
   '.../wordpress-importer/parsers.php'` display copy (plus the full stack trace).
   Pinned via `should contain:` on `Fatal error` / `wordpress-importer/parsers.php`.
-- The clean `Error: Failed to read WXR file.` exit (php/class-wp-cli.php:1009) is
-  UNREACHABLE with the wordpress-importer version that `wp plugin install` fetches
-  today (0.9.6). Feeding a non-XML file does not return a `WP_Error`: `WXR_Parser`
-  falls through to `WXR_Parser_XML_Processor`, which fatals with
-  `Uncaught Error: Class "WordPress\DataLiberation\EntityReader\WXREntityReader"
-  not found` in wordpress-importer/parsers/class-wxr-parser-xml-processor.php:357,
-  because CAP `require`s only parsers.php (line 1002) without the importer's
-  autoloader for the Data Liberation library. Exit code 1 via the same
-  critical-error handler. The draft's clean-error scenario was rewritten as
-  "Fatal error on a file that is not a WXR file" (pinned: exit 1, `Fatal error`,
+- ~~The clean `Error: Failed to read WXR file.` exit is UNREACHABLE with importer
+  0.9.6: `WXR_Parser` falls through to `WXR_Parser_XML_Processor`, which fatals on a
+  missing Data Liberation class because CAP requires only parsers.php without the
+  toolkit.~~ **FIXED** — see the resolution above; the fatal-pinning scenario became
+  "A file that is not a WXR is reported, not fatal". Historical calibration detail
+  of the old fatal (pinned then: exit 1, `Fatal error`,
   the xml-processor path, and 0 guest authors created). A valid WXR file parses
   fine (the SimpleXML parser succeeds before the fallback chain is reached).
 - The WXR flow never sets `website`, `description`, or `avatar` keys, so
@@ -1268,8 +1271,9 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   instead of borrowing the CSV group's fixture, and asserts only rc 1, loose
   `/Fatal error/` + `/wordpress-importer/` matches, `STDERR should not match /Failed to
   read WXR file/` and 0 guest authors. Same fatal as with a CSV file
-  (`Class "WordPress\DataLiberation\EntityReader\WXREntityReader" not found`), so
-  CAP's clean `Failed to read WXR file.` branch stays dead at the pinned version.
+  (`Class "WordPress\DataLiberation\EntityReader\WXREntityReader" not found`) —
+  historical; resolved by the toolkit load above. Note a CSV handed to the WXR
+  command now gets the clean parse error too, for the same reason.
 - A valid WXR with NO `<wp:author>` nodes (features/fixtures/no-authors.wxr) prints
   exactly `All done!`, exits 0 and creates nothing — `$import_data['authors']` is an
   empty array rather than an undefined key, so the `foreach` at :1017 is quiet. Now

--- a/features/create-guest-authors-from-wxr.feature
+++ b/features/create-guest-authors-from-wxr.feature
@@ -224,16 +224,21 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		2
 		"""
 
-	Scenario: Fatal error in the importer when the file is not a WXR file
+	# The importer's fallback parser used to fatal here, because CAP loaded
+	# parsers.php without the bundled toolkit the fallback needs — so the branch
+	# reporting this error could never run. With the toolkit loaded the same way
+	# the importer's own bootstrap loads it, the parser returns the WP_Error it
+	# was always meant to. Only CAP's half of the message is pinned; the reason
+	# after the colon belongs to wordpress-importer.
+	Scenario: A file that is not a WXR is reported, not fatal
 		When I try `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/not-a-wxr.xml`
 		Then the return code should be 1
-		# The crash comes from wordpress-importer 0.9.6's parser fallback chain, so only
-		# the fact that CAP dies inside that plugin is pinned, not the class or file.
-		And STDOUT should match /Fatal error/
-		And STDOUT should match /wordpress-importer/
-		# CAP's own `Failed to read WXR file.` branch is unreachable: the parser fatals
-		# rather than returning a WP_Error.
-		And STDERR should not match /Failed to read WXR file/
+		And STDOUT should be empty
+		And STDERR should contain:
+		"""
+		Error: Failed to read WXR file:
+		"""
+		And STDERR should not match /Fatal error/
 		When I run `wp post list --post_type=guest-author --format=count`
 		Then STDOUT should be:
 		"""

--- a/php/cli/class-create-guest-authors-from-wxr-command.php
+++ b/php/cli/class-create-guest-authors-from-wxr-command.php
@@ -84,11 +84,23 @@ class Create_Guest_Authors_From_Wxr_Command {
 			require_once $parser_path;
 		}
 
+		// The 0.9.x importer's fallback parser needs the bundled toolkit, which only
+		// the importer's own bootstrap loads. Without it, a file that is not a WXR
+		// fatals inside the fallback instead of returning the WP_Error the branch
+		// below reads — the branch was unreachable for exactly this reason. Guarded
+		// as the bootstrap guards it; older importers have no toolkit and their
+		// fallback chain is self-contained.
+		$toolkit_path = WP_PLUGIN_DIR . '/wordpress-importer/php-toolkit/load.php';
+
+		if ( ! class_exists( 'WordPress\\XML\\XMLProcessor' ) && file_exists( $toolkit_path ) ) {
+			require_once $toolkit_path;
+		}
+
 		$parser      = new WXR_Parser();
 		$import_data = $parser->parse( $parsed_args['file'] );
 
 		if ( is_wp_error( $import_data ) ) {
-			WP_CLI::error( 'Failed to read WXR file.' );
+			WP_CLI::error( 'Failed to read WXR file: ' . $import_data->get_error_message() );
 		}
 
 		// Get author nodes.


### PR DESCRIPTION
## Summary

Feeding `create-guest-authors-from-wxr` a file that is not a WXR produced an uncaught PHP fatal from inside wordpress-importer — a stack trace on STDOUT, WordPress's generic critical-error line, and CAP's own `Failed to read WXR file.` branch sitting unreachable below it.

The behaviour catalogue framed the fix as "validate the file before handing it over", and I repeated that framing as recently as #1423. Reading the installed importer showed something simpler and better. Importer 0.9.x's fallback parser (`WXR_Parser_XML_Processor`) depends on the importer's bundled php-toolkit, which only the importer's **own bootstrap** loads — and CAP loads only `parsers.php`. Valid files never noticed, because `WXR_Parser` returns via SimpleXML first. Garbage fell through to the half-loaded fallback, which died reaching for a class that was never required. The parser's error contract was fine all along; **we had broken it by half-loading the parser.**

So the fix is not new validation logic — it is loading what we half-loaded: the toolkit, under the *exact* guard the importer's bootstrap uses (`class_exists( 'WordPress\XML\XMLProcessor' )`), plus a `file_exists` check so older importer versions, which have no toolkit and a self-contained fallback chain, are unaffected.

Probed live in the container before patching: with the toolkit present, the non-WXR fixture returns `WP_Error( 'WXR_parse_error', 'This does not appear to be a WXR file, missing/invalid WXR version number' )`, and the good fixture still parses its two authors through SimpleXML exactly as before.

The error now appends the parser's reason after CAP's prefix — an operator holding a 300 MB export wants to know whether it is truncated or simply not a WXR. Only CAP's half (`Failed to read WXR file:`) is pinned; the wording after the colon belongs to wordpress-importer.

## Coverage

The scenario that pinned the fatal inverts into the clean error, which discriminates by construction: revert the toolkit load and the fatal returns, failing both the `STDERR should contain` on CAP's prefix and the explicit `STDERR should not match /Fatal error/`. The remaining seven scenarios — including the importer-absent guard from #1423 and every valid-file path — pass unchanged, which is the proof that loading the toolkit changed nothing for good files.

A side effect worth noting: a CSV handed to the WXR command now also gets the clean parse error rather than the identical fatal, for the same reason, and the catalogue records it.

## Test plan

- [x] `features/create-guest-authors-from-wxr.feature` green at 8 scenarios / 119 steps
- [x] Fallback behaviour probed live against the installed importer before patching, for both the garbage and the good fixture
- [x] PHPCS exit 0 on the changed file
- [ ] Full Behat suite via CI