### PR TITLE
Pluralise every CLI count message

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -18,9 +18,10 @@ PHP 8.4) rather than inferred from reading the source.
 
 (Calibrated against the live env 2026-09-01; all scenarios green.)
 
-- Summary lines never pluralise: `- 1 posts now have the proper co-author`,
-  `- 1 posts already had the co-author assigned` even for a single post
-  (php/class-wp-cli.php:415-425). Confirmed.
+- ~~Summary lines never pluralise: `- 1 posts now have the proper co-author`,
+  `- 1 posts already had the co-author assigned` even for a single post.~~ **FIXED** by the pluralisation sweep: `_n()` with `%s` and `number_format_i18n()`, both branches pinned.
+  The "already had" plural needed a two-post extension of the re-run scenario;
+  nothing else ever reached it, because the count is truthiness-guarded.
 - When a run matches nothing, the output is just `All done! Here are your results:`
   with no result lines at all — there is no "0 posts" line and no per-post output.
   Confirmed.
@@ -265,11 +266,13 @@ PHP 8.4) rather than inferred from reading the source.
 - The two summary lines this added are pluralised with `_n()` from the outset,
   following `assign-user-to-coauthor`, and both branches are covered by scenarios —
   one post and two. The general pluralisation sweep across the older strings is
-  still deferred to its own pass, but that is a reason to leave existing strings
-  alone, not a licence to add new broken ones. Note the new strings use `%s` rather
+  now done, but the principle stands: it was a reason to leave existing strings
+  alone, never a licence to add new broken ones. The new strings used `%s` rather
   than the precedent's `%d`: `number_format_i18n()` returns a thousands-separated
-  string, and `%d` truncates `1,234` to `1`. The precedent has that bug; it is
-  logged here rather than fixed in passing, since it belongs to another command.
+  string, and `%d` truncates `1,234` to `1`. ~~The precedent has that bug.~~
+  **FIXED** in the sweep, pinned by a unit test that stubs the formatter to return
+  `1,234` and asserts it survives into the output — Behat cannot stage a thousand
+  posts, so the formatting contract is tested instead of the volume.
 
 ## (shared test environment — affects everyone's calibration)
 
@@ -329,10 +332,13 @@ PHP 8.4) rather than inferred from reading the source.
 - "Error: Term 'x' doesn't exist, skipping" is emitted via `WP_CLI::log` to STDOUT
   and the exit code stays 0 (line 580), so scripted callers cannot detect the miss
   from the exit code. Confirmed.
-- Summary lines never pluralise: `- 1 authors were successfully reassigned terms`
-  (lines 610-612). Confirmed.
-- The merge message's post count comes straight from `$old_term->count` and read
-  `Reassigning 1 posts` for one published post carrying the term — CAP's custom
+- ~~Summary lines never pluralise: `- 1 authors were successfully reassigned
+  terms`.~~ **FIXED** by the pluralisation sweep: `_n()` with `%s` and `number_format_i18n()`, both branches pinned. The singular of the missing-terms line reads "was missing an
+  old term", since each author misses exactly one. The merge message's plural
+  (`Reassigning 2 posts`) needed a new two-post merge scenario: the merge path can
+  never report zero, so no existing pin exercised it.
+- The merge message's post count comes straight from `$old_term->count` (it read
+  `Reassigning 1 posts` before the sweep; now `1 post`) — CAP's custom
   `_update_users_posts_count` had run on `wp post term add`. Confirmed.
 
 - Re-calibrated 2026-09-02 after adversarial review: 11 scenarios, all green.
@@ -417,8 +423,8 @@ PHP 8.4) rather than inferred from reading the source.
   unobserved. A `get_terms()` `WP_Error` is now caught too — without that,
   `array_filter()` on a non-array would have turned a PHP warning into a fatal.
 - ~~The success message reads "All done! Grab a cold one (Affogatto)".~~ **FIXED** —
-  the drink is an *affogato*. "Now migrating up to 1 terms" still does not
-  pluralise; that belongs to the pluralisation sweep, which is deliberately left as
+  the drink is an *affogato*. ~~"Now migrating up to 1 terms" still does not
+  pluralise~~ — **FIXED** by the sweep, which was deliberately left as
   one dedicated pass rather than scattered through fix PRs, since it touches nearly
   every command and feature file.
 - Terms are processed in `get_terms` default order (name ASC). Still true, but no
@@ -504,8 +510,9 @@ PHP 8.4) rather than inferred from reading the source.
   init. Revisions are still read via direct SQL on `post_type='revision' AND
   post_status='inherit'`.
 - All output is `WP_CLI::log` — there is no `WP_CLI::success` and the exit code is
-  always 0. Count lines never pluralise: "Found 1 revisions to look through",
-  "1 revisions had author terms removed". Confirmed.
+  always 0 (deliberately left; see the correction below — siblings exit 0 too).
+  ~~Count lines never pluralise: "Found 1 revisions to look through", "1 revisions
+  had author terms removed".~~ **FIXED** by the pluralisation sweep: `_n()` with `%s` and `number_format_i18n()`, both branches pinned.
 - Current plugin code no longer adds author terms to revisions
   (`coauthors_update_post` bails for unsupported post types such as `revision`),
   so the characterisation scenarios attach terms to revisions manually to
@@ -731,7 +738,10 @@ PHP 8.4) rather than inferred from reading the source.
 - The command walks every supported post type (post AND page by default), unlike
   `create-author-terms-for-posts` which defaults to `post` only. Pinned in the
   "Pages are inspected by default" scenario.
-- Never-pluralised grammar: `Of 1 posts, 1 now have author terms.`
+- ~~Never-pluralised grammar: `Of 1 posts, 1 now have author terms.`~~ **FIXED**,
+  and reworded rather than merely pluralised: two counts share the sentence, so it
+  became `Done! Author terms added to %1$s of %2$s post(s).`, where only the
+  trailing noun needs agreement and one `_n()` selection (on the total) covers it.
 - ~~The two per-post log lines use DIFFERENT identifiers for the same term: the
   "Skipping" line prints term NAMES while the "Added" line prints the user's
   `user_nicename` — neither shows the `cap-` prefixed slug that is actually
@@ -814,7 +824,7 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
 - ~~`Updating author terms with new counts` is misleading here too.~~ Duplicate —
   the pass was deleted and the write path replaced by #1425; struck for the same
   reason as above.
-- Grammar: `Found 1 posts`, `1 records affected` (never pluralised).
+- ~~Grammar: `Found 1 posts`, `1 records affected` (never pluralised).~~ **FIXED** by the pluralisation sweep: `_n()` with `%s` and `number_format_i18n()`, both branches pinned.
 - A post whose author is missing is counted in `Found N posts` but produces
   `0 records affected` after the skip postmeta warning; the run still ends with
   `Success: Done!`.
@@ -1070,8 +1080,9 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   assertions.
 - Author terms are created for EVERY user returned by `get_users()` regardless
   of role or post count.
-- Grammar: `Now updating 1 terms`; final message is `Success: All done` (no
-  full stop), unlike other subcommands' `All done!`.
+- ~~Grammar: `Now updating 1 terms`.~~ **FIXED** by the pluralisation sweep: `_n()` with `%s` and `number_format_i18n()`, both branches pinned. The final message is still
+  `Success: All done` (no full stop), unlike other subcommands' `All done!` —
+  cosmetic, deliberately untouched.
 
 
 - Hardened 2026-09-02 after adversarial review: 8 scenarios.
@@ -1123,8 +1134,8 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
     CSV path can produce those warnings. The created profile then has no
     `cap-first_name`/`cap-last_name` meta at all. Pinned with
     features/fixtures/guest-authors-single-name.csv (display_name `Prince`).
-  - Count line does not pluralise: a one-row CSV logs `Found 1 authors in CSV`
-    (:1090). Pinned.
+  - ~~Count line does not pluralise: a one-row CSV logs `Found 1 authors in
+    CSV`.~~ **FIXED** by the pluralisation sweep, both branches pinned.
 
 - Hardened 2026-09-02 after adversarial review: 10 scenarios, all green.
 - **The sanitisation layer is now pinned** (features/fixtures/guest-authors-dirty.csv),

