### PR TITLE
feat(cli): add read-only check command

### DIFF
--- a/docs/cli-behaviour-notes.md
+++ b/docs/cli-behaviour-notes.md
@@ -1306,3 +1306,53 @@ cap-admin term so a fresh run reports `Found 0 posts with missing author terms.`
   steps rather than one ordered `.*`-chained regex, and the `missing --file parameter`
   error pins only the CAP-independent fragment (the `Error: Parameter errors:` framing
   belongs to WP-CLI).
+
+## check
+
+Added after the refactor, so unlike the entries above this section documents a new
+command rather than pinning inherited behaviour. Covered by features/check.feature.
+
+`wp co-authors-plus check` is read-only and reports the drift conditions the fixer
+commands repair, without repairing any of them. It is a report, not a gate: it always
+exits 0, so a monitoring run is not failed by finding drift. Consumers read
+`--format=json` and decide what a finding means for them.
+
+Options are `--only=<checks>` and the scaffolded `--format=<format>` (table, csv, json,
+count, yaml), plus `--field`/`--fields`.
+
+The nine checks, in report order:
+
+- `posts-missing-terms` — posts with no co-author terms, over the plugin's own
+  supported post types. Trash, auto-drafts and revisions are excluded; a post carrying
+  a backfill skip marker is still counted, because it really does have no terms.
+- `missing-user-terms` — WordPress users with no term. One query, with the two slug
+  arms (`cap-`-prefixed and bare) that `get_author_term()` itself tries, so a legacy
+  unprefixed term is not reported as missing.
+- `missing-guest-author-terms` — guest authors with no term, resolved through
+  `get_author_term()` since the nicename is derived rather than stored. Skipped when
+  guest authors are disabled.
+- `stale-term-counts` — terms whose stored count differs from the count
+  `get_author_term_post_count()` computes.
+- `stale-term-descriptions` — terms whose description differs from the one
+  `update_author_term()` would write from `ajax_search_fields`.
+- `unprefixed-terms` — terms whose slug lacks `cap-`, the pre-3.0 condition
+  migrate-author-terms repairs.
+- `revision-terms` — revisions carrying co-author terms.
+- `orphaned-skip-markers` — `_cap_skip_backfill` rows on a post that is gone, or that
+  has since gained terms, leaving the marker blocking nothing.
+- `guest-author-drift` — guest author profiles whose own post carries a term whose slug
+  no longer matches the profile's nicename. Not detected by any command before this.
+  Skipped when guest authors are disabled.
+
+Notes:
+
+- An unknown `--only` name is an error, not a silent match-nothing. A typo in a runbook
+  that ran every check instead of the one named would be worse than failing.
+- `--format=count` counts report rows, i.e. the number of checks run (9 by default), not
+  the number of findings. A single check's finding count is its `count` field, readable
+  with `--field=count`.
+- `CoAuthors_Plus::get_author_term_post_count()` is new: it is the count
+  `update_author_term_post_count()` writes, split out so a check can compare against it
+  without writing. It returns null both when no co-author backs the term and when the
+  query fails, so a database error is not mistaken for a stale count of zero.
+

