### PR TITLE
Document the create() sanitisation contract

### DIFF
--- a/php/class-coauthors-guest-authors.php
+++ b/php/class-coauthors-guest-authors.php
@@ -1393,9 +1393,25 @@ class CoAuthors_Guest_Authors {
 	/**
 	 * Create a guest author.
 	 *
-	 * @param $args array Author args. Required keys to create author: 'display_name' and 'user_email'.
+	 * This is a low-level primitive and trusts its arguments. Post meta is
+	 * stored exactly as given, and the display name goes straight into
+	 * wp_insert_post(), so core filters the resulting post title (trim, and
+	 * kses for users without the unfiltered_html capability).
+	 *
+	 * Callers sanitise before they get here: Guest_Author_Service, the CLI
+	 * creator and the importers all run values through
+	 * Guest_Author_Service::sanitize_profile(), which applies each field's
+	 * declared sanitize_function, falling back to sanitize_text_field. The one
+	 * caller that does not sanitise is create_guest_author_from_user_id(),
+	 * which copies values already stored on a WP_User.
+	 *
+	 * Not sanitising here also keeps the user_login collision guard honest: it
+	 * compares the caller's linked_account value against the user's real login,
+	 * and create_guest_author_from_user_id() passes that login through untouched.
 	 *
 	 * @since 3.0
+	 *
+	 * @param array $args Author args. Required keys: 'display_name' and 'user_login'.
 	 * @return int|WP_Error The ID of the created guest author, or a WP_Error object if the author could not be created.
 	 */
 	public function create( $args ) {

--- a/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
+++ b/tests/Integration/GuestAuthors/CreateGuestAuthorTest.php
@@ -314,4 +314,47 @@ class CreateGuestAuthorTest extends TestCase {
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'duplicate-field', $response->get_error_code() );
 	}
+
+	/**
+	 * Pins the create() contract: arguments are stored as given, callers sanitise.
+	 *
+	 * This pins the contract documented on create() itself: it is a low-level
+	 * primitive that does not sanitise. Tags, newlines and tabs in the display
+	 * name are written to cap-display_name untouched. The write paths that
+	 * accept untrusted input sanitise first, through
+	 * Guest_Author_Service::sanitize_profile(), and this test is the tripwire if
+	 * create() ever starts sanitising internally: it should fail and the
+	 * contract be updated deliberately.
+	 *
+	 * Only the meta value is asserted, not post_title, because wp_insert_post()
+	 * filters the title (trim, and kses for users without unfiltered_html), so a
+	 * title assertion would test core rather than this contract.
+	 *
+	 * @link https://github.com/Automattic/Co-Authors-Plus/issues/1435
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_stores_arguments_verbatim(): void {
+
+		global $coauthors_plus;
+
+		$raw_display_name = "<script>alert(1)</script>\nline\ttab";
+
+		$guest_author_id = $coauthors_plus->guest_authors->create(
+			array(
+				'display_name' => $raw_display_name,
+				'user_login'   => 'verbatim-contract-author',
+			)
+		);
+
+		$this->assertIsInt( $guest_author_id );
+
+		$stored_display_name = get_post_meta(
+			$guest_author_id,
+			$coauthors_plus->guest_authors->get_post_meta_key( 'display_name' ),
+			true
+		);
+
+		$this->assertSame( $raw_display_name, $stored_display_name );
+	}
 }


### PR DESCRIPTION
## Description

Decides the open question in #1435: `CoAuthors_Guest_Authors::create()` stays a trusted low-level primitive. It stores the arguments it is given and leaves sanitisation to its callers, which already run untrusted input through `Guest_Author_Service::sanitize_profile()` before calling it. There is no behaviour change here, only documentation and a test that pins the contract.

The `create()` docblock now states that contract, and fixes two stale details along the way: a malformed `@param $args array` tag, and the claim that `user_email` is required when `get_guest_author_fields()` marks `user_login` as the required key. It also records why not sanitising inside `create()` matters: the `user_login` collision guard compares `linked_account` against the user's real login, and `create_guest_author_from_user_id()` passes that login through untouched.

A new integration test, `test_create_stores_arguments_verbatim()`, pins the contract. It runs a display name containing script tags, a newline and a tab through `create()` and asserts `cap-display_name` stores it unchanged. If `create()` ever starts sanitising internally, that test fails and the contract gets updated deliberately rather than quietly. The test asserts the meta value only, not `post_title`, because `wp_insert_post()` filters the title and that would test core rather than this contract.

## Deploy Notes

None. No new dependencies, no runtime behaviour change, and no changes to stored data.

## Steps to Test

1. Start wp-env if it is not already running:

   ```sh
   npx @wordpress/env start
   ```

2. Run the suite covering this change:

   ```sh
   npx @wordpress/env run tests-cli --env-cwd=wp-content/plugins/co-authors-plus \
     ./vendor/bin/phpunit --testsuite integration --exclude=ms-required \
     --no-coverage --filter CreateGuestAuthorTest
   ```

   Expected: `OK (9 tests, 22 assertions)`, including `Create stores arguments verbatim`.

3. Run the full integration suite to check for regressions:

   ```sh
   npx @wordpress/env run tests-cli --env-cwd=wp-content/plugins/co-authors-plus \
     ./vendor/bin/phpunit --testsuite integration --exclude=ms-required --no-coverage
   ```

   Expected: `OK (370 tests, 1158 assertions)`.

4. Optional, to see the pin is real: add `$args['display_name'] = sanitize_text_field( $args['display_name'] );` near the top of `create()` and re-run step 2. The new test should fail because the stored value no longer matches. Revert the line afterwards.