--- a/features/assign-coauthors.feature
+++ b/features/assign-coauthors.feature
@@ -27,10 +27,10 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		2: Post #{POST_ID_2} already has "author1" associated as a co-author
 		3: Post #{POST_ID_3} does not have "ghostwriter" associated as a co-author but there is not a co-author profile
 		All done! Here are your results:
-		- 1 posts already had the co-author assigned
-		- 1 posts reference co-authors that don't exist. These are:
+		- 1 post already had the co-author assigned
+		- 1 post references a co-author that doesn't exist. This is:
 		  ghostwriter
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={POST_ID_1} --field=slug`
 		Then STDOUT should be:
@@ -54,19 +54,26 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		And I run `wp post create --post_title="Imported post" --post_status=publish --porcelain`
 		And save STDOUT as {POST_ID}
 		And I run `wp post meta update {POST_ID} _original_import_author author1`
+		And I run `wp post create --post_title="Second import" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post meta update {POST_B} _original_import_author author1`
 		And I run `wp co-authors-plus assign-coauthors`
 		Then STDOUT should be:
 		"""
 		1: Post #{POST_ID} has been assigned "author1" as the author
+		2: Post #{POST_B} has been assigned "author1" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 2 posts now have the proper co-author
 		"""
+		# Two posts, so the plural branch of the "already had" summary runs too;
+		# nothing else ever pins it, because the count is truthiness-guarded.
 		When I run the previous command again
 		Then STDOUT should be:
 		"""
 		1: Post #{POST_ID} already has "author1" associated as a co-author
+		2: Post #{POST_B} already has "author1" associated as a co-author
 		All done! Here are your results:
-		- 1 posts already had the co-author assigned
+		- 2 posts already had the co-author assigned
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -89,7 +96,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "author1" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -117,7 +124,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "author1" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -171,7 +178,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "author2" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -199,7 +206,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "author2" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -219,7 +226,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "author3" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -244,7 +251,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{PAGE_ID} has been assigned "author1" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
 		Then STDOUT should be:
@@ -262,7 +269,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "author-one" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		"""
 		# The raw meta value is "Author One"; the resolved login is "author-one". The
 		# comparison used to be against the raw value, so it never matched what had just
@@ -272,7 +279,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} already has "author-one" associated as a co-author
 		All done! Here are your results:
-		- 1 posts already had the co-author assigned
+		- 1 post already had the co-author assigned
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -296,7 +303,7 @@ Feature: Co-authors can be assigned to posts from a post meta value
 		"""
 		1: Post #{POST_ID} has been assigned "jane-doe" as the author
 		All done! Here are your results:
-		- 1 posts now have the proper co-author
+		- 1 post now has the proper co-author
 		- 1 post kept its original post_author, because no co-author assigned to it has a WordPress account
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`

--- a/features/create-author-terms-for-posts.feature
+++ b/features/create-author-terms-for-posts.feature
@@ -87,10 +87,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		When I run `wp co-authors-plus create-author-terms-for-posts --post-statuses=draft`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_ID} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -132,10 +132,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		When I run `wp co-authors-plus create-author-terms-for-posts --post-types=page`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {PAGE_ID} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {PAGE_ID} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 
@@ -149,10 +149,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus create-author-terms-for-posts --specific-post-ids={POST_A}`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_A} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -173,10 +173,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And STDOUT should be:
 		"""
 		Warning: --above-post-id and --below-post-id are ignored when --specific-post-ids is given.
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_B} --field=slug`
@@ -198,10 +198,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus create-author-terms-for-posts --above-post-id={POST_A} --below-post-id={POST_C}`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --format=count`
@@ -225,10 +225,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus create-author-terms-for-posts --above-post-id={POST_A}`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_B} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_B} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --format=count`
@@ -247,10 +247,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus create-author-terms-for-posts --below-post-id={POST_B}`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_A} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_A} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
@@ -286,7 +286,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus create-author-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
@@ -324,7 +324,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		When I run `wp co-authors-plus create-author-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Warning: Post Author ID 0 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected
@@ -403,10 +403,10 @@ Feature: Missing author terms can be backfilled for targeted posts
 		And I run `wp co-authors-plus create-author-terms-for-posts --unbatched`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Success: Inserted term relationship for post {POST_ID} and author 1 (admin).
-		1 records affected
+		1 record affected
 		Success: Done!
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -432,7 +432,7 @@ Feature: Missing author terms can be backfilled for targeted posts
 		When I run `wp co-authors-plus create-author-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Found 1 posts with missing author terms.
+		Found 1 post with missing author terms.
 		Processing post {POST_ID} (1/1 or 100.00%)
 		Warning: Post Author ID 999 does not exist in wp_users table, inserting skip postmeta (`_cap_skip_backfill`).
 		0 records affected

--- a/features/create-guest-author.feature
+++ b/features/create-guest-author.feature
@@ -7,9 +7,9 @@ Feature: Guest authors can be created
 		When I run `wp co-authors-plus create-guest-authors`
 		Then STDOUT should be:
       """
-      Attempting to create guest author profiles for 1 users.
+      Attempting to create a guest author profile for 1 user.
       All done! Here are your results:
-      - 1 guest author profiles were created
+      - 1 guest author profile was created
       - 0 users already had guest author profiles
       """
 
@@ -18,10 +18,10 @@ Feature: Guest authors can be created
 		Then I run the previous command again
 		Then STDOUT should be:
       """
-      Attempting to create guest author profiles for 1 users.
+      Attempting to create a guest author profile for 1 user.
       All done! Here are your results:
       - 0 guest author profiles were created
-      - 1 users already had guest author profiles
+      - 1 user already had a guest author profile
       """
 
 	Scenario: Process a chunk of users with --offset and --number
@@ -46,6 +46,6 @@ Feature: Guest authors can be created
       """
       Attempting to create guest author profiles for 3 users.
       All done! Here are your results:
-      - 1 guest author profiles were created
+      - 1 guest author profile was created
       - 2 users already had guest author profiles
       """

--- a/features/create-guest-authors-from-csv.feature
+++ b/features/create-guest-authors-from-csv.feature
@@ -108,7 +108,7 @@ Feature: Guest authors can be created from a CSV file
 		Then the return code should be 0
 		And STDOUT should contain:
 		"""
-		Found 1 authors in CSV
+		Found 1 author in CSV
 		"""
 		And STDOUT should contain:
 		"""
@@ -188,7 +188,7 @@ Feature: Guest authors can be created from a CSV file
 		Then the return code should be 0
 		And STDOUT should contain:
 		"""
-		Found 1 authors in CSV
+		Found 1 author in CSV
 		"""
 		And STDOUT should contain:
 		"""
@@ -266,6 +266,17 @@ Feature: Guest authors can be created from a CSV file
 		Then STDOUT should be:
 		"""
 		cap-valid-person
+		"""
+		# A one-row file whose only row fails, so the tally's singular branch runs.
+		When I run `wp co-authors-plus create-guest-authors-from-csv --file=features/fixtures/guest-authors-invalid-single.csv`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Found 1 author in CSV
+		"""
+		And STDOUT should contain:
+		"""
+		Warning: 1 of 1 author could not be created.
 		"""
 
 	Scenario: A CSV file with only a header row creates nothing

--- a/features/create-guest-authors-from-wxr.feature
+++ b/features/create-guest-authors-from-wxr.feature
@@ -199,6 +199,13 @@ Feature: Guest authors can be created from the author nodes of a WXR file
 		cap-wxr-good-one
 		cap-wxr-good-two
 		"""
+		# A file whose only author node fails, so the tally's singular branch runs.
+		When I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors-invalid-single.wxr`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		Warning: 1 of 1 author could not be created.
+		"""
 
 	Scenario: Importing the same WXR file twice skips the existing guest authors
 		Given I run `wp co-authors-plus create-guest-authors-from-wxr --file=features/fixtures/guest-authors.wxr`

--- a/features/create-terms-for-posts.feature
+++ b/features/create-terms-for-posts.feature
@@ -8,8 +8,8 @@ Feature: Author terms can be created for all posts
 		When I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 0 total posts.
-		Success: Done! Of 0 posts, 0 now have author terms.
+		Now inspecting or updating 0 posts.
+		Success: Done! Author terms added to 0 of 0 posts.
 		"""
 
 	Scenario: Add author terms to posts that are missing them, then skip them on a second run