--- a/features/check.feature
+++ b/features/check.feature
@@ -1,0 +1,269 @@
+Feature: The co-author term index can be checked for drift
+
+	Background:
+		Given a WP installation with the Co-Authors Plus plugin
+		And I run `wp eval 'foreach ( get_terms( array( "taxonomy" => "author", "hide_empty" => false ) ) as $t ) { wp_delete_term( $t->term_id, "author" ); }'`
+
+	Scenario: A term whose stored count is wrong is reported
+		When I run `wp post create --post_title="Admin post" --post_status=publish --post_author=1`
+		And I run `wp eval '$t = get_term_by( "slug", "cap-admin", "author" ); global $wpdb; $wpdb->update( $wpdb->term_taxonomy, array( "count" => 5 ), array( "term_taxonomy_id" => $t->term_taxonomy_id ) ); clean_term_cache( $t->term_id, "author" );'`
+		And I run `wp co-authors-plus check --only=stale-term-counts --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"stale-term-counts","status":"issues","count":1
+		"""
+
+	Scenario: A term whose stored count is correct is not reported
+		When I run `wp post create --post_title="Admin post" --post_status=publish --post_author=1`
+		And I run `wp co-authors-plus check --only=stale-term-counts --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"stale-term-counts","status":"ok","count":0
+		"""
+
+	Scenario: A term whose stored description is wrong is reported
+		When I run `wp post create --post_title="Admin post" --post_status=publish --post_author=1`
+		And I run `wp term update author cap-admin --by=slug --description="Out of date"`
+		And I run `wp co-authors-plus check --only=stale-term-descriptions --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"stale-term-descriptions","status":"issues","count":1
+		"""
+
+	Scenario: A term whose stored description is correct is not reported
+		When I run `wp post create --post_title="Admin post" --post_status=publish --post_author=1`
+		And I run `wp co-authors-plus check --only=stale-term-descriptions --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"stale-term-descriptions","status":"ok","count":0
+		"""
+
+	Scenario: A guest author with no author term is reported
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe`
+		And I run `wp eval 'wp_delete_term( get_term_by( "slug", "cap-jane-doe", "author" )->term_id, "author" );'`
+		And I run `wp co-authors-plus check --only=missing-guest-author-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"missing-guest-author-terms","status":"issues","count":1
+		"""
+
+	Scenario: A guest author with an author term is not reported
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe`
+		And I run `wp co-authors-plus check --only=missing-guest-author-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"missing-guest-author-terms","status":"ok","count":0
+		"""
+
+	# --format=count counts rows, so this is the number of checks, not the number
+	# of findings. It is 9 whatever the state of the site, which is what makes it
+	# a usable assertion for "every check ran exactly once".
+	Scenario: Every check runs by default
+		When I run `wp co-authors-plus check --format=count`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		9
+		"""
+
+	Scenario: Every check is named in the default report
+		When I run `wp co-authors-plus check`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		posts-missing-terms
+		"""
+		And STDOUT should contain:
+		"""
+		missing-user-terms
+		"""
+		And STDOUT should contain:
+		"""
+		missing-guest-author-terms
+		"""
+		And STDOUT should contain:
+		"""
+		stale-term-counts
+		"""
+		And STDOUT should contain:
+		"""
+		stale-term-descriptions
+		"""
+		And STDOUT should contain:
+		"""
+		unprefixed-terms
+		"""
+		And STDOUT should contain:
+		"""
+		revision-terms
+		"""
+		And STDOUT should contain:
+		"""
+		orphaned-skip-markers
+		"""
+		And STDOUT should contain:
+		"""
+		guest-author-drift
+		"""
+
+	Scenario: A post that gained no author term is reported
+		When I run `wp post create --post_title="No terms post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval 'wp_set_post_terms( {POST_ID}, array(), "author" );'`
+		And I run `wp co-authors-plus check --only=posts-missing-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"posts-missing-terms","status":"issues","count":1
+		"""
+
+	Scenario: A post with an author term is not reported
+		When I run `wp post create --post_title="Authored post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp term list author --object_ids={POST_ID} --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-admin
+		"""
+		When I run `wp co-authors-plus check --only=posts-missing-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"posts-missing-terms","status":"ok","count":0
+		"""
+
+	# A user is given a term only when they author something or their profile is
+	# updated, so the post below is what puts admin into the clear and leaves the
+	# new user as the only one missing a term.
+	Scenario: A user with no author term is reported
+		When I run `wp post create --post_title="Admin post" --post_status=publish --post_author=1`
+		And I run `wp user create checker checker@example.com --role=author --porcelain`
+		And I run `wp co-authors-plus check --only=missing-user-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"missing-user-terms","status":"issues","count":1
+		"""
+
+	Scenario: A user whose term exists is not reported
+		When I run `wp post create --post_title="Admin post" --post_status=publish --post_author=1`
+		And I run `wp co-authors-plus check --only=missing-user-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"missing-user-terms","status":"ok","count":0
+		"""
+
+	Scenario: An unprefixed legacy term is reported
+		When I run `wp term create author legacy --porcelain`
+		And I run `wp co-authors-plus check --only=unprefixed-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"unprefixed-terms","status":"issues","count":1
+		"""
+
+	Scenario: A prefixed term is not reported as unprefixed
+		When I run `wp term create author legacy --slug=cap-legacy`
+		And I run `wp co-authors-plus check --only=unprefixed-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"unprefixed-terms","status":"ok","count":0
+		"""
+
+	Scenario: A revision carrying author terms is reported
+		When I run `wp post create --post_title="Revised post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post update {POST_ID} --post_content="Updated content"`
+		And I run `wp post list --post_type=revision --post_status=inherit --post_parent={POST_ID} --posts_per_page=1 --orderby=ID --order=DESC --field=ID`
+		And save STDOUT as {REVISION_ID}
+		And I run `wp eval 'wp_set_post_terms( {REVISION_ID}, array( "cap-admin" ), "author" );'`
+		And I run `wp co-authors-plus check --only=revision-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"revision-terms","status":"issues","count":1
+		"""
+
+	Scenario: A revision without author terms is not reported
+		When I run `wp post create --post_title="Plain post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post update {POST_ID} --post_content="Updated content"`
+		And I run `wp co-authors-plus check --only=revision-terms --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"revision-terms","status":"ok","count":0
+		"""
+
+	# The marker is orphaned because the post has terms anyway, so it is no
+	# longer holding the backfill back from anything.
+	Scenario: A backfill skip marker on a post that has terms is orphaned
+		When I run `wp post create --post_title="Skipped post" --post_status=publish --post_author=1 --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp post meta add {POST_ID} _cap_skip_backfill nonexistent_post_author_id`
+		And I run `wp co-authors-plus check --only=orphaned-skip-markers --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"orphaned-skip-markers","status":"issues","count":1
+		"""
+
+	Scenario: A backfill skip marker on a post that still has no terms is not orphaned
+		When I run `wp post create --post_title="Still skipped post" --post_status=publish --porcelain`
+		And save STDOUT as {POST_ID}
+		And I run `wp eval 'wp_set_post_terms( {POST_ID}, array(), "author" );'`
+		And I run `wp post meta add {POST_ID} _cap_skip_backfill nonexistent_post_author_id`
+		And I run `wp co-authors-plus check --only=orphaned-skip-markers --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"orphaned-skip-markers","status":"ok","count":0
+		"""
+
+	Scenario: A guest author whose term slug no longer matches the profile is reported
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe`
+		And I run `wp term list author --slug=cap-jane-doe --field=slug`
+		Then STDOUT should be:
+		"""
+		cap-jane-doe
+		"""
+		And I run `wp eval 'wp_update_term( get_term_by( "slug", "cap-jane-doe", "author" )->term_id, "author", array( "slug" => "cap-jane-renamed" ) );'`
+		And I run `wp co-authors-plus check --only=guest-author-drift --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"guest-author-drift","status":"issues","count":1
+		"""
+
+	Scenario: A guest author whose term slug matches the profile is not reported
+		When I run `wp co-authors-plus create-author --display_name="Jane Doe" --user_login=jane-doe`
+		And I run `wp co-authors-plus check --only=guest-author-drift --format=json`
+		Then the return code should be 0
+		And STDOUT should contain:
+		"""
+		{"check":"guest-author-drift","status":"ok","count":0
+		"""
+
+	Scenario: --only runs exactly the named checks
+		When I run `wp co-authors-plus check --only=unprefixed-terms,revision-terms --format=count`
+		Then the return code should be 0
+		And STDOUT should be:
+		"""
+		2
+		"""
+
+	Scenario: An unknown check name is rejected
+		When I run `wp co-authors-plus check --only=no-such-check`
+		Then the return code should not be 0
+		And STDERR should contain:
+		"""
+		Unknown check(s): no-such-check
+		"""

--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -871,6 +871,65 @@ class CoAuthors_Plus {
 			return new WP_Error( 'missing-coauthor', __( 'No co-author exists for that term', 'co-authors-plus' ) );
 		}
 
+		$count = $this->count_published_posts_for_term( $term, $coauthor );
+
+		// A failed query returns false. Writing that would store a count of 0
+		// and lose the real one, so the stored value is left as it is.
+		if ( false === $count ) {
+			return new WP_Error( 'count-query-failed', __( 'The post count query failed', 'co-authors-plus' ) );
+		}
+
+		$wpdb->update( $wpdb->term_taxonomy, array( 'count' => $count ), array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
+
+		wp_cache_delete( 'author-term-' . $coauthor->user_nicename, 'co-authors-plus' );
+	}
+
+	/**
+	 * Get the published post count an author term should hold.
+	 *
+	 * The same count update_author_term_post_count() writes, without the write,
+	 * so a caller can compare it against the stored value and report drift
+	 * instead of repairing it silently.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param object $term The co-author term.
+	 * @return int|null The count, or null when it cannot be determined.
+	 */
+	public function get_author_term_post_count( $term ): ?int {
+
+		$coauthor = $this->get_coauthor_by( 'user_nicename', $term->slug );
+		if ( ! $coauthor ) {
+			return null;
+		}
+
+		$count = $this->count_published_posts_for_term( $term, $coauthor );
+
+		// The query returns false when it fails. Reporting that as a count of
+		// zero would surface as drift, so it is treated as "unknown" instead.
+		if ( false === $count ) {
+			return null;
+		}
+
+		return (int) $count;
+	}
+
+	/**
+	 * Count the published posts attributed to an author term and co-author.
+	 *
+	 * A WordPress user is counted through post_author as well as the term, to
+	 * match how their byline is read, while a guest author is counted through
+	 * the term alone.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param object $term     The co-author term.
+	 * @param object $coauthor The co-author the term represents.
+	 * @return int|false Row count, or false on query failure.
+	 */
+	private function count_published_posts_for_term( $term, $coauthor ) {
+		global $wpdb;
+
 		$query = "SELECT COUNT({$wpdb->posts}.ID) FROM {$wpdb->posts}";
 
 		$query .= " LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)";
@@ -889,10 +948,7 @@ class CoAuthors_Plus {
 
 		$query .= $wpdb->prepare( " GROUP BY {$wpdb->posts}.ID HAVING MAX( IF ( {$wpdb->term_taxonomy}.taxonomy = '%s', IF ( {$having_terms},2,1 ),0 ) ) <> 1 ", $this->coauthor_taxonomy ); //phpcs:ignore
 
-		$count = $wpdb->query( $query ); // phpcs:ignore
-		$wpdb->update( $wpdb->term_taxonomy, array( 'count' => $count ), array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
-
-		wp_cache_delete( 'author-term-' . $coauthor->user_nicename, 'co-authors-plus' );
+		return $wpdb->query( $query ); // phpcs:ignore
 	}
 
 	/**

--- a/php/cli/class-check-command.php
+++ b/php/cli/class-check-command.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * The check WP-CLI command.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\CLI;
+
+use Automattic\CoAuthorsPlus\Services\Coauthor_Checks_Service;
+use WP_CLI;
+use WP_CLI\Formatter;
+
+/**
+ * Reports where the co-author term index and the bylines agree.
+ *
+ * Read-only, and a report rather than a gate: it always exits 0, so a cron job
+ * or a monitoring run is not failed by finding drift. Consumers read the
+ * machine-readable formats, and decide what a finding means for them.
+ *
+ * Each check corresponds to a condition one of the fixer commands can repair.
+ * Nothing here writes, so it is safe to run on production at any time.
+ */
+class Check_Command {
+
+	/**
+	 * Checks to run.
+	 *
+	 * @var Coauthor_Checks_Service
+	 */
+	private $checks;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Coauthor_Checks_Service $checks Check service.
+	 */
+	public function __construct( Coauthor_Checks_Service $checks ) {
+		$this->checks = $checks;
+	}
+
+	/**
+	 * Check the co-author term index for the conditions the fixer commands repair.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--only=<checks>]
+	 * : Comma-separated list of checks to run. Defaults to all of them. An
+	 * unknown name is rejected. The names are listed by the error message, and
+	 * are checked against Services\Coauthor_Checks_Service::CHECKS, so this
+	 * description does not have to be kept in step with a second list.
+	 *
+	 * [--field=<field>]
+	 * : Print one field for each check.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to show.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - count
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Run every check.
+	 *     $ wp co-authors-plus check
+	 *
+	 *     # The machine-readable audit for monitoring.
+	 *     $ wp co-authors-plus check --format=json
+	 *
+	 *     # Just the two backfill-related checks.
+	 *     $ wp co-authors-plus check --only=posts-missing-terms,orphaned-skip-markers
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param string[]              $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$only = $this->requested_checks( $assoc_args['only'] ?? '' );
+
+		$rows = $this->checks->run( $only );
+
+		$formatter = new Formatter( $assoc_args, array( 'check', 'status', 'count', 'summary' ) );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Parse and validate the --only list.
+	 *
+	 * An unknown name is reported rather than ignored: a typo in a runbook that
+	 * silently ran every check instead of the one named would be worse than
+	 * failing.
+	 *
+	 * @param string $only Comma-separated check names, or an empty string.
+	 * @return string[] Validated check names, or an empty array for "all".
+	 */
+	private function requested_checks( string $only ): array {
+		if ( '' === trim( $only ) ) {
+			return array();
+		}
+
+		$requested = array_filter( array_map( 'trim', explode( ',', $only ) ) );
+		$unknown   = array_diff( $requested, Coauthor_Checks_Service::CHECKS );
+
+		if ( ! empty( $unknown ) ) {
+			WP_CLI::error(
+				sprintf(
+					'Unknown check(s): %1$s. Available checks: %2$s.',
+					implode( ', ', $unknown ),
+					implode( ', ', Coauthor_Checks_Service::CHECKS )
+				)
+			);
+		}
+
+		return $requested;
+	}
+}

--- a/php/cli/register-commands.php
+++ b/php/cli/register-commands.php
@@ -13,6 +13,7 @@
 declare( strict_types=1 );
 
 use Automattic\CoAuthorsPlus\CLI\Assign_Coauthors_Command;
+use Automattic\CoAuthorsPlus\CLI\Check_Command;
 use Automattic\CoAuthorsPlus\CLI\Command_Namespace;
 use Automattic\CoAuthorsPlus\CLI\Assign_User_To_Coauthor_Command;
 use Automattic\CoAuthorsPlus\CLI\Create_Author_Command;
@@ -34,6 +35,7 @@ use Automattic\CoAuthorsPlus\CLI\Rename_Coauthor_Command;
 use Automattic\CoAuthorsPlus\CLI\Swap_Coauthors_Command;
 use Automattic\CoAuthorsPlus\CLI\Update_Author_Terms_Command;
 use Automattic\CoAuthorsPlus\Services\Coauthor_Assignment_Service;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Checks_Service;
 use Automattic\CoAuthorsPlus\Services\Coauthor_Export_Service;
 use Automattic\CoAuthorsPlus\Services\Coauthor_Import_Service;
 use Automattic\CoAuthorsPlus\Services\Guest_Author_Service;
@@ -48,6 +50,7 @@ require_once __DIR__ . '/../services/class-coauthor-assignment-service.php';
 require_once __DIR__ . '/../services/class-guest-author-service.php';
 require_once __DIR__ . '/../services/class-coauthor-export-service.php';
 require_once __DIR__ . '/../services/class-coauthor-import-service.php';
+require_once __DIR__ . '/../services/class-coauthor-checks-service.php';
 require_once __DIR__ . '/class-migrate-author-terms-command.php';
 require_once __DIR__ . '/class-reassign-terms-command.php';
 require_once __DIR__ . '/class-remove-terms-from-revisions-command.php';
@@ -58,6 +61,7 @@ require_once __DIR__ . '/class-create-guest-authors-command.php';
 require_once __DIR__ . '/class-create-guest-authors-from-csv-command.php';
 require_once __DIR__ . '/class-create-guest-authors-from-wxr-command.php';
 require_once __DIR__ . '/class-list-authors-command.php';
+require_once __DIR__ . '/class-check-command.php';
 require_once __DIR__ . '/class-create-author-terms-for-posts-command.php';
 require_once __DIR__ . '/class-create-terms-for-posts-command.php';
 require_once __DIR__ . '/class-delete-skip-backfill-postmeta-command.php';
@@ -108,6 +112,11 @@ add_action(
 		WP_CLI::add_command(
 			'co-authors-plus list-authors',
 			new List_Authors_Command()
+		);
+
+		WP_CLI::add_command(
+			'co-authors-plus check',
+			new Check_Command( new Coauthor_Checks_Service( $coauthors_plus ) )
 		);
 
 		WP_CLI::add_command(

--- a/php/services/class-coauthor-checks-service.php
+++ b/php/services/class-coauthor-checks-service.php
@@ -1,0 +1,642 @@
+<?php
+/**
+ * Read-only checks over the co-author term index and the data it mirrors.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Services;
+
+use Automattic\CoAuthorsPlus\CLI\Create_Author_Terms_For_Posts_Command;
+use CoAuthors\Prefix;
+use CoAuthors_Guest_Authors;
+use CoAuthors_Plus;
+
+/**
+ * Reports where the term index and the bylines agree, and where they do not.
+ *
+ * Every fixer command in the plugin repairs one kind of drift between the
+ * mirrored `author` taxonomy and the posts, users and guest author profiles it
+ * is meant to reflect. Each of those commands already knows how to detect the
+ * condition it repairs, but that detection is private to the command and only
+ * runs on the way to a write. This service collects the same detection into one
+ * read-only pass, so an operator can see what is wrong before deciding whether
+ * to run a fixer.
+ *
+ * The checks deliberately compose the plugin's own read paths (get_author_term,
+ * get_author_term_post_count, Prefix) rather than restating their rules, so a
+ * check cannot disagree with the repair it describes.
+ */
+class Coauthor_Checks_Service {
+
+	/**
+	 * Number of terms to read per page while enumerating.
+	 *
+	 * @var int
+	 */
+	private const TERM_BATCH_SIZE = 500;
+
+	/**
+	 * Number of guest authors to read per page while enumerating.
+	 *
+	 * @var int
+	 */
+	private const GUEST_AUTHOR_BATCH_SIZE = 100;
+
+	/**
+	 * The canonical list of checks, in the order they are reported.
+	 *
+	 * @var string[]
+	 */
+	const CHECKS = array(
+		'posts-missing-terms',
+		'missing-user-terms',
+		'missing-guest-author-terms',
+		'stale-term-counts',
+		'stale-term-descriptions',
+		'unprefixed-terms',
+		'revision-terms',
+		'orphaned-skip-markers',
+		'guest-author-drift',
+	);
+
+	/**
+	 * Plugin instance the checks read through.
+	 *
+	 * @var CoAuthors_Plus
+	 */
+	private $coauthors_plus;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CoAuthors_Plus $coauthors_plus Plugin instance.
+	 */
+	public function __construct( CoAuthors_Plus $coauthors_plus ) {
+		$this->coauthors_plus = $coauthors_plus;
+	}
+
+	/**
+	 * Run every check, or the named subset.
+	 *
+	 * Names not in CHECKS are ignored, so callers can validate their own input.
+	 *
+	 * @param string[] $only Check names to run. Empty runs every check.
+	 * @return array<int, array<string, mixed>> One row per check.
+	 */
+	public function run( array $only = array() ): array {
+		$names = empty( $only ) ? self::CHECKS : array_values( array_intersect( self::CHECKS, $only ) );
+		$rows  = array();
+
+		foreach ( $names as $name ) {
+			$method = 'check_' . str_replace( '-', '_', $name );
+			$row    = $this->$method();
+
+			$rows[] = array(
+				'check'   => $name,
+				'status'  => $row['status'],
+				'count'   => $row['count'],
+				'summary' => $row['summary'],
+			);
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Posts with no co-author terms at all.
+	 *
+	 * Trash, auto-drafts and revisions are left out: the first two are not
+	 * binned content, and a revision is covered by its own check below. Posts
+	 * carrying a backfill skip marker are still counted, because they really do
+	 * have no terms; the marker only means a fixer has already passed them by.
+	 */
+	private function check_posts_missing_terms(): array {
+		global $wpdb;
+
+		$post_types = $this->coauthors_plus->supported_post_types();
+
+		if ( empty( $post_types ) ) {
+			return $this->result( 0, __( 'No post types support co-authors.', 'co-authors-plus' ) );
+		}
+
+		$placeholder = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		$args        = array_merge( $post_types, array( $this->coauthors_plus->coauthor_taxonomy ) );
+
+		// phpcs:disable -- Query is properly prepared.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT p.ID)
+				FROM {$wpdb->posts} p
+				WHERE p.post_type IN ( $placeholder )
+				  AND p.post_status NOT IN ( 'trash', 'auto-draft', 'inherit' )
+				  AND NOT EXISTS (
+				      SELECT 1
+				      FROM {$wpdb->term_relationships} tr
+				      INNER JOIN {$wpdb->term_taxonomy} tt
+				          ON tr.term_taxonomy_id = tt.term_taxonomy_id
+				      WHERE tr.object_id = p.ID
+				        AND tt.taxonomy = %s
+				  )",
+				$args
+			)
+		);
+		// phpcs:enable
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of posts. */
+				_n(
+					'%s post has no co-author terms.',
+					'%s posts have no co-author terms.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * WordPress users with no co-author term.
+	 *
+	 * A single query rather than a call per user, because a site can have tens
+	 * of thousands. The two slug arms match get_author_term(), which looks for
+	 * the prefixed slug and then falls back to the bare nicename, so a user
+	 * whose term is unprefixed is not reported as missing.
+	 */
+	private function check_missing_user_terms(): array {
+		global $wpdb;
+
+		// phpcs:disable -- Query is properly prepared.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(u.ID)
+				FROM {$wpdb->users} u
+				WHERE NOT EXISTS (
+				    SELECT 1
+				    FROM {$wpdb->terms} t
+				    INNER JOIN {$wpdb->term_taxonomy} tt
+				        ON t.term_id = tt.term_id
+				    WHERE tt.taxonomy = %s
+				      AND (
+				          t.slug = CONCAT( %s, u.user_nicename )
+				          OR t.slug = u.user_nicename
+				      )
+				)",
+				$this->coauthors_plus->coauthor_taxonomy,
+				Prefix::VALUE
+			)
+		);
+		// phpcs:enable
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of users. */
+				_n(
+					'%s user has no author term.',
+					'%s users have no author term.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Guest authors with no co-author term.
+	 *
+	 * Enumerated and resolved through get_author_term() rather than a query,
+	 * because a guest author's nicename is derived from their login field
+	 * rather than stored where SQL can reach it. The guest author list is a
+	 * contributor list, so this stays bounded.
+	 */
+	private function check_missing_guest_author_terms(): array {
+		if ( ! $this->guest_authors_enabled() ) {
+			return $this->skipped( __( 'Guest authors are disabled.', 'co-authors-plus' ) );
+		}
+
+		$count = 0;
+
+		foreach ( $this->guest_author_ids() as $guest_author_id ) {
+			$guest_author = $this->coauthors_plus->guest_authors->get_guest_author_by( 'ID', $guest_author_id );
+
+			if ( ! $guest_author ) {
+				continue;
+			}
+
+			if ( ! $this->coauthors_plus->get_author_term( $guest_author ) ) {
+				++$count;
+			}
+		}
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of guest authors. */
+				_n(
+					'%s guest author has no author term.',
+					'%s guest authors have no author term.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Author terms whose stored post count is out of date.
+	 *
+	 * The stored count is on the term, the expected one is computed by the same
+	 * method the fixer writes from, so the two cannot drift apart.
+	 */
+	private function check_stale_term_counts(): array {
+		$count = 0;
+
+		foreach ( $this->author_terms() as $term ) {
+			$expected = $this->coauthors_plus->get_author_term_post_count( $term );
+
+			// A null here means the count could not be determined, either
+			// because no co-author backs the term or because the query failed.
+			// Neither is a stale count, so neither is reported by this check.
+			if ( null === $expected ) {
+				continue;
+			}
+
+			if ( (int) $term->count !== $expected ) {
+				++$count;
+			}
+		}
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of author terms. */
+				_n(
+					'%s author term has an out of date post count.',
+					'%s author terms have an out of date post count.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Author terms whose stored description is out of date.
+	 *
+	 * The description holds the co-author's searchable fields, so a profile edit
+	 * that did not refresh the term shows up here.
+	 */
+	private function check_stale_term_descriptions(): array {
+		$count = 0;
+
+		foreach ( $this->author_terms() as $term ) {
+			$coauthor = $this->coauthors_plus->get_coauthor_by( 'user_nicename', $term->slug );
+
+			if ( ! $coauthor ) {
+				continue;
+			}
+
+			if ( (string) $term->description !== $this->description_for( $coauthor ) ) {
+				++$count;
+			}
+		}
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of author terms. */
+				_n(
+					'%s author term has an out of date description.',
+					'%s author terms have an out of date description.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Author terms whose slug is missing the plugin's prefix.
+	 *
+	 * These are the pre-3.0 terms migrate-author-terms repairs. An unprefixed
+	 * term still resolves through get_author_term()'s fallback, so it does not
+	 * announce itself, it just quietly makes an author archive wrong.
+	 */
+	private function check_unprefixed_terms(): array {
+		global $wpdb;
+
+		// phpcs:disable -- Query is properly prepared.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(t.term_id)
+				FROM {$wpdb->terms} t
+				INNER JOIN {$wpdb->term_taxonomy} tt
+				    ON t.term_id = tt.term_id
+				WHERE tt.taxonomy = %s
+				  AND t.slug NOT LIKE %s",
+				$this->coauthors_plus->coauthor_taxonomy,
+				$wpdb->esc_like( Prefix::VALUE ) . '%'
+			)
+		);
+		// phpcs:enable
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: 1: Number of author terms. 2: The term slug prefix. */
+				_n(
+					'%1$s author term has a slug without the %2$s prefix.',
+					'%1$s author terms have a slug without the %2$s prefix.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count ),
+				Prefix::VALUE
+			)
+		);
+	}
+
+	/**
+	 * Revisions carrying co-author terms.
+	 *
+	 * An old bug gave revisions author terms. remove-terms-from-revisions
+	 * repairs it, and any site that never ran that cleanup still carries them.
+	 */
+	private function check_revision_terms(): array {
+		global $wpdb;
+
+		// phpcs:disable -- Query is properly prepared.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT p.ID)
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->term_relationships} tr
+				    ON p.ID = tr.object_id
+				INNER JOIN {$wpdb->term_taxonomy} tt
+				    ON tr.term_taxonomy_id = tt.term_taxonomy_id
+				WHERE p.post_type = 'revision'
+				  AND p.post_status = 'inherit'
+				  AND tt.taxonomy = %s",
+				$this->coauthors_plus->coauthor_taxonomy
+			)
+		);
+		// phpcs:enable
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of revisions. */
+				_n(
+					'%s revision carries co-author terms.',
+					'%s revisions carry co-author terms.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Backfill skip markers that are no longer doing anything.
+	 *
+	 * The marker tells the backfill not to retry a post it could not handle. It
+	 * is orphaned when the post is gone, or when the post later gained its
+	 * terms anyway, which leaves the marker blocking nothing.
+	 */
+	private function check_orphaned_skip_markers(): array {
+		global $wpdb;
+
+		// phpcs:disable -- Query is properly prepared.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(pm.meta_id)
+				FROM {$wpdb->postmeta} pm
+				LEFT JOIN {$wpdb->posts} p
+				    ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s
+				  AND (
+				      p.ID IS NULL
+				      OR EXISTS (
+				          SELECT 1
+				          FROM {$wpdb->term_relationships} tr
+				          INNER JOIN {$wpdb->term_taxonomy} tt
+				              ON tr.term_taxonomy_id = tt.term_taxonomy_id
+				          WHERE tr.object_id = pm.post_id
+				            AND tt.taxonomy = %s
+				      )
+				  )",
+				Create_Author_Terms_For_Posts_Command::SKIP_POST_FOR_BACKFILL_META_KEY,
+				$this->coauthors_plus->coauthor_taxonomy
+			)
+		);
+		// phpcs:enable
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of postmeta rows. */
+				_n(
+					'%s backfill skip marker is orphaned.',
+					'%s backfill skip markers are orphaned.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Guest author profiles that have drifted from their author term.
+	 *
+	 * Guest author terms can be renamed without their profile, and profiles can
+	 * be renamed without their term, leaving the two pointing at different
+	 * slugs while get_author_term()'s fallback quietly papers over it. This
+	 * reads the term holding the profile's own post, which is the assignment
+	 * the site actually queries, and compares its slug to the one the profile's
+	 * nicename implies. A profile carrying no term at all is left to
+	 * missing-guest-author-terms.
+	 */
+	private function check_guest_author_drift(): array {
+		if ( ! $this->guest_authors_enabled() ) {
+			return $this->skipped( __( 'Guest authors are disabled.', 'co-authors-plus' ) );
+		}
+
+		$count = 0;
+
+		foreach ( $this->guest_author_ids() as $guest_author_id ) {
+			$guest_author = $this->coauthors_plus->guest_authors->get_guest_author_by( 'ID', $guest_author_id );
+
+			if ( ! $guest_author ) {
+				continue;
+			}
+
+			$terms = wp_get_object_terms( $guest_author_id, $this->coauthors_plus->coauthor_taxonomy );
+
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $term ) {
+				if ( Prefix::prefix_slug( $guest_author->user_nicename ) !== $term->slug ) {
+					++$count;
+					break;
+				}
+			}
+		}
+
+		return $this->result(
+			$count,
+			sprintf(
+				/* translators: %s: Number of guest author profiles. */
+				_n(
+					'%s guest author profile has drifted from its author term.',
+					'%s guest author profiles have drifted from their author term.',
+					$count,
+					'co-authors-plus'
+				),
+				number_format_i18n( $count )
+			)
+		);
+	}
+
+	/**
+	 * Every author term, read in pages so a large term index does not have to
+	 * be held in memory at once.
+	 *
+	 * @return array<int, \WP_Term>
+	 */
+	private function author_terms(): array {
+		$terms  = array();
+		$offset = 0;
+
+		do {
+			$batch = get_terms(
+				array(
+					'taxonomy'   => $this->coauthors_plus->coauthor_taxonomy,
+					'hide_empty' => false,
+					'number'     => self::TERM_BATCH_SIZE,
+					'offset'     => $offset,
+					'orderby'    => 'term_id',
+					'order'      => 'ASC',
+				)
+			);
+
+			if ( is_wp_error( $batch ) ) {
+				break;
+			}
+
+			$terms  = array_merge( $terms, $batch );
+			$found  = count( $batch );
+			$offset += self::TERM_BATCH_SIZE;
+
+			\WP_CLI\Utils\wp_clear_object_cache();
+		} while ( self::TERM_BATCH_SIZE === $found );
+
+		return $terms;
+	}
+
+	/**
+	 * Every guest author ID, read in pages.
+	 *
+	 * @return int[]
+	 */
+	private function guest_author_ids(): array {
+		$ids   = array();
+		$paged = 1;
+
+		do {
+			$batch = get_posts(
+				array(
+					'post_type'        => $this->coauthors_plus->guest_authors->post_type,
+					// Guest authors are stored as drafts, so 'any' is what finds them.
+					'post_status'      => 'any',
+					'posts_per_page'   => self::GUEST_AUTHOR_BATCH_SIZE,
+					'paged'            => $paged,
+					'orderby'          => 'ID',
+					'order'            => 'ASC',
+					'fields'           => 'ids',
+					'suppress_filters' => false,
+				)
+			);
+
+			$found = count( $batch );
+			$ids   = array_merge( $ids, $batch );
+			++$paged;
+
+			\WP_CLI\Utils\wp_clear_object_cache();
+		} while ( self::GUEST_AUTHOR_BATCH_SIZE === $found );
+
+		return array_map( 'intval', $ids );
+	}
+
+	/**
+	 * Whether guest author profiles are available to check.
+	 *
+	 * Read lazily rather than in the constructor, so the command can be built
+	 * and registered whether or not the feature is switched on.
+	 */
+	private function guest_authors_enabled(): bool {
+		return $this->coauthors_plus->guest_authors instanceof CoAuthors_Guest_Authors
+			&& $this->coauthors_plus->is_guest_authors_enabled();
+	}
+
+	/**
+	 * The description a co-author's term should hold.
+	 *
+	 * Mirrors CoAuthors_Plus::update_author_term(), including its use of
+	 * ajax_search_fields, so the comparison cannot disagree with the write.
+	 *
+	 * @param object $coauthor Co-author object.
+	 * @return string
+	 */
+	private function description_for( $coauthor ): string {
+		$values = array();
+
+		foreach ( $this->coauthors_plus->ajax_search_fields as $field ) {
+			$values[] = $coauthor->$field ?? '';
+		}
+
+		return implode( ' ', $values );
+	}
+
+	/**
+	 * Build a check row from its finding count.
+	 *
+	 * @param int    $count   Number found.
+	 * @param string $summary Human readable summary.
+	 * @return array<string, mixed>
+	 */
+	private function result( int $count, string $summary ): array {
+		return array(
+			'status'  => $count > 0 ? 'issues' : 'ok',
+			'count'   => $count,
+			'summary' => $summary,
+		);
+	}
+
+	/**
+	 * Build a check row for a check that does not apply.
+	 *
+	 * @param string $summary Why it was skipped.
+	 * @return array<string, mixed>
+	 */
+	private function skipped( string $summary ): array {
+		return array(
+			'status'  => 'skipped',
+			'count'   => 0,
+			'summary' => $summary,
+		);
+	}
+}

--- a/tests/Unit/Cli/CheckCommandTest.php
+++ b/tests/Unit/Cli/CheckCommandTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * WordPress-free unit tests for the check command's argument handling.
+ *
+ * @package Automattic\CoAuthorsPlus
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\CoAuthorsPlus\Tests\Unit\Cli;
+
+use Automattic\CoAuthorsPlus\CLI\Check_Command;
+use Automattic\CoAuthorsPlus\Services\Coauthor_Checks_Service;
+use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
+use WP_CLI;
+use WP_CLI\ExitException;
+use WP_CLI\Loggers\Execution;
+
+/**
+ * The command validates --only before asking the service to run.
+ *
+ * A typo in a runbook that silently ran every check instead of the one named
+ * would be worse than failing, so an unknown name is an error rather than a
+ * filter that matches nothing. The service is mocked: what is under test here is
+ * the parsing and the error, not the checks themselves, which the Behat suite
+ * exercises against a real installation.
+ *
+ * The real WP_CLI class is used (Composer loads it eagerly, so it cannot be
+ * alias-mocked): its Execution logger captures output in memory, and its own
+ * $capture_exit switch makes error() throw ExitException instead of exiting the
+ * test process.
+ *
+ * @covers \Automattic\CoAuthorsPlus\CLI\Check_Command::__invoke
+ */
+final class CheckCommandTest extends TestCase {
+
+	/**
+	 * In-memory logger capturing what the command writes.
+	 *
+	 * @var Execution
+	 */
+	private $logger;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->logger = new Execution();
+		WP_CLI::set_logger( $this->logger );
+		$this->set_capture_exit( true );
+	}
+
+	public function tear_down(): void {
+		$this->set_capture_exit( false );
+		WP_CLI::set_logger( null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Flip WP_CLI's private $capture_exit switch so error() throws instead of exiting.
+	 *
+	 * The setAccessible() call is required to reach a private static property on
+	 * PHP 7.4, the lowest version the plugin supports, but is deprecated from
+	 * 8.1 where reflection no longer needs it. Calling it unconditionally would
+	 * fail this suite on 8.5.
+	 *
+	 * @param bool $capture Whether exits should be captured as ExitException.
+	 */
+	private function set_capture_exit( bool $capture ): void {
+		$property = new \ReflectionProperty( WP_CLI::class, 'capture_exit' );
+
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+
+		$property->setValue( null, $capture );
+	}
+
+	/**
+	 * A service that records the checks it was asked for.
+	 *
+	 * @param array<int, array<string, mixed>> $rows Rows the service should return.
+	 * @param string[]                         $run  Receives the `$only` argument.
+	 * @return Coauthor_Checks_Service
+	 */
+	private function service_recording_run( array $rows, array &$run ): Coauthor_Checks_Service {
+		$service = \Mockery::mock( Coauthor_Checks_Service::class );
+		$service->shouldReceive( 'run' )
+			->once()
+			->andReturnUsing(
+				static function ( $only ) use ( $rows, &$run ) {
+					$run[] = $only;
+					return $rows;
+				}
+			);
+
+		return $service;
+	}
+
+	/**
+	 * An unknown check name halts with an error naming it.
+	 */
+	public function test_unknown_check_name_errors_out(): void {
+		$service = \Mockery::mock( Coauthor_Checks_Service::class );
+		$service->shouldNotReceive( 'run' );
+
+		$command = new Check_Command( $service );
+
+		try {
+			$command( array(), array( 'only' => 'no-such-check' ) );
+			$this->fail( 'WP_CLI::error() should have halted the command for an unknown check name.' );
+		} catch ( ExitException $e ) {
+			$this->assertSame( 1, $e->getCode(), 'The command should halt with exit code 1.' );
+		}
+
+		$this->assertStringContainsString( 'Unknown check(s): no-such-check', $this->logger->stderr );
+	}
+
+	/**
+	 * Only the names given are passed through to the service.
+	 *
+	 * --format=count is used because it is the one format that renders without
+	 * WP_CLI\Utils\pick_fields(), which is not loaded in the WordPress-free unit
+	 * environment. Output is buffered so the direct echo is not flagged as risky.
+	 */
+	public function test_valid_only_list_is_passed_through(): void {
+		$only    = array();
+		$service = $this->service_recording_run(
+			array(
+				array(
+					'check'   => 'unprefixed-terms',
+					'status'  => 'ok',
+					'count'   => 0,
+					'summary' => 'Nothing to see.',
+				),
+			),
+			$only
+		);
+
+		$command = new Check_Command( $service );
+		$args    = array(
+			'only'   => 'unprefixed-terms, revision-terms',
+			'format' => 'count',
+		);
+
+		ob_start();
+		$command( array(), $args );
+		$output = (string) ob_get_clean();
+
+		$this->assertSame(
+			array( array( 'unprefixed-terms', 'revision-terms' ) ),
+			$only,
+			'The trimmed names should reach the service in the order given.'
+		);
+		$this->assertSame( '1', $output, 'One row was returned, so count renders it.' );
+	}
+
+	/**
+	 * With no --only, the service runs every check.
+	 *
+	 * --format=count for the same reason as the test above.
+	 */
+	public function test_no_only_runs_every_check(): void {
+		$only    = array();
+		$service = $this->service_recording_run( array(), $only );
+
+		$command = new Check_Command( $service );
+
+		ob_start();
+		$command( array(), array( 'format' => 'count' ) );
+		ob_end_clean();
+
+		$this->assertSame(
+			array( array() ),
+			$only,
+			'An empty list is what the service takes to mean "all checks".'
+		);
+	}
+}

--- a/tests/Unit/Cli/ClearObjectCacheTest.php
+++ b/tests/Unit/Cli/ClearObjectCacheTest.php
@@ -32,18 +32,19 @@ use Automattic\CoAuthorsPlus\Tests\Unit\TestCase;
 final class ClearObjectCacheTest extends TestCase {
 
 	/**
-	 * Commands that process posts in batches and must flush the object cache
-	 * between batches.
+	 * Commands and services that process large result sets in batches and must
+	 * flush the object cache between batches.
 	 *
-	 * When adding a command that loops over a large result set, add its file
-	 * here so the flush cannot be dropped unnoticed.
+	 * When adding code that loops over a large result set, add its file here so
+	 * the flush cannot be dropped unnoticed.
 	 */
-	private const BATCHING_COMMANDS = array(
-		'class-assign-coauthors-command.php',
-		'class-create-terms-for-posts-command.php',
-		'class-list-posts-without-terms-command.php',
-		'class-swap-coauthors-command.php',
-		'class-update-author-terms-command.php',
+	private const BATCHING_FILES = array(
+		'php/cli/class-assign-coauthors-command.php',
+		'php/cli/class-create-terms-for-posts-command.php',
+		'php/cli/class-list-posts-without-terms-command.php',
+		'php/cli/class-swap-coauthors-command.php',
+		'php/cli/class-update-author-terms-command.php',
+		'php/services/class-coauthor-checks-service.php',
 	);
 
 	/**
@@ -99,21 +100,22 @@ final class ClearObjectCacheTest extends TestCase {
 	}
 
 	/**
-	 * Every batching command still flushes the object cache between batches.
+	 * Every batching command and service still flushes the object cache between
+	 * batches.
 	 *
-	 * Checked per file, not across the directory as a whole, so one command
+	 * Checked per file, not across the directory as a whole, so one file
 	 * dropping its flush cannot hide behind another that kept it.
 	 */
-	public function test_each_batching_command_flushes_the_object_cache(): void {
-		foreach ( self::BATCHING_COMMANDS as $command ) {
-			$source = $this->path( 'php/cli/' . $command );
+	public function test_each_batching_file_flushes_the_object_cache(): void {
+		foreach ( self::BATCHING_FILES as $file ) {
+			$source = $this->path( $file );
 
-			$this->assertFileExists( $source, "$command is listed as a batching command but does not exist. Update BATCHING_COMMANDS." );
+			$this->assertFileExists( $source, "$file is listed as a batching file but does not exist. Update BATCHING_FILES." );
 
 			$this->assertStringContainsString(
 				'\WP_CLI\Utils\wp_clear_object_cache();',
 				(string) file_get_contents( $source ),
-				"$command no longer flushes the object cache between batches. A long run would exhaust memory on a real site."
+				"$file no longer flushes the object cache between batches. A long run would exhaust memory on a real site."
 			);
 		}
 	}


### PR DESCRIPTION
## Description

Issue #1417 proposes splitting the existing WP-CLI fixer commands into a read-only `check` plus an explicit `repair`, and calls the check command the safe part to build first. This adds just that part.

`wp co-authors-plus check` reports on drift in the author term index without writing anything. It runs nine checks and prints one row per check with a status, a count, and a summary.

The nine checks:

- `posts-missing-terms` posts with no author term at all
- `missing-user-terms` users with no author term
- `missing-guest-author-terms` guest authors with no author term
- `stale-term-counts` stored term count does not match the posts
- `stale-term-descriptions` stored term description does not match the co-author
- `unprefixed-terms` author terms whose slug lacks the `cap-` prefix
- `revision-terms` author terms attached to revisions
- `orphaned-skip-markers` skip backfill markers with no post behind them
- `guest-author-drift` guest author whose linked profile term slug has drifted

Notes:

- `--only` narrows the run to named checks. An unknown name is an input error, not a silent match-nothing, because a typo in a runbook quietly running every check is worse than failing loud.
- The command always exits 0. It is a report, so a CI job can run it and read the output without the job going red.
- `--format=count` counts report rows (the number of checks run), not findings. A single check's finding count is its `count` field, readable with `--field=count`.
- Guest author checks report `skipped` when guest authors are disabled.
- Detection sits in a new `Coauthor_Checks_Service` rather than in the command, so the repair half of the proposal can reuse it later.

Two supporting changes:

- `CoAuthors_Plus::get_author_term_post_count()` is extracted from `update_author_term_post_count()`. The stale count check compares against the same query the fixer writes from, so the two cannot drift apart.
- A failed count query now returns null instead of 0. Previously `update_author_term_post_count()` would write a failed query result as a count of 0 and lose the real one; it now returns a `WP_Error` and leaves the stored count alone. The check treats null as unknown rather than reporting it as drift.

Out of scope here, as follow-ups on #1417: the `repair` command, the `wp co-author` namespace, and deprecation shims for the current command names.

Fixes #1417

## Deploy Notes

No new dependencies, no build step changes, no schema changes. The new files ship with the plugin as usual.

## Steps to Test

1. Check out the PR.
1. Run `wp co-authors-plus check`. Expect a table of nine rows and exit code 0.
1. Confirm the run is read-only by taking a count before and after: `wp term list author --format=count` should be unchanged.
1. Run `wp co-authors-plus check --only=stale-term-counts,orphaned-skip-markers`. Expect two rows.
1. Run `wp co-authors-plus check --only=nope`. Expect an error naming the unknown check and listing the available ones, with exit code 1.
1. Stage drift and confirm it is reported. For a stale count:
   `wp eval '$t = get_term_by( "slug", "cap-admin", "author" ); global $wpdb; $wpdb->update( $wpdb->term_taxonomy, array( "count" => 99 ), array( "term_taxonomy_id" => $t->term_taxonomy_id ) );'`
   then `wp co-authors-plus check --only=stale-term-counts --field=count` should print `1`.
1. Run `wp co-authors-plus check --format=json` and confirm each row has `check`, `status`, `count`, and `summary`.