### PR TITLE
Stop refreshing author terms on REST GET requests

### DIFF
--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -273,11 +273,22 @@ class Endpoints {
 	 * so we exclude it from the response rather than feed the editor data it
 	 * can't round-trip.
 	 *
+	 * Reads the existing author term rather than refreshing it: the editor
+	 * saves selections by term id, so an author must have a term to be
+	 * selectable at all, and only a missing term is backfilled (a one-time
+	 * write per author, e.g. the post_author fallback on a pre-CAP post).
+	 * Description freshness is owned by the profile-update hook, not by GET
+	 * requests.
+	 *
 	 * @param object $author The result from co-authors methods.
 	 * @return array|null
 	 */
 	public function _format_author_data( $author ): ?array {
-		$term = $this->coauthors->update_author_term( $author );
+		$term = $this->coauthors->get_author_term( $author );
+
+		if ( ! $term ) {
+			$term = $this->coauthors->update_author_term( $author );
+		}
 
 		if ( ! $term || is_wp_error( $term ) ) {
 			return null;

--- a/php/class-coauthors-endpoint.php
+++ b/php/class-coauthors-endpoint.php
@@ -273,22 +273,16 @@ class Endpoints {
 	 * so we exclude it from the response rather than feed the editor data it
 	 * can't round-trip.
 	 *
-	 * Reads the existing author term rather than refreshing it: the editor
-	 * saves selections by term id, so an author must have a term to be
-	 * selectable at all, and only a missing term is backfilled (a one-time
-	 * write per author, e.g. the post_author fallback on a pre-CAP post).
-	 * Description freshness is owned by the profile-update hook, not by GET
-	 * requests.
+	 * This is a pure read: it never creates or refreshes the term. Description
+	 * freshness is owned by the profile-update hook, and the one caller that
+	 * can legitimately see a term-less author backfills before formatting
+	 * (see _build_authors_response()).
 	 *
 	 * @param object $author The result from co-authors methods.
 	 * @return array|null
 	 */
 	public function _format_author_data( $author ): ?array {
 		$term = $this->coauthors->get_author_term( $author );
-
-		if ( ! $term ) {
-			$term = $this->coauthors->update_author_term( $author );
-		}
 
 		if ( ! $term || is_wp_error( $term ) ) {
 			return null;
@@ -319,6 +313,15 @@ class Endpoints {
 
 		if ( ! empty( $authors ) ) {
 			foreach ( $authors as $author ) {
+				// Self-heal the one term-less case that can reach this response:
+				// the post_author fallback in get_coauthors() on a pre-CAP post.
+				// The editor persists selections by term id, so without a term
+				// the author would be omitted and silently dropped on the next
+				// save. A one-time write per author; the formatter stays pure.
+				if ( ! $this->coauthors->get_author_term( $author ) ) {
+					$this->coauthors->update_author_term( $author );
+				}
+
 				$formatted = $this->_format_author_data( $author );
 				if ( null !== $formatted ) {
 					$response[] = $formatted;

--- a/tests/Integration/Rest/EndpointsTest.php
+++ b/tests/Integration/Rest/EndpointsTest.php
@@ -240,6 +240,57 @@ class EndpointsTest extends TestCase {
 		$this->assertCount( 2, $update_response->data );
 	}
 
+	/**
+	 * Formatting an author with an existing term must not write to it: term
+	 * description refreshes belong to the profile-update hook, not to GET
+	 * routes.
+	 *
+	 * @covers \CoAuthors\API\Endpoints::_format_author_data
+	 */
+	public function test_format_author_data_does_not_refresh_existing_term(): void {
+		global $coauthors_plus;
+
+		$author = $this->create_author();
+		$term   = $coauthors_plus->update_author_term( $author );
+
+		wp_update_term(
+			$term->term_id,
+			$coauthors_plus->coauthor_taxonomy,
+			array( 'description' => 'stale description' )
+		);
+		wp_cache_delete( 'author-term-' . $author->user_nicename, 'co-authors-plus' );
+
+		$formatted = $this->_api->_format_author_data( $author );
+
+		$this->assertSame( $term->term_id, $formatted['termId'] );
+		$this->assertSame(
+			'stale description',
+			get_term( $term->term_id, $coauthors_plus->coauthor_taxonomy )->description,
+			'Failed to assert that formatting an author for a GET response leaves the term description untouched.'
+		);
+	}
+
+	/**
+	 * An author with no term yet (e.g. the post_author fallback on a pre-CAP
+	 * post) must still be backfilled once, or they would vanish from responses
+	 * and be unselectable in the editor.
+	 *
+	 * @covers \CoAuthors\API\Endpoints::_format_author_data
+	 */
+	public function test_format_author_data_backfills_missing_term(): void {
+		global $coauthors_plus;
+
+		$author = $this->create_author();
+
+		$this->assertFalse( $coauthors_plus->get_author_term( $author ) );
+
+		$formatted = $this->_api->_format_author_data( $author );
+
+		$term = $coauthors_plus->get_author_term( $author );
+		$this->assertNotEmpty( $term );
+		$this->assertSame( $term->term_id, $formatted['termId'] );
+	}
+
 	public function data_only_editor_role_can_edit_coauthors(): array {
 		return array(
 			'Subscriber' => array(

--- a/tests/Integration/Rest/EndpointsTest.php
+++ b/tests/Integration/Rest/EndpointsTest.php
@@ -271,24 +271,57 @@ class EndpointsTest extends TestCase {
 	}
 
 	/**
-	 * An author with no term yet (e.g. the post_author fallback on a pre-CAP
-	 * post) must still be backfilled once, or they would vanish from responses
-	 * and be unselectable in the editor.
+	 * The formatter is a pure read: an author with no term is returned as
+	 * null, and no term is created as a side effect of formatting.
 	 *
 	 * @covers \CoAuthors\API\Endpoints::_format_author_data
 	 */
-	public function test_format_author_data_backfills_missing_term(): void {
+	public function test_format_author_data_is_a_pure_read(): void {
 		global $coauthors_plus;
 
 		$author = $this->create_author();
 
 		$this->assertFalse( $coauthors_plus->get_author_term( $author ) );
 
-		$formatted = $this->_api->_format_author_data( $author );
+		$this->assertNull( $this->_api->_format_author_data( $author ) );
+
+		$this->assertFalse(
+			$coauthors_plus->get_author_term( $author ),
+			'Failed to assert that formatting an author does not create a term.'
+		);
+	}
+
+	/**
+	 * The authors route must backfill a term for the post_author fallback on a
+	 * pre-CAP post (no author terms, term-less author), or the author would be
+	 * omitted from the response and silently dropped on the next editor save.
+	 *
+	 * @covers \CoAuthors\API\Endpoints::_build_authors_response
+	 */
+	public function test_get_coauthors_backfills_term_for_legacy_post_author(): void {
+		global $coauthors_plus;
+
+		$author  = $this->create_author();
+		$post_id = self::factory()->post->create( array( 'post_author' => $author->ID ) );
+
+		// Recreate the legacy state: no author terms on the post, no term for the author.
+		wp_delete_object_term_relationships( $post_id, $coauthors_plus->coauthor_taxonomy );
+		$term = $coauthors_plus->get_author_term( $author );
+		if ( $term ) {
+			wp_delete_term( $term->term_id, $coauthors_plus->coauthor_taxonomy );
+			wp_cache_delete( 'author-term-' . $author->user_nicename, 'co-authors-plus' );
+		}
+		$this->assertFalse( $coauthors_plus->get_author_term( $author ) );
+
+		$get_request = new \WP_REST_Request( 'GET' );
+		$get_request->set_url_params( array( 'post_id' => $post_id ) );
+
+		$get_response = $this->_api->get_coauthors( $get_request );
 
 		$term = $coauthors_plus->get_author_term( $author );
-		$this->assertNotEmpty( $term );
-		$this->assertSame( $term->term_id, $formatted['termId'] );
+		$this->assertNotEmpty( $term, 'Failed to assert that the authors route backfills a missing author term.' );
+		$this->assertSame( $author->user_nicename, $get_response->data[0]['userNicename'] );
+		$this->assertSame( $term->term_id, $get_response->data[0]['termId'] );
 	}
 
 	public function data_only_editor_role_can_edit_coauthors(): array {


### PR DESCRIPTION
## Summary

Addresses the steady-state part of #1434.

`Endpoints::_format_author_data()` called `CoAuthors_Plus::update_author_term()` for every author it formatted, so the GET `search`, `authors` and `authors-by-term-ids` routes wrote to the terms table during what callers reasonably assume is a read. Even when the term description was already up to date, the call still deleted and re-primed the author term cache for every author on every request. The refresh is also redundant these days: term description freshness has been owned by the profile-update hook (`update_author_term_on_profile_update()`) since 4.1.0.

The formatter is now a pure read via `get_author_term()` — it can neither create nor refresh a term, so no current or future route can inherit write-on-read behaviour from it. That's safe because on almost every path a term exists by construction: search results are found *via* `get_terms` on the co-author taxonomy, the by-term-ids route resolves the term before the author, and the POST route creates terms in `add_coauthors()`.

Exactly one path can produce a term-less author: the `post_author` fallback in `get_coauthors()` on a post saved before Co-Authors Plus. That author cannot simply be skipped — the editor persists selections by term id (`set_post_author_for_rest_save()` resolves them with `get_term()`), so omitting them from the response means the next editor save silently drops the original author. `_build_authors_response()` therefore backfills a missing term explicitly, at route level, scoped to that single case: a one-time write per legacy author, after which every read is pure. `search_authors()` needed no change, as it already follows the read-first pattern.

Three integration tests pin the behaviour: formatting an author whose term has a stale description leaves the description untouched, the formatter creates no term for a term-less author (both fail against the previous code), and the authors route backfills a term for a legacy post's `post_author` and includes them in the response.

This does not yet make the read routes literally write-free — the legacy backfill remains, and `search_authors()` still creates terms for users who merely appear in results. Moving those writes fully out of GET (selection-time creation, CLI healing for legacy posts) is the remaining scope on #1434.

## Test plan

- [ ] `wp-env run tests-cli --env-cwd=wp-content/plugins/co-authors-plus ./vendor/bin/phpunit --testsuite integration --filter EndpointsTest` passes (16 tests)
- [ ] With an author whose term description is stale, a GET to `coauthors/v1/search` no longer rewrites the term description