@@ -22,12 +22,12 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 2 total posts.
+		Now inspecting or updating 2 posts.
 		No co-authors found for post #{POST_A}.
 		1/2) Added - Post #{POST_A} 'First post' now has this author term: cap-admin
 		No co-authors found for post #{POST_B}.
 		2/2) Added - Post #{POST_B} 'Second post' now has this author term: cap-admin
-		Success: Done! Of 2 posts, 2 now have author terms.
+		Success: Done! Author terms added to 2 of 2 posts.
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
 		Then STDOUT should be:
@@ -37,10 +37,10 @@ Feature: Author terms can be created for all posts
 		When I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 2 total posts.
+		Now inspecting or updating 2 posts.
 		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: cap-admin
 		2/2) Skipping - Post #{POST_B} 'Second post' already has these terms: cap-admin
-		Success: Done! Of 2 posts, 0 now have author terms.
+		Success: Done! Author terms added to 0 of 2 posts.
 		"""
 
 	Scenario: Skip posts that already have author terms while fixing those without
@@ -52,11 +52,11 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 2 total posts.
+		Now inspecting or updating 2 posts.
 		1/2) Skipping - Post #{POST_A} 'First post' already has these terms: cap-admin
 		No co-authors found for post #{POST_B}.
 		2/2) Added - Post #{POST_B} 'Second post' now has this author term: cap-admin
-		Success: Done! Of 2 posts, 1 now have author terms.
+		Success: Done! Author terms added to 1 of 2 posts.
 		"""
 		When I run `wp term list author --object_ids={POST_B} --field=slug`
 		Then STDOUT should be:
@@ -71,10 +71,10 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 1 total posts.
+		Now inspecting or updating 1 post.
 		No co-authors found for post #{PAGE_ID}.
 		1/1) Added - Post #{PAGE_ID} 'About page' now has this author term: cap-admin
-		Success: Done! Of 1 posts, 1 now have author terms.
+		Success: Done! Author terms added to 1 of 1 post.
 		"""
 		When I run `wp term list author --object_ids={PAGE_ID} --field=slug`
 		Then STDOUT should be:
@@ -91,10 +91,10 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 1 total posts.
+		Now inspecting or updating 1 post.
 		No co-authors found for post #{POST_ID}.
 		1/1) Added - Post #{POST_ID} 'Writer post' now has this author term: cap-writer
-		Success: Done! Of 1 posts, 1 now have author terms.
+		Success: Done! Author terms added to 1 of 1 post.
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -110,10 +110,10 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 1 total posts.
+		Now inspecting or updating 1 post.
 		No co-authors found for post #{POST_ID}.
 		Warning: 1/1) Skipping - Post #{POST_ID} 'Orphan post' has no author term for user ID 999.
-		Success: Done! Of 1 posts, 0 now have author terms.
+		Success: Done! Author terms added to 0 of 1 post.
 		"""
 		And the return code should be 0
 		When I run `wp term list author --object_ids={POST_ID} --format=count`
@@ -136,12 +136,12 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 2 total posts.
+		Now inspecting or updating 2 posts.
 		No co-authors found for post #{POST_A}.
 		1/2) Added - Post #{POST_A} 'Alpha post' now has this author term: cap-alpha
 		No co-authors found for post #{POST_B}.
 		2/2) Added - Post #{POST_B} 'Beta post' now has this author term: cap-beta
-		Success: Done! Of 2 posts, 2 now have author terms.
+		Success: Done! Author terms added to 2 of 2 posts.
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
 		Then STDOUT should be:
@@ -166,8 +166,8 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 0 total posts.
-		Success: Done! Of 0 posts, 0 now have author terms.
+		Now inspecting or updating 0 posts.
+		Success: Done! Author terms added to 0 of 0 posts.
 		"""
 		When I run `wp term list author --object_ids={DRAFT_ID} --format=count`
 		Then STDOUT should be:
@@ -194,9 +194,9 @@ Feature: Author terms can be created for all posts
 		When I run `wp co-authors-plus create-terms-for-posts`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 1 total posts.
+		Now inspecting or updating 1 post.
 		1/1) Skipping - Post #{POST_ID} 'Ghostwritten post' already has these terms: cap-writer
-		Success: Done! Of 1 posts, 0 now have author terms.
+		Success: Done! Author terms added to 0 of 1 post.
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -232,10 +232,10 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts --post-statuses=draft`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 1 total posts.
+		Now inspecting or updating 1 post.
 		No co-authors found for post #{DRAFT_ID}.
 		1/1) Added - Post #{DRAFT_ID} 'Draft post' now has this author term: cap-admin
-		Success: Done! Of 1 posts, 1 now have author terms.
+		Success: Done! Author terms added to 1 of 1 post.
 		"""
 		When I run `wp term list author --object_ids={DRAFT_ID} --field=slug`
 		Then STDOUT should be:
@@ -256,12 +256,12 @@ Feature: Author terms can be created for all posts
 		And I run `wp co-authors-plus create-terms-for-posts --post-statuses=publish,draft`
 		Then STDOUT should be:
 		"""
-		Now inspecting or updating 2 total posts.
+		Now inspecting or updating 2 posts.
 		No co-authors found for post #{POST_A}.
 		1/2) Added - Post #{POST_A} 'Published post' now has this author term: cap-admin
 		No co-authors found for post #{POST_B}.
 		2/2) Added - Post #{POST_B} 'Draft post' now has this author term: cap-admin
-		Success: Done! Of 2 posts, 2 now have author terms.
+		Success: Done! Author terms added to 2 of 2 posts.
 		"""
 		When I run `wp term list author --object_ids={POST_A} --field=slug`
 		Then STDOUT should be:

--- a/features/export-coauthors.feature
+++ b/features/export-coauthors.feature
@@ -20,7 +20,7 @@ Feature: Guest authors and their post assignments can be exported
 		When I run `wp co-authors-plus export-coauthors --file=/tmp/cap-export.json`
 		Then STDOUT should be:
 		"""
-		Success: Exported 1 guest authors to /tmp/cap-export.json
+		Success: Exported 1 guest author to /tmp/cap-export.json
 		"""
 		And the return code should be 0
 
@@ -43,7 +43,7 @@ Feature: Guest authors and their post assignments can be exported
 		And I run `wp co-authors-plus export-coauthors --file=/tmp/cap-export-lonely.json`
 		Then STDOUT should be:
 		"""
-		Success: Exported 1 guest authors to /tmp/cap-export-lonely.json
+		Success: Exported 1 guest author to /tmp/cap-export-lonely.json
 		"""
 		When I run `wp eval 'echo count( json_decode( file_get_contents( "/tmp/cap-export-lonely.json" ), true )["guest_authors"][0]["post_refs"] );'`
 		Then STDOUT should be:

--- a/features/fixtures/guest-authors-invalid-single.csv
+++ b/features/fixtures/guest-authors-invalid-single.csv
@@ -1,0 +1,2 @@
+display_name,user_login,user_email,website,description,avatar,first_name,last_name
+,no-display-two,nodisplay2@example.com,,,0,,

--- a/features/fixtures/guest-authors-invalid-single.wxr
+++ b/features/fixtures/guest-authors-invalid-single.wxr
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+	<title>Invalid Guest Author Fixture</title>
+	<link>https://example.com</link>
+	<description>WXR fixture with one author node missing its display name</description>
+	<pubDate>Mon, 01 Sep 2025 00:00:00 +0000</pubDate>
+	<language>en-US</language>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://example.com</wp:base_site_url>
+	<wp:base_blog_url>https://example.com</wp:base_blog_url>
+	<wp:author>
+		<wp:author_id>301</wp:author_id>
+		<wp:author_login><![CDATA[wxr-no-display-solo]]></wp:author_login>
+		<wp:author_email><![CDATA[wxr-no-display-solo@example.com]]></wp:author_email>
+		<wp:author_display_name></wp:author_display_name>
+		<wp:author_first_name></wp:author_first_name>
+		<wp:author_last_name></wp:author_last_name>
+	</wp:author>
+</channel>
+</rss>

