### PR TITLE
fix: re-index the Yoast schema graph after filtering Person nodes

### DIFF
--- a/php/integrations/yoast.php
+++ b/php/integrations/yoast.php
@@ -214,11 +214,14 @@ class Yoast {
 
 		if ( $add_to_graph ) {
 			// Clean all Persons from the schema, as the user stored as post owner might be incorrectly added if the post has only guest authors as authors.
-			$data = array_filter(
-				$data,
-				function( $piece ) {
-					return empty( $piece['@type'] ) || $piece['@type'] !== 'Person';
-				}
+			// Re-index the result so json_encode() keeps @graph as a JSON array even when a Person node is removed from the middle. See #1360.
+			$data = array_values(
+				array_filter(
+					$data,
+					function( $piece ) {
+						return empty( $piece['@type'] ) || $piece['@type'] !== 'Person';
+					}
+				)
 			);
 
 			if ( ! empty( $author_data ) ) {

--- a/tests/Unit/Integrations/YoastFilterGraphTest.php
+++ b/tests/Unit/Integrations/YoastFilterGraphTest.php
@@ -53,6 +53,8 @@ final class YoastFilterGraphTest extends TestCase {
 
 	const PRESENTATION_CLASS = 'Yoast\\WP\\SEO\\Presentations\\Indexable_Author_Archive_Presentation';
 
+	const SCHEMA_TYPES_CLASS = 'Yoast\\WP\\SEO\\Config\\Schema_Types';
+
 	/**
 	 * Regression coverage for issue #1113.
 	 *
@@ -105,6 +107,134 @@ final class YoastFilterGraphTest extends TestCase {
 			Yoast::filter_graph( $data, $context ),
 			'filter_graph() must return the graph unchanged when the context post has no ID.'
 		);
+	}
+
+	/**
+	 * Regression coverage for issue #1360.
+	 *
+	 * The PHP array_filter() function preserves keys, so removing the
+	 * Yoast-generated Person node from the middle of the graph used to leave a
+	 * numeric key gap behind it. With the key gap in place, json_encode()
+	 * serialized @graph as a JSON object rather than an array, and JSON-LD
+	 * consumers expanding that object discarded every node. The filtered graph
+	 * must come back as a contiguous list instead.
+	 *
+	 * The merge at the end of filter_graph() re-indexes as a side effect, but it is
+	 * skipped whenever no author resolves, which is the path this test drives: a
+	 * post carrying an author term whose slug matches no user and no guest author.
+	 *
+	 * @covers \CoAuthors\Integrations\Yoast::filter_graph
+	 */
+	public function test_filter_graph_reindexes_the_graph_when_a_person_node_is_removed(): void {
+		Functions\when( 'is_singular' )->justReturn( true );
+
+		$this->stub_get_coauthors_dependencies();
+		$this->mock_schema_types();
+
+		$context           = new \stdClass();
+		$context->post     = new \stdClass();
+		$context->post->ID = 42;
+
+		// Yoast's typical piece order on a post: the Person node sits before the
+		// trailing block schema, so removing it leaves a gap behind it.
+		$data = array(
+			array(
+				'@type' => 'Article',
+				'@id'   => 'https://example.com/#article',
+			),
+			array(
+				'@type' => 'WebPage',
+				'@id'   => 'https://example.com/#webpage',
+			),
+			array(
+				'@type' => 'ImageObject',
+				'@id'   => 'https://example.com/#mainimage',
+			),
+			array(
+				'@type' => 'BreadcrumbList',
+				'@id'   => 'https://example.com/#breadcrumb',
+			),
+			array(
+				'@type' => 'WebSite',
+				'@id'   => 'https://example.com/#website',
+			),
+			array(
+				'@type' => 'Organization',
+				'@id'   => 'https://example.com/#organization',
+			),
+			array(
+				'@type' => 'Person',
+				'@id'   => 'https://example.com/#person',
+			),
+			array(
+				'@type' => 'HowTo',
+				'@id'   => 'https://example.com/#howto',
+			),
+		);
+
+		$result = Yoast::filter_graph( $data, $context );
+
+		$this->assertSame(
+			array_values( $result ),
+			$result,
+			'filter_graph() must return the graph as a contiguous list so @graph stays a JSON array.'
+		);
+
+		$decoded = json_decode( json_encode( $result ) );
+		$this->assertIsArray(
+			$decoded,
+			'@graph must serialize as a JSON array, not a JSON object.'
+		);
+
+		$this->assertSame(
+			array( 'Article', 'WebPage', 'ImageObject', 'BreadcrumbList', 'WebSite', 'Organization', 'HowTo' ),
+			array_column( $result, '@type' ),
+			'The Person node must be removed and every other node kept, in order.'
+		);
+
+		$this->assertSame(
+			array(),
+			$result[0]['author'],
+			'The article node must carry the (empty) co-author reference list.'
+		);
+	}
+
+	/**
+	 * Let get_coauthors() run to completion and return an empty list, the way it
+	 * does when a post carries an author term whose slug matches no user and no
+	 * guest author. With guest authors forced, it skips the post_author fallback
+	 * and so needs no $wpdb.
+	 */
+	private function stub_get_coauthors_dependencies(): void {
+		Functions\when( 'cap_get_coauthor_terms_for_post' )->justReturn( array() );
+
+		$GLOBALS['coauthors_plus'] = (object) array( 'force_guest_authors' => true );
+	}
+
+	/**
+	 * Stand in for Yoast's Schema_Types service, constructed inside filter_graph().
+	 *
+	 * Overload replaces the class definition for the remainder of the process, so
+	 * only one test in a run may use this.
+	 */
+	private function mock_schema_types(): void {
+		$types = \Mockery::mock( 'overload:' . self::SCHEMA_TYPES_CLASS );
+		$types->shouldReceive( 'get_article_type_options' )
+			->zeroOrMoreTimes()
+			->andReturn(
+				array(
+					array( 'value' => 'Article' ),
+				)
+			);
+	}
+
+	/**
+	 * Clean up the global seeded by stub_get_coauthors_dependencies().
+	 */
+	protected function tear_down(): void {
+		unset( $GLOBALS['coauthors_plus'] );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/Unit/Integrations/YoastFilterGraphTest.php
+++ b/tests/Unit/Integrations/YoastFilterGraphTest.php
@@ -38,22 +38,29 @@ if ( ! function_exists( 'add_action' ) ) {
  */
 require_once dirname( __DIR__, 3 ) . '/template-tags.php';
 
+/*
+ * Load the guarded Yoast Schema_Types stub before the integration class is
+ * autoloaded, so the `new Schema_Types()` inside filter_graph() never reaches
+ * for an absent Yoast autoloader.
+ */
+require_once __DIR__ . '/yoast-stubs.php';
+
 /**
  * Unit coverage for the Yoast integration's public filter callbacks.
  *
  * Yoast SEO itself is not a test dependency (only `yoast/wp-test-utils` is, which
  * ships Mockery). Where the integration depends on Yoast types that are absent at
  * test time we use Mockery to generate them: a mock of the author-archive
- * presentation (so the `is_a()` guard is satisfied) and an `alias:` mock of the
- * static `\WPSEO_Options` accessor. The WordPress request functions the methods
+ * presentation (so the `is_a()` guard is satisfied), an `alias:` mock of the
+ * static `\WPSEO_Options` accessor, and a guarded plain stub class for the
+ * Schema_Types service filter_graph() instantiates (see yoast-stubs.php).
+ * The WordPress request functions the methods
  * call (`is_singular()`, `is_author()`, `get_post_type()`,
  * `get_queried_object_id()`) are replaced with Brain Monkey stubs.
  */
 final class YoastFilterGraphTest extends TestCase {
 
 	const PRESENTATION_CLASS = 'Yoast\\WP\\SEO\\Presentations\\Indexable_Author_Archive_Presentation';
-
-	const SCHEMA_TYPES_CLASS = 'Yoast\\WP\\SEO\\Config\\Schema_Types';
 
 	/**
 	 * Regression coverage for issue #1113.
@@ -129,7 +136,6 @@ final class YoastFilterGraphTest extends TestCase {
 		Functions\when( 'is_singular' )->justReturn( true );
 
 		$this->stub_get_coauthors_dependencies();
-		$this->mock_schema_types();
 
 		$context           = new \stdClass();
 		$context->post     = new \stdClass();
@@ -180,12 +186,6 @@ final class YoastFilterGraphTest extends TestCase {
 			'filter_graph() must return the graph as a contiguous list so @graph stays a JSON array.'
 		);
 
-		$decoded = json_decode( json_encode( $result ) );
-		$this->assertIsArray(
-			$decoded,
-			'@graph must serialize as a JSON array, not a JSON object.'
-		);
-
 		$this->assertSame(
 			array( 'Article', 'WebPage', 'ImageObject', 'BreadcrumbList', 'WebSite', 'Organization', 'HowTo' ),
 			array_column( $result, '@type' ),
@@ -197,44 +197,6 @@ final class YoastFilterGraphTest extends TestCase {
 			$result[0]['author'],
 			'The article node must carry the (empty) co-author reference list.'
 		);
-	}
-
-	/**
-	 * Let get_coauthors() run to completion and return an empty list, the way it
-	 * does when a post carries an author term whose slug matches no user and no
-	 * guest author. With guest authors forced, it skips the post_author fallback
-	 * and so needs no $wpdb.
-	 */
-	private function stub_get_coauthors_dependencies(): void {
-		Functions\when( 'cap_get_coauthor_terms_for_post' )->justReturn( array() );
-
-		$GLOBALS['coauthors_plus'] = (object) array( 'force_guest_authors' => true );
-	}
-
-	/**
-	 * Stand in for Yoast's Schema_Types service, constructed inside filter_graph().
-	 *
-	 * Overload replaces the class definition for the remainder of the process, so
-	 * only one test in a run may use this.
-	 */
-	private function mock_schema_types(): void {
-		$types = \Mockery::mock( 'overload:' . self::SCHEMA_TYPES_CLASS );
-		$types->shouldReceive( 'get_article_type_options' )
-			->zeroOrMoreTimes()
-			->andReturn(
-				array(
-					array( 'value' => 'Article' ),
-				)
-			);
-	}
-
-	/**
-	 * Clean up the global seeded by stub_get_coauthors_dependencies().
-	 */
-	protected function tear_down(): void {
-		unset( $GLOBALS['coauthors_plus'] );
-
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/Unit/Integrations/YoastPresentationPostTest.php
+++ b/tests/Unit/Integrations/YoastPresentationPostTest.php
@@ -11,7 +11,6 @@ namespace Automattic\CoAuthorsPlus\Tests\Unit\Integrations;
 
 use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
 use Brain\Monkey\Filters;
-use Brain\Monkey\Functions;
 use CoAuthors\Integrations\Yoast;
 
 /*
@@ -45,28 +44,6 @@ final class YoastPresentationPostTest extends TestCase {
 		$presentation->context->post = $post;
 
 		return $presentation;
-	}
-
-	/**
-	 * Let get_coauthors() run to completion without WordPress.
-	 *
-	 * With no co-author terms and guest authors forced, it skips both the term
-	 * lookup results and the post_author fallback (so no $wpdb is needed) and goes
-	 * straight to its `get_coauthors` filter, which the calling test asserts on.
-	 */
-	private function stub_get_coauthors_dependencies(): void {
-		Functions\when( 'cap_get_coauthor_terms_for_post' )->justReturn( array() );
-
-		$GLOBALS['coauthors_plus'] = (object) array( 'force_guest_authors' => true );
-	}
-
-	/**
-	 * Clean up the global seeded by stub_get_coauthors_dependencies().
-	 */
-	protected function tear_down(): void {
-		unset( $GLOBALS['coauthors_plus'] );
-
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/Unit/Integrations/yoast-stubs.php
+++ b/tests/Unit/Integrations/yoast-stubs.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Minimal stubs for Yoast SEO classes used by the integration unit tests.
+ *
+ * The unit suite runs without Yoast SEO installed. filter_graph()
+ * instantiates Yoast's Schema_Types service, so a plain guarded stub lets the
+ * method under test construct it. The class_exists() guard means a real Yoast
+ * autoloader always wins over this stub, and unlike a Mockery "overload:"
+ * mock the definition is not restricted to a single test per process.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Yoast\WP\SEO\Config;
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Deliberate stub for a Yoast SEO class.
+if ( ! class_exists( Schema_Types::class ) ) {
+	/**
+	 * Stand-in for Yoast's Schema_Types service.
+	 *
+	 * Provides the single article type option the tests assert against.
+	 */
+	class Schema_Types {
+
+		/**
+		 * List the article type options that filter_graph() matches against.
+		 *
+		 * The stub returns the single article type the tests assert against.
+		 *
+		 * @return array
+		 */
+		public function get_article_type_options(): array {
+			return array(
+				array(
+					'value' => 'Article',
+				),
+			);
+		}
+	}
+}
+// phpcs:enable

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\CoAuthorsPlus\Tests\Unit;
 
+use Brain\Monkey\Functions;
 use Yoast\WPTestUtils\BrainMonkey\TestCase as BrainMonkeyTestCase;
 
 /**
@@ -21,4 +22,26 @@ use Yoast\WPTestUtils\BrainMonkey\TestCase as BrainMonkeyTestCase;
  * initialisation will be bypassed.
  */
 abstract class TestCase extends BrainMonkeyTestCase {
+
+	/**
+	 * Let get_coauthors() run to completion without WordPress.
+	 *
+	 * With no co-author terms and guest authors forced, it skips both the term
+	 * lookup results and the post_author fallback (so no $wpdb is needed) and goes
+	 * straight to its `get_coauthors` filter, which the calling test asserts on.
+	 */
+	protected function stub_get_coauthors_dependencies(): void {
+		Functions\when( 'cap_get_coauthor_terms_for_post' )->justReturn( array() );
+
+		$GLOBALS['coauthors_plus'] = (object) array( 'force_guest_authors' => true );
+	}
+
+	/**
+	 * Clean up the global seeded by stub_get_coauthors_dependencies().
+	 */
+	protected function tear_down(): void {
+		unset( $GLOBALS['coauthors_plus'] );
+
+		parent::tear_down();
+	}
 }


### PR DESCRIPTION
## Description

`filter_graph()` removed Person nodes from Yoast's schema graph with `array_filter()`, which preserves numeric keys. When the removed node was not the last element, the leftover key gap made `json_encode()` serialize `@graph` as a JSON object instead of an array. JSON-LD consumers expanding that object discard every node in it, because `"0"`, `"1"`, and so on are neither JSON-LD keywords nor IRIs. The page then ships no structured data at all, while the source still looks complete.

Wrapping the `array_filter()` in `array_values()` re-indexes the graph unconditionally, so `@graph` always comes back as a list. This closes both trigger paths from the issue: an empty author list (the `array_merge()` that used to re-index as a side effect only ran when `get_coauthors()` resolved at least one author) and the site-represents-person path that skips the same merge.

Fixes #1360

## Deploy Notes

None. No new dependencies. The Yoast integration's contract with `wpseo_schema_graph` is unchanged: the filter expects an array of schema pieces, and re-indexing restores exactly the list shape Yoast builds the graph with.

## Steps to Test

1. Install Yoast SEO alongside the patched Co-Authors Plus.
2. Pick a published post that produces at least one schema node after the author, such as a Yoast HowTo or FAQ block.
3. Make `get_coauthors()` return an empty list for it. For example, give the post an `author` term whose slug matches no user and no guest author, which happens after a user nicename is edited. The `post_author` fallback does not apply, because it only runs when the post has no author term at all.
4. On the unpatched build, view source and search for `"@graph"`. It is a JSON object with a missing numeric key, for example `"@graph":{"0":{...},"1":{...},"3":{...}}`. Rich Results Test reports no structured data.
5. Apply the patch and reload. `"@graph"` is now a JSON array, and Rich Results Test detects the Article and Person nodes.
6. Confirm a healthy post with working authors is unchanged: same nodes, same order, still a JSON array.

Automated coverage: the new unit test in `tests/Unit/Integrations/YoastFilterGraphTest.php` feeds a graph with a Person in the middle and an empty author list, then asserts the result is a contiguous list and that a JSON round-trip stays an array. It fails on the unpatched build and passes with the patch. Run with `composer test:unit -- --filter YoastFilterGraphTest`.