--- a/features/import-coauthors.feature
+++ b/features/import-coauthors.feature
@@ -49,7 +49,7 @@ Feature: Guest authors and their post assignments can be imported
 		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-in.json`
 		Then STDOUT should be:
 		"""
-		Success: Created 1 profiles and linked 1 posts.
+		Success: Done. Profiles created: 1. Posts linked: 1.
 		"""
 		And the return code should be 0
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -62,7 +62,7 @@ Feature: Guest authors and their post assignments can be imported
 		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-in.json`
 		Then STDOUT should be:
 		"""
-		Success: Created 0 profiles and linked 0 posts. 1 profiles already existed.
+		Success: Done. Profiles created: 0. Posts linked: 0. 1 profile already existed.
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
 		Then STDOUT should be:
@@ -103,9 +103,15 @@ Feature: Guest authors and their post assignments can be imported
 		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-order.json`
 		Then STDOUT should be:
 		"""
-		Success: Created 3 profiles and linked 3 posts.
+		Success: Done. Profiles created: 3. Posts linked: 3.
 		"""
 		And the return code should be 0
+		# A second identical run, so the existed summary's plural branch runs.
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-order.json`
+		Then STDOUT should be:
+		"""
+		Success: Done. Profiles created: 0. Posts linked: 0. 3 profiles already existed.
+		"""
 		When I run `wp eval 'echo implode( ",", wp_list_pluck( wp_get_object_terms( {NEW_POST_ID}, "author", array( "orderby" => "term_order" ) ), "slug" ) );'`
 		Then STDOUT should be:
 		"""
@@ -120,7 +126,7 @@ Feature: Guest authors and their post assignments can be imported
 		Then STDOUT should be:
 		"""
 		Dry run: nothing will be written.
-		Success: Would create 1 profiles and linked 1 posts.
+		Success: Dry run. Profiles to create: 1. Posts to link: 1.
 		"""
 		When I run `wp post list --post_type=guest-author --format=count`
 		Then STDOUT should be:
@@ -139,7 +145,7 @@ Feature: Guest authors and their post assignments can be imported
 		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-skip.json --skip-create`
 		Then STDOUT should contain:
 		"""
-		Success: Created 0 profiles and linked 0 posts.
+		Success: Done. Profiles created: 0. Posts linked: 0.
 		"""
 		And STDOUT should contain:
 		"""
@@ -156,10 +162,18 @@ Feature: Guest authors and their post assignments can be imported
 		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-missing.json`
 		Then STDOUT should contain:
 		"""
-		1 assignments had no matching post on this site.
+		1 assignment had no matching post on this site.
 		"""
 		And STDOUT should contain:
 		"""
 		No post found with slug "not-here".
+		"""
+		And the return code should be 0
+		# Two refs, so the summary's plural branch runs.
+		When I run `wp eval 'file_put_contents( "/tmp/cap-missing2.json", wp_json_encode( array( "version" => "4.1.1", "guest_authors" => array( array( "profile" => array( "display_name" => "Kim Poe", "user_login" => "kim-poe" ), "post_refs" => array( array( "post_slug" => "not-here", "post_type" => "post", "position" => 0 ), array( "post_slug" => "also-not-here", "post_type" => "post", "position" => 0 ) ) ) ) ) ) );'`
+		When I run `wp co-authors-plus import-coauthors --file=/tmp/cap-missing2.json`
+		Then STDOUT should contain:
+		"""
+		2 assignments had no matching post on this site.
 		"""
 		And the return code should be 0

--- a/features/migrate-author-terms.feature
+++ b/features/migrate-author-terms.feature
@@ -20,7 +20,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Now migrating up to 1 terms
+		Now migrating up to 1 term
 		Term someone ({TERM_ID}) isn't prefixed, adding one
 		Success: All done! Grab a cold one (Affogato)
 		"""
@@ -36,7 +36,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And I run `wp co-authors-plus migrate-author-terms`
 		Then STDOUT should be:
 		"""
-		Now migrating up to 1 terms
+		Now migrating up to 1 term
 		Term legacy-author ({TERM_ID}) isn't prefixed, adding one
 		Success: All done! Grab a cold one (Affogato)
 		"""
@@ -75,7 +75,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		And I run `wp co-authors-plus migrate-author-terms`
 		Then STDOUT should be:
 		"""
-		Now migrating up to 1 terms
+		Now migrating up to 1 term
 		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
 		Term someone ({BARE_ID}) isn't prefixed, adding one
 		Success: All done! Grab a cold one (Affogato)
@@ -121,7 +121,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Now migrating up to 1 terms
+		Now migrating up to 1 term
 		Term guardian ({TERM_ID}) isn't prefixed, adding one
 		Success: All done! Grab a cold one (Affogato)
 		"""
@@ -151,7 +151,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Now migrating up to 1 terms
+		Now migrating up to 1 term
 		Term someone ({BARE_ID}) has a new term too: cap-someone ({PREFIXED_ID}). Merging
 		Term someone ({BARE_ID}) isn't prefixed, adding one
 		Success: All done! Grab a cold one (Affogato)
@@ -172,7 +172,7 @@ Feature: Legacy author terms can be migrated to prefixed slugs
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Now migrating up to 1 terms
+		Now migrating up to 1 term
 		Term someone ({TERM_ID}) isn't prefixed, adding one
 		Success: All done! Grab a cold one (Affogato)
 		"""

--- a/features/reassign-terms.feature
+++ b/features/reassign-terms.feature
@@ -13,7 +13,7 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 		Success: Converted 'olduser' term to 'newuser'
 		Reassignment complete. Here are your results:
-		- 1 authors were successfully reassigned terms
+		- 1 author was successfully reassigned terms
 		- 0 authors had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
@@ -37,7 +37,7 @@ Feature: Author terms can be reassigned between co-authors
 		Reassignment complete. Here are your results:
 		- 0 authors were successfully reassigned terms
 		- 0 authors had their old term merged to their new term
-		- 1 authors were missing old terms
+		- 1 author was missing an old term
 		"""
 		When I run `wp term list author --field=slug`
 		Then STDOUT should be:
@@ -57,10 +57,10 @@ Feature: Author terms can be reassigned between co-authors
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Success: There's already a 'newuser' term for 'olduser'. Reassigning 1 posts and then deleting the term
+		Success: There's already a 'newuser' term for 'olduser'. Reassigning 1 post and then deleting the term
 		Reassignment complete. Here are your results:
 		- 0 authors were successfully reassigned terms
-		- 1 authors had their old term merged to their new term
+		- 1 author had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
 		When I run `wp term list author --object_ids={POST_ID} --field=slug`
@@ -121,7 +121,7 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 		Success: Converted 'olduser' term to 'newuser'
 		Reassignment complete. Here are your results:
-		- 1 authors were successfully reassigned terms
+		- 1 author was successfully reassigned terms
 		- 0 authors had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
@@ -219,7 +219,7 @@ Feature: Author terms can be reassigned between co-authors
 		Reassignment complete. Here are your results:
 		- 0 authors were successfully reassigned terms
 		- 0 authors had their old term merged to their new term
-		- 1 authors were missing old terms
+		- 1 author was missing an old term
 		"""
 		When I run `wp term create author orphan --porcelain`
 		And save STDOUT as {ORPHAN_ID}
@@ -231,7 +231,7 @@ Feature: Author terms can be reassigned between co-authors
 		Reassignment complete. Here are your results:
 		- 0 authors were successfully reassigned terms
 		- 0 authors had their old term merged to their new term
-		- 1 authors were missing old terms
+		- 1 author was missing an old term
 		"""
 		When I run `wp term list author --fields=term_id,slug --format=csv`
 		Then STDOUT should be:
@@ -269,7 +269,7 @@ Feature: Author terms can be reassigned between co-authors
 		"""
 		Success: Converted 'olduser' term to 'newuser'
 		Reassignment complete. Here are your results:
-		- 1 authors were successfully reassigned terms
+		- 1 author was successfully reassigned terms
 		- 0 authors had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
@@ -300,7 +300,7 @@ Feature: Author terms can be reassigned between co-authors
 		Warning: The --new_term flag is deprecated; use --new-term instead.
 		Success: Converted 'olduser' term to 'newuser'
 		Reassignment complete. Here are your results:
-		- 1 authors were successfully reassigned terms
+		- 1 author was successfully reassigned terms
 		- 0 authors had their old term merged to their new term
 		- 0 authors were missing old terms
 		"""
@@ -318,4 +318,37 @@ Feature: Author terms can be reassigned between co-authors
 		And STDERR should contain:
 		"""
 		unknown --author_mapping parameter
+		"""
+
+	# Two posts carrying the old term, so the merge message's plural branch runs;
+	# the merge path can never report zero, so no other scenario reaches it.
+	Scenario: Merging reports how many posts move across
+		When I run `wp user create olduser olduser@example.com --role=author`
+		And I run `wp user create newuser newuser@example.com --role=author`
+		And I run `wp co-authors-plus create-guest-authors`
+		And I run `wp post create --post_title="First shared" --post_status=publish --porcelain`
+		And save STDOUT as {POST_A}
+		And I run `wp post term add {POST_A} author cap-olduser`
+		And I run `wp post create --post_title="Second shared" --post_status=publish --porcelain`
+		And save STDOUT as {POST_B}
+		And I run `wp post term add {POST_B} author cap-olduser`
+		And I run `wp co-authors-plus reassign-terms --old-term=olduser --new-term=newuser`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		Success: There's already a 'newuser' term for 'olduser'. Reassigning 2 posts and then deleting the term
+		Reassignment complete. Here are your results:
+		- 0 authors were successfully reassigned terms
+		- 1 author had their old term merged to their new term
+		- 0 authors were missing old terms
+		"""
+		When I run `wp term list author --object_ids={POST_A} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-newuser
+		"""
+		When I run `wp term list author --object_ids={POST_B} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-newuser
 		"""

--- a/features/remove-terms-from-revisions.feature
+++ b/features/remove-terms-from-revisions.feature
@@ -22,7 +22,7 @@ Feature: Author terms can be removed from post revisions
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Found 1 revisions to look through
+		Found 1 revision to look through
 		All done! 0 revisions had author terms removed
 		"""
 
@@ -43,9 +43,9 @@ Feature: Author terms can be removed from post revisions
 		Then the return code should be 0
 		And STDOUT should be:
 		"""
-		Found 1 revisions to look through
+		Found 1 revision to look through
 		#{REVISION_ID}: Removing cap-admin
-		All done! 1 revisions had author terms removed
+		All done! 1 revision had author terms removed
 		"""
 		When I run `wp term list author --object_ids={REVISION_ID} --field=slug`
 		Then STDOUT should be empty
@@ -73,12 +73,12 @@ Feature: Author terms can be removed from post revisions
 		Then the return code should be 0
 		And STDOUT should contain:
 		"""
-		Found 1 revisions to look through
+		Found 1 revision to look through
 		"""
 		And STDOUT should match /Removing (cap-admin,cap-alice|cap-alice,cap-admin)/
 		And STDOUT should contain:
 		"""
-		All done! 1 revisions had author terms removed
+		All done! 1 revision had author terms removed
 		"""
 		When I run `wp term list author --object_ids={REVISION_ID} --field=slug`
 		Then STDOUT should be empty
@@ -105,7 +105,7 @@ Feature: Author terms can be removed from post revisions
 		"""
 		Found 2 revisions to look through
 		#{REV_B}: Removing cap-admin
-		All done! 1 revisions had author terms removed
+		All done! 1 revision had author terms removed
 		"""
 
 	Scenario: Running the command twice reports nothing left to remove
@@ -119,7 +119,7 @@ Feature: Author terms can be removed from post revisions
 		And I run the previous command again
 		Then STDOUT should be:
 		"""
-		Found 1 revisions to look through
+		Found 1 revision to look through
 		All done! 0 revisions had author terms removed
 		"""
 

--- a/features/swap-coauthors.feature
+++ b/features/swap-coauthors.feature
@@ -127,7 +127,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID} has been assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -153,7 +153,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID_1} will be assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -184,7 +184,7 @@ Feature: One co-author can be swapped with another on their posts
 		"""
 		Warning: The --dry flag is deprecated; use --dry-run instead.
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID_1} will be assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -208,7 +208,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID_1} has been assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -223,7 +223,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID_2} has been assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -261,7 +261,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID_1} has been assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -289,7 +289,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID} has been assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -302,7 +302,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{PAGE_ID} has been assigned "author2" as a co-author
 		Success: All done!
 		"""
@@ -377,7 +377,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from author1 to jane-doe
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID} has been assigned "jane-doe" as a co-author
 		1 post kept its original post_author, because no co-author assigned to it has a WordPress account
 		Success: All done!
@@ -427,7 +427,7 @@ Feature: One co-author can be swapped with another on their posts
 		Then STDOUT should be:
 		"""
 		Swapping authorship from jane-doe to author2
-		Found 1 posts to update.
+		Found 1 post to update.
 		1: Post #{POST_ID} has been assigned "author2" as a co-author
 		Success: All done!
 		"""

--- a/features/update-author-terms.feature
+++ b/features/update-author-terms.feature
@@ -26,7 +26,7 @@ Feature: Author terms can be recounted and recreated
 		When I run `wp co-authors-plus update-author-terms`
 		Then STDOUT should be:
 		"""
-		Now updating 1 terms
+		Now updating 1 term
 		Term cap-admin ({TERM_ID}) changed from 1 to 1 and the description was refreshed
 		Now inspecting or updating 0 Guest Authors.
 		Success: All done
@@ -50,7 +50,7 @@ Feature: Author terms can be recounted and recreated
 		When I run `wp co-authors-plus update-author-terms`
 		Then STDOUT should be:
 		"""
-		Now updating 1 terms
+		Now updating 1 term
 		Term cap-admin ({TERM_ID}) changed from 5 to 1 and the description was refreshed
 		Now inspecting or updating 0 Guest Authors.
 		Success: All done
@@ -67,7 +67,7 @@ Feature: Author terms can be recounted and recreated
 		When I run `wp co-authors-plus update-author-terms`
 		Then STDOUT should be:
 		"""
-		Now updating 1 terms
+		Now updating 1 term
 		Term cap-ghost ({TERM_ID}) changed from 0 to 0 and the description was refreshed
 		Created author term for admin
 		Now inspecting or updating 0 Guest Authors.
@@ -86,7 +86,7 @@ Feature: Author terms can be recounted and recreated
 		And I run `wp co-authors-plus update-author-terms`
 		Then STDOUT should be:
 		"""
-		Now updating 1 terms
+		Now updating 1 term
 		Term cap-admin ({TERM_ID}) changed from 0 to 0 and the description was refreshed
 		Now inspecting or updating 0 Guest Authors.
 		Success: All done
@@ -126,9 +126,9 @@ Feature: Author terms can be recounted and recreated
 		When I run `wp co-authors-plus update-author-terms`
 		Then STDOUT should be:
 		"""
-		Now updating 1 terms
+		Now updating 1 term
 		Term cap-admin ({TERM_ID}) changed from 0 to 0 and the description was refreshed
-		Now inspecting or updating 1 Guest Authors.
+		Now inspecting or updating 1 Guest Author.
 		Success: All done
 		"""
 
@@ -142,7 +142,7 @@ Feature: Author terms can be recounted and recreated
 		"""
 		Now updating 0 terms
 		Created author term for admin
-		Now inspecting or updating 1 Guest Authors.
+		Now inspecting or updating 1 Guest Author.
 		Created author term for Guest Author guest-one
 		Success: All done
 		"""
@@ -171,7 +171,7 @@ Feature: Author terms can be recounted and recreated
 		"""
 		Now updating 0 terms
 		Created author term for admin
-		Now inspecting or updating 1 Guest Authors.
+		Now inspecting or updating 1 Guest Author.
 		Created author term for Guest Author guest-one
 		Success: All done
 		"""

--- a/php/cli/class-assign-coauthors-command.php
+++ b/php/cli/class-assign-coauthors-command.php
@@ -186,10 +186,32 @@ class Assign_Coauthors_Command {
 
 		WP_CLI::log( 'All done! Here are your results:' );
 		if ( $posts_already_associated ) {
-			WP_CLI::log( "- {$posts_already_associated} posts already had the co-author assigned" );
+			WP_CLI::log(
+				'- ' . sprintf(
+					/* translators: Count of posts. */
+					_n(
+						'%s post already had the co-author assigned',
+						'%s posts already had the co-author assigned',
+						$posts_already_associated,
+						'co-authors-plus'
+					),
+					number_format_i18n( $posts_already_associated )
+				)
+			);
 		}
 		if ( $posts_missing_coauthor ) {
-			WP_CLI::log( "- {$posts_missing_coauthor} posts reference co-authors that don't exist. These are:" );
+			WP_CLI::log(
+				'- ' . sprintf(
+					/* translators: Count of posts. */
+					_n(
+						'%s post references a co-author that doesn\'t exist. This is:',
+						'%s posts reference co-authors that don\'t exist. These are:',
+						$posts_missing_coauthor,
+						'co-authors-plus'
+					),
+					number_format_i18n( $posts_missing_coauthor )
+				)
+			);
 			WP_CLI::log( '  ' . implode( ', ', array_unique( $missing_coauthors ) ) );
 		}
 		if ( $posts_missing_meta_value ) {
@@ -208,7 +230,18 @@ class Assign_Coauthors_Command {
 			);
 		}
 		if ( $posts_associated ) {
-			WP_CLI::log( "- {$posts_associated} posts now have the proper co-author" );
+			WP_CLI::log(
+				'- ' . sprintf(
+					/* translators: Count of posts. */
+					_n(
+						'%s post now has the proper co-author',
+						'%s posts now have the proper co-author',
+						$posts_associated,
+						'co-authors-plus'
+					),
+					number_format_i18n( $posts_associated )
+				)
+			);
 		}
 		if ( $posts_keeping_author ) {
 			WP_CLI::log(

--- a/php/cli/class-assign-user-to-coauthor-command.php
+++ b/php/cli/class-assign-user-to-coauthor-command.php
@@ -140,8 +140,8 @@ class Assign_User_To_Coauthor_Command {
 		$success_message = sprintf(
 			/* translators: Count of posts. */
 			_n(
-				'All done! %d post was affected.',
-				'All done! %d posts were affected.',
+				'All done! %s post was affected.',
+				'All done! %s posts were affected.',
 				$affected,
 				'co-authors-plus'
 			),

--- a/php/cli/class-create-author-terms-for-posts-command.php
+++ b/php/cli/class-create-author-terms-for-posts-command.php
@@ -137,7 +137,18 @@ class Create_Author_Terms_For_Posts_Command {
 			$below_post_id
 		);
 
-		WP_CLI::log( sprintf( 'Found %d posts with missing author terms.', $count_of_posts_with_missing_author_terms ) );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of posts. */
+				_n(
+					'Found %s post with missing author terms.',
+					'Found %s posts with missing author terms.',
+					$count_of_posts_with_missing_author_terms,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count_of_posts_with_missing_author_terms )
+			)
+		);
 
 		$authors      = array();
 		$author_terms = array();
@@ -249,7 +260,18 @@ class Create_Author_Terms_For_Posts_Command {
 
 		wp_defer_term_counting( false );
 
-		WP_CLI::log( sprintf( '%d records affected', $affected ) );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of database records. */
+				_n(
+					'%s record affected',
+					'%s records affected',
+					$affected,
+					'co-authors-plus'
+				),
+				number_format_i18n( $affected )
+			)
+		);
 
 		if ( $skipped > 0 ) {
 			WP_CLI::warning(

--- a/php/cli/class-create-guest-authors-command.php
+++ b/php/cli/class-create-guest-authors-command.php
@@ -84,7 +84,18 @@ class Create_Guest_Authors_Command {
 		$created  = 0;
 		$skipped  = 0;
 
-		WP_CLI::log( "Attempting to create guest author profiles for {$count} users." );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of users. */
+				_n(
+					'Attempting to create a guest author profile for %s user.',
+					'Attempting to create guest author profiles for %s users.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
 
 		$progress = \WP_CLI\Utils\make_progress_bar( 'Processing guest authors...', $count );
 		foreach ( $users as $user ) {
@@ -99,7 +110,29 @@ class Create_Guest_Authors_Command {
 		}
 		$progress->finish();
 		WP_CLI::log( 'All done! Here are your results:' );
-		WP_CLI::log( "- {$created} guest author profiles were created" );
-		WP_CLI::log( "- {$skipped} users already had guest author profiles" );
+		WP_CLI::log(
+			'- ' . sprintf(
+				/* translators: Count of guest author profiles. */
+				_n(
+					'%s guest author profile was created',
+					'%s guest author profiles were created',
+					$created,
+					'co-authors-plus'
+				),
+				number_format_i18n( $created )
+			)
+		);
+		WP_CLI::log(
+			'- ' . sprintf(
+				/* translators: Count of users. */
+				_n(
+					'%s user already had a guest author profile',
+					'%s users already had guest author profiles',
+					$skipped,
+					'co-authors-plus'
+				),
+				number_format_i18n( $skipped )
+			)
+		);
 	}
 }

--- a/php/cli/class-create-guest-authors-from-csv-command.php
+++ b/php/cli/class-create-guest-authors-from-csv-command.php
@@ -101,7 +101,18 @@ class Create_Guest_Authors_From_Csv_Command {
 		}
 		fclose( $file );
 
-		WP_CLI::log( 'Found ' . count( $authors ) . ' authors in CSV' );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of authors. */
+				_n(
+					'Found %s author in CSV',
+					'Found %s authors in CSV',
+					count( $authors ),
+					'co-authors-plus'
+				),
+				number_format_i18n( count( $authors ) )
+			)
+		);
 
 		$failed = 0;
 
@@ -140,7 +151,19 @@ class Create_Guest_Authors_From_Csv_Command {
 
 		if ( $failed > 0 ) {
 			// A bad row does not abort the import, so say how many were dropped.
-			WP_CLI::warning( sprintf( '%d of %d authors could not be created.', $failed, count( $authors ) ) );
+			WP_CLI::warning(
+				sprintf(
+					/* translators: 1: Count of failed authors. 2: Total count of authors. */
+					_n(
+						'%1$s of %2$s author could not be created.',
+						'%1$s of %2$s authors could not be created.',
+						count( $authors ),
+						'co-authors-plus'
+					),
+					number_format_i18n( $failed ),
+					number_format_i18n( count( $authors ) )
+				)
+			);
 		}
 
 		WP_CLI::log( 'All done!' );

--- a/php/cli/class-create-guest-authors-from-wxr-command.php
+++ b/php/cli/class-create-guest-authors-from-wxr-command.php
@@ -126,7 +126,19 @@ class Create_Guest_Authors_From_Wxr_Command {
 
 		if ( $failed > 0 ) {
 			// A bad author node does not abort the import, so say how many were dropped.
-			WP_CLI::warning( sprintf( '%d of %d authors could not be created.', $failed, count( $authors ) ) );
+			WP_CLI::warning(
+				sprintf(
+					/* translators: 1: Count of failed authors. 2: Total count of authors. */
+					_n(
+						'%1$s of %2$s author could not be created.',
+						'%1$s of %2$s authors could not be created.',
+						count( $authors ),
+						'co-authors-plus'
+					),
+					number_format_i18n( $failed ),
+					number_format_i18n( count( $authors ) )
+				)
+			);
 		}
 
 		WP_CLI::log( 'All done!' );

--- a/php/cli/class-create-terms-for-posts-command.php
+++ b/php/cli/class-create-terms-for-posts-command.php
@@ -88,7 +88,18 @@ class Create_Terms_For_Posts_Command {
 		$affected    = 0;
 		$count       = 0;
 		$total_posts = $posts->found_posts;
-		WP_CLI::log( "Now inspecting or updating {$posts->found_posts} total posts." );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of posts. */
+				_n(
+					'Now inspecting or updating %s post.',
+					'Now inspecting or updating %s posts.',
+					(int) $posts->found_posts,
+					'co-authors-plus'
+				),
+				number_format_i18n( (int) $posts->found_posts )
+			)
+		);
 		while ( $posts->post_count ) {
 
 			foreach ( $posts->posts as $single_post ) {
@@ -129,6 +140,18 @@ class Create_Terms_For_Posts_Command {
 			$args['paged']++;
 			$posts = new WP_Query( $args );
 		}//end while
-		WP_CLI::success( "Done! Of {$total_posts} posts, {$affected} now have author terms." );
+		WP_CLI::success(
+			sprintf(
+				/* translators: 1: Count of posts given author terms. 2: Total count of posts. */
+				_n(
+					'Done! Author terms added to %1$s of %2$s post.',
+					'Done! Author terms added to %1$s of %2$s posts.',
+					$total_posts,
+					'co-authors-plus'
+				),
+				number_format_i18n( $affected ),
+				number_format_i18n( $total_posts )
+			)
+		);
 	}
 }

--- a/php/cli/class-export-coauthors-command.php
+++ b/php/cli/class-export-coauthors-command.php
@@ -121,7 +121,19 @@ class Export_Coauthors_Command {
 			)
 		);
 
-		WP_CLI::success( sprintf( 'Exported %d guest authors to %s', count( $entries ), $file ) );
+		WP_CLI::success(
+			sprintf(
+				/* translators: 1: Count of guest authors. 2: File path. */
+				_n(
+					'Exported %1$s guest author to %2$s',
+					'Exported %1$s guest authors to %2$s',
+					count( $entries ),
+					'co-authors-plus'
+				),
+				number_format_i18n( count( $entries ) ),
+				$file
+			)
+		);
 	}
 
 	/**

--- a/php/cli/class-import-coauthors-command.php
+++ b/php/cli/class-import-coauthors-command.php
@@ -171,21 +171,39 @@ class Import_Coauthors_Command {
 		if ( $summary['posts_not_found'] > 0 ) {
 			WP_CLI::log(
 				sprintf(
-					'%d assignments had no matching post on this site.',
-					$summary['posts_not_found']
+					/* translators: Count of byline assignments. */
+					_n(
+						'%s assignment had no matching post on this site.',
+						'%s assignments had no matching post on this site.',
+						$summary['posts_not_found'],
+						'co-authors-plus'
+					),
+					number_format_i18n( $summary['posts_not_found'] )
 				)
 			);
 		}
 
+		// Label form rather than a sentence, so neither count needs verb agreement
+		// and the old 'Would create N profiles and linked N posts' tense clash goes.
 		$message = sprintf(
-			'%s %d profiles and linked %d posts.',
-			$dry_run ? 'Would create' : 'Created',
-			$summary['authors_created'],
-			$summary['posts_linked']
+			$dry_run
+				? 'Dry run. Profiles to create: %1$s. Posts to link: %2$s.'
+				: 'Done. Profiles created: %1$s. Posts linked: %2$s.',
+			number_format_i18n( $summary['authors_created'] ),
+			number_format_i18n( $summary['posts_linked'] )
 		);
 
 		if ( $summary['authors_skipped'] > 0 ) {
-			$message .= sprintf( ' %d profiles already existed.', $summary['authors_skipped'] );
+			$message .= ' ' . sprintf(
+				/* translators: Count of guest author profiles. */
+				_n(
+					'%s profile already existed.',
+					'%s profiles already existed.',
+					$summary['authors_skipped'],
+					'co-authors-plus'
+				),
+				number_format_i18n( $summary['authors_skipped'] )
+			);
 		}
 
 		WP_CLI::success( $message );

--- a/php/cli/class-migrate-author-terms-command.php
+++ b/php/cli/class-migrate-author-terms-command.php
@@ -77,7 +77,18 @@ class Migrate_Author_Terms_Command {
 			static fn ( $author_term ): bool => ! Prefix::slug_has_prefix( $author_term->slug )
 		);
 
-		WP_CLI::log( 'Now migrating up to ' . count( $author_terms ) . ' terms' );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of author terms. */
+				_n(
+					'Now migrating up to %s term',
+					'Now migrating up to %s terms',
+					count( $author_terms ),
+					'co-authors-plus'
+				),
+				number_format_i18n( count( $author_terms ) )
+			)
+		);
 
 		foreach ( $author_terms as $author_term ) {
 			// A prefixed term was accidentally created, and the old term needs to be merged into the new (WordPress.com VIP).

--- a/php/cli/class-reassign-terms-command.php
+++ b/php/cli/class-reassign-terms-command.php
@@ -168,7 +168,20 @@ class Reassign_Terms_Command {
 					continue;
 				}
 
-				WP_CLI::log( "Success: There's already a '{$new_user}' term for '{$old_user}'. Reassigning {$old_term->count} posts and then deleting the term" );
+				WP_CLI::log(
+					sprintf(
+						/* translators: 1: New co-author login. 2: Old co-author login. 3: Count of posts. */
+						_n(
+							'Success: There\'s already a \'%1$s\' term for \'%2$s\'. Reassigning %3$s post and then deleting the term',
+							'Success: There\'s already a \'%1$s\' term for \'%2$s\'. Reassigning %3$s posts and then deleting the term',
+							$old_term->count,
+							'co-authors-plus'
+						),
+						$new_user,
+						$old_user,
+						number_format_i18n( $old_term->count )
+					)
+				);
 				$term_args = array(
 					'default'       => $new_term->term_id,
 					'force_default' => true,
@@ -194,8 +207,41 @@ class Reassign_Terms_Command {
 		}//end foreach
 
 		WP_CLI::log( 'Reassignment complete. Here are your results:' );
-		WP_CLI::log( "- $results->success authors were successfully reassigned terms" );
-		WP_CLI::log( "- $results->new_term_exists authors had their old term merged to their new term" );
-		WP_CLI::log( "- $results->old_term_missing authors were missing old terms" );
+		WP_CLI::log(
+			'- ' . sprintf(
+				/* translators: Count of authors. */
+				_n(
+					'%s author was successfully reassigned terms',
+					'%s authors were successfully reassigned terms',
+					$results->success,
+					'co-authors-plus'
+				),
+				number_format_i18n( $results->success )
+			)
+		);
+		WP_CLI::log(
+			'- ' . sprintf(
+				/* translators: Count of authors. */
+				_n(
+					'%s author had their old term merged to their new term',
+					'%s authors had their old term merged to their new term',
+					$results->new_term_exists,
+					'co-authors-plus'
+				),
+				number_format_i18n( $results->new_term_exists )
+			)
+		);
+		WP_CLI::log(
+			'- ' . sprintf(
+				/* translators: Count of authors. */
+				_n(
+					'%s author was missing an old term',
+					'%s authors were missing old terms',
+					$results->old_term_missing,
+					'co-authors-plus'
+				),
+				number_format_i18n( $results->old_term_missing )
+			)
+		);
 	}
 }

--- a/php/cli/class-remove-terms-from-revisions-command.php
+++ b/php/cli/class-remove-terms-from-revisions-command.php
@@ -57,7 +57,18 @@ class Remove_Terms_From_Revisions_Command {
 
 		$ids = $wpdb->get_col( "SELECT ID FROM $wpdb->posts WHERE post_type='revision' AND post_status='inherit'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- WP-CLI one-time maintenance command.
 
-		WP_CLI::log( 'Found ' . count( $ids ) . ' revisions to look through' );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of revisions. */
+				_n(
+					'Found %s revision to look through',
+					'Found %s revisions to look through',
+					count( $ids ),
+					'co-authors-plus'
+				),
+				number_format_i18n( count( $ids ) )
+			)
+		);
 		$affected = 0;
 		foreach ( $ids as $post_id ) {
 
@@ -70,6 +81,17 @@ class Remove_Terms_From_Revisions_Command {
 			wp_set_post_terms( $post_id, array(), $this->coauthors_plus->coauthor_taxonomy );
 			$affected++;
 		}
-		WP_CLI::log( "All done! {$affected} revisions had author terms removed" );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of revisions. */
+				_n(
+					'All done! %s revision had author terms removed',
+					'All done! %s revisions had author terms removed',
+					$affected,
+					'co-authors-plus'
+				),
+				number_format_i18n( $affected )
+			)
+		);
 	}
 }

--- a/php/cli/class-swap-coauthors-command.php
+++ b/php/cli/class-swap-coauthors-command.php
@@ -160,7 +160,18 @@ class Swap_Coauthors_Command {
 		$posts_total          = 0;
 		$posts_keeping_author = 0;
 
-		WP_CLI::log( "Found $posts->found_posts posts to update." );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of posts. */
+				_n(
+					'Found %s post to update.',
+					'Found %s posts to update.',
+					(int) $posts->found_posts,
+					'co-authors-plus'
+				),
+				number_format_i18n( (int) $posts->found_posts )
+			)
+		);
 
 		// This command is term-driven. A post whose only link to the from author is
 		// wp_posts.post_author carries no cap- term, matches nothing above, and used to

--- a/php/cli/class-update-author-terms-command.php
+++ b/php/cli/class-update-author-terms-command.php
@@ -61,7 +61,18 @@ class Update_Author_Terms_Command {
 				'hide_empty' => false,
 			) 
 		);
-		WP_CLI::log( 'Now updating ' . count( $author_terms ) . ' terms' );
+		WP_CLI::log(
+			sprintf(
+				/* translators: Count of author terms. */
+				_n(
+					'Now updating %s term',
+					'Now updating %s terms',
+					count( $author_terms ),
+					'co-authors-plus'
+				),
+				number_format_i18n( count( $author_terms ) )
+			)
+		);
 		foreach ( $author_terms as $author_term ) {
 			$old_count = $author_term->count;
 			$coauthor  = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_term->slug );
@@ -96,7 +107,18 @@ class Update_Author_Terms_Command {
 			);
 
 			$posts = new WP_Query( $args );
-			WP_CLI::log( "Now inspecting or updating {$posts->found_posts} Guest Authors." );
+			WP_CLI::log(
+				sprintf(
+					/* translators: Count of guest authors. */
+					_n(
+						'Now inspecting or updating %s Guest Author.',
+						'Now inspecting or updating %s Guest Authors.',
+						(int) $posts->found_posts,
+						'co-authors-plus'
+					),
+					number_format_i18n( (int) $posts->found_posts )
+				)
+			);
 
 			while ( $posts->post_count ) {
 				foreach ( $posts->posts as $guest_author_id ) {

--- a/tests/Unit/Cli/AssignUserToCoauthorSummaryTest.php
+++ b/tests/Unit/Cli/AssignUserToCoauthorSummaryTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * WordPress-free unit test for the assign-user-to-coauthor summary formatting.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Cli;
+
+use Automattic\CoAuthorsPlus\CLI\Assign_User_To_Coauthor_Command;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_CLI;
+use WP_CLI\Loggers\Execution;
+
+/**
+ * The summary interpolates number_format_i18n() output, which is a
+ * thousands-separated STRING above 999 — so the placeholder must be %s. The
+ * suite cannot stage a thousand posts, so this pins the formatting contract
+ * instead: a formatter stubbed to return "1,234" must survive into the output
+ * verbatim. Under the old %d placeholder, sprintf truncates "1,234" to "1"
+ * and this test fails.
+ *
+ * @covers \Automattic\CoAuthorsPlus\CLI\Assign_User_To_Coauthor_Command::__invoke
+ */
+final class AssignUserToCoauthorSummaryTest extends TestCase {
+
+	/**
+	 * In-memory logger capturing what the command writes.
+	 *
+	 * @var Execution
+	 */
+	private $logger;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->logger = new Execution();
+		WP_CLI::set_logger( $this->logger );
+	}
+
+	public function tear_down(): void {
+		WP_CLI::set_logger( null );
+		unset( $GLOBALS['wpdb'] );
+
+		parent::tear_down();
+	}
+
+	public function test_summary_preserves_a_thousands_separated_count(): void {
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults ) {
+				return array_merge( $defaults, $args );
+			}
+		);
+		Functions\when( '__' )->returnArg();
+		Functions\when( '_n' )->alias(
+			static function ( $single, $plural, $number ) {
+				return 1 === $number ? $single : $plural;
+			}
+		);
+		// Deliberately a lie for a count of zero: the point is that whatever
+		// string the formatter returns must reach the output uncast.
+		Functions\when( 'number_format_i18n' )->justReturn( '1,234' );
+
+		$wpdb        = Mockery::mock( 'wpdb' );
+		$wpdb->posts = 'wp_posts';
+		$wpdb->shouldReceive( 'prepare' )->andReturn( 'SELECT 1' );
+		$wpdb->shouldReceive( 'get_col' )->andReturn( array() );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$coauthors_plus = Mockery::mock( 'CoAuthors_Plus' );
+		$coauthors_plus->shouldReceive( 'get_coauthor_by' )
+			->with( 'login', 'jane' )
+			->andReturn( (object) array( 'user_login' => 'jane' ) );
+		$coauthors_plus->shouldReceive( 'supported_post_types' )->andReturn( array( 'post' ) );
+
+		$command = new Assign_User_To_Coauthor_Command( $coauthors_plus );
+		$command(
+			array(),
+			array(
+				'user_id'  => '5',
+				'coauthor' => 'jane',
+			)
+		);
+
+		$this->assertStringContainsString(
+			'1,234 posts were affected.',
+			$this->logger->stdout,
+			'The formatted count must survive sprintf intact; %d would truncate it to 1.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

The closing pass of the CLI audit. Thirty-odd summary and progress strings across fourteen commands interpolated a count next to a noun or verb that never agreed with it — `Found 1 posts to update.`, `Now updating 1 terms`, `- 1 authors were missing old terms` — so every single-item run read like a typo. Each now goes through `_n()` with `number_format_i18n()` and `%s` placeholders, the pattern the handful of already-correct sites established. This converts count strings only; it deliberately does not wrap the surrounding untranslated prose in `__()` — pluralisation, not a full i18n pass.

**Two strings were reworded rather than pluralised**, because no single plural selection could fix them. The backfill summary carried two counts in one sentence (`Done! Of 2 posts, 1 now have author terms.` — whichever count you select on, the other disagrees); it became `Done! Author terms added to 1 of 2 posts.`, where only the trailing noun needs agreement. The import summary became label form — `Done. Profiles created: 3. Posts linked: 3.` — which needs no agreement at all and removes the old `Would create 1 profiles and linked 1 posts` tense clash as a bonus.

**The one pre-existing `_n()` with a `%d` placeholder is corrected.** `number_format_i18n()` returns a thousands-separated *string* above 999, and `%d` truncates `1,234` to `1` — so `assign-user-to-coauthor` would have reported one post affected after a thousand-post run. Behat cannot stage that volume, so a unit test pins the formatting contract instead: the formatter is stubbed to return `1,234` and the output must carry it verbatim. Verified failing under `%d` and passing under `%s`.

## Coverage

Every conversion has both `_n()` branches exercised. Most already were — zero-count pins select the plural in English, so the many `Found 0 posts` scenarios count as plural coverage — and the six genuinely uncovered branches gained the cheapest fixture that reaches them: a second post in the assign re-run (the "already had" count is truthiness-guarded, so nothing else ever printed it), a two-post merge scenario (the merge path can never report zero), one-bad-row CSV and WXR fixtures for the importer tallies' singulars, a two-ref import file for the missing-assignments plural, and a re-run of the three-profile import for `3 profiles already existed.`

The calibration run — all fourteen touched feature files in one invocation, **152 scenarios / 1,747 steps — passed first time**, with every one of the 32 mechanical re-pin counts matching the inventory's prediction exactly.

## Deliberately untouched

Progress fractions (`2/3 or 66.67%`), IDs, page ordinals and percentages — numbers not adjacent to agreeing words. `update-author-terms`' `Success: All done` missing full stop — cosmetic, not grammatical, and recorded as such. And every historical quotation inside the behaviour notes' struck entries: those record what old defects printed, and rewriting them would falsify the record — only the live "never pluralises" claims are struck.

## Test plan

- [x] Behat: 152 scenarios / 1,747 steps across all fourteen touched features, one invocation, green first run
- [x] Unit: 122 tests / 275 assertions, including the new `%d` discriminator, verified failing under the reverted placeholder
- [x] PHPCS exit 0 on all fourteen command files and the new test
- [ ] Full Behat suite and matrix via CI