### PR TITLE
fix(search): use core description__like instead of terms_clauses rewriting

### DIFF
--- a/php/class-coauthors-plus.php
+++ b/php/class-coauthors-plus.php
@@ -2186,14 +2186,31 @@ class CoAuthors_Plus {
 		}
 
 		$args = array(
-			'search' => $search,
-			'get'    => 'all',
-			'number' => 10,
+			'description__like' => $search,
+			'get'               => 'all',
+			'number'            => 10,
 		);
 		$args = apply_filters( 'coauthors_search_authors_get_terms_args', $args );
-		add_filter( 'terms_clauses', array( $this, 'filter_terms_clauses' ) );
-		$found_terms = get_terms( array_merge( array( 'taxonomy' => $this->coauthor_taxonomy ), $args ) );
-		remove_filter( 'terms_clauses', array( $this, 'filter_terms_clauses' ) );
+		$base_args   = array_merge( array( 'taxonomy' => $this->coauthor_taxonomy ), $args );
+		$found_terms = get_terms( $base_args );
+
+		if ( is_wp_error( $found_terms ) ) {
+			return array();
+		}
+
+		// The term description does not always contain the user_nicename, so
+		// also match the exact term slug, like the old search clause did.
+		$slug = sanitize_title( $search );
+		if ( '' !== $slug ) {
+			$slug_args         = $base_args;
+			$slug_args['slug'] = array_unique( array( Prefix::prefix_slug( $slug ), $slug ) );
+			unset( $slug_args['description__like'] );
+			$slug_terms = get_terms( $slug_args );
+
+			if ( ! empty( $slug_terms ) && ! is_wp_error( $slug_terms ) ) {
+				$found_terms = array_merge( $found_terms, $slug_terms );
+			}
+		}
 
 		if ( empty( $found_terms ) ) {
 			return array();
@@ -2229,6 +2246,9 @@ class CoAuthors_Plus {
 
 	/**
 	 * Modify get_terms() to LIKE against the term description instead of the term name
+	 *
+	 * Kept for backward compatibility. search_authors() no longer hooks this;
+	 * it passes 'description__like' to get_terms() directly.
 	 *
 	 * @since 3.0
 	 */

--- a/tests/Integration/Bylines/SearchAuthorsTest.php
+++ b/tests/Integration/Bylines/SearchAuthorsTest.php
@@ -171,4 +171,93 @@ class SearchAuthorsTest extends TestCase {
 		$this->assertArrayNotHasKey( $this->author1->user_login, $authors );
 		$this->assertArrayHasKey( $author2->user_login, $authors );
 	}
+
+	/**
+	 * Checks that search matches the term description without any SQL string rewriting.
+	 *
+	 * The search runs against the term description via get_terms()' native
+	 * 'description__like' argument, so no terms_clauses filter is hooked and the
+	 * result does not depend on the SQL format core generates.
+	 *
+	 * @covers ::search_authors
+	 * @covers ::filter_terms_clauses
+	 */
+	public function test_search_authors_matches_description_without_terms_clauses_filter(): void {
+
+		global $coauthors_plus;
+
+		$captured = array(
+			'authors'        => null,
+			'cap_filter_hit' => false,
+		);
+
+		$spy = static function ( $pieces ) use ( &$captured ) {
+			$captured['cap_filter_hit'] = false !== has_filter(
+				'terms_clauses',
+				array( $GLOBALS['coauthors_plus'], 'filter_terms_clauses' )
+			);
+
+			return $pieces;
+		};
+
+		add_filter( 'terms_clauses', $spy, 20, 1 );
+
+		$captured['authors'] = $coauthors_plus->search_authors( $this->author1->display_name );
+
+		remove_filter( 'terms_clauses', $spy, 20 );
+
+		$this->assertNotEmpty( $captured['authors'] );
+		$this->assertArrayHasKey( $this->author1->user_login, $captured['authors'] );
+
+		// search_authors() must not rely on terms_clauses string rewriting anymore.
+		$this->assertFalse( $captured['cap_filter_hit'] );
+	}
+
+	/**
+	 * Checks filter_terms_clauses() still rewrites the name clause for callers that hook it.
+	 *
+	 * @covers ::filter_terms_clauses
+	 */
+	public function test_filter_terms_clauses_still_rewrites_name_like(): void {
+
+		global $coauthors_plus;
+
+		$pieces = array(
+			'where' => "((t.name LIKE '%editor%') OR (t.slug LIKE '%editor%'))",
+		);
+
+		$expected = "((tt.description LIKE '%editor%') OR (t.slug LIKE '%editor%'))";
+
+		$this->assertSame( $expected, $coauthors_plus->filter_terms_clauses( $pieces )['where'] );
+	}
+
+	/**
+	 * Checks that a search by user_nicename finds the co-author even when the
+	 * nicename appears nowhere in the term description.
+	 *
+	 * @covers ::search_authors
+	 */
+	public function test_search_authors_finds_author_by_nicename_not_in_description(): void {
+
+		global $coauthors_plus;
+
+		$user = $this->factory()->user->create_and_get(
+			array(
+				'role'          => 'author',
+				'user_login'    => 'plainlogin',
+				'user_nicename' => 'oddnicename',
+				'display_name'  => 'Plain Name',
+				'user_email'    => 'plain@example.com',
+			)
+		);
+
+		// A term only exists once the author was assigned to a post or the
+		// term back-fill ran, so create it the same way add_coauthors() does.
+		$coauthors_plus->update_author_term( $user );
+
+		$authors = $coauthors_plus->search_authors( 'oddnicename' );
+
+		$this->assertNotEmpty( $authors );
+		$this->assertArrayHasKey( 'plainlogin', $authors );
+	}
 }


### PR DESCRIPTION
## Description

Author search (`search_authors()`, and with it the Authors metabox search and the `coauthors/v1/search` REST route) worked by hooking `terms_clauses` during `get_terms()` and rewriting the generated SQL with `str_replace( 't.name LIKE', 'tt.description LIKE', ... )`. That literal string surgery is fragile: if another plugin hooks `terms_clauses` first and alters the clause, or core changes how the search clause is built, the replacement silently no-ops or the query returns nothing and the author search comes back empty.

This PR replaces the SQL rewriting with the core-native `description__like` argument to `get_terms()` (available since WP 4.7), which core turns into `tt.description LIKE %s` on its own. No filters are attached and removed around the call anymore.

One behaviour nuance is preserved explicitly: the term description holds `display_name first_name last_name user_login ID user_email`, but not always the `user_nicename`. The old search clause also matched `t.slug LIKE`, so this adds a second exact-slug lookup (prefixed and unprefixed) alongside the description match to keep searches by nicename working.

Closes #1440

## Deploy Notes

No new dependencies. One note for anyone hooking `coauthors_search_authors_get_terms_args`: the args now contain `description__like` instead of `search`. `filter_terms_clauses()` remains a public method for backward compatibility but `search_authors()` no longer attaches it. The filterable args are also applied to both the description query and the slug query, so hooks that add `number` or `exclude` keep working on both.

## Steps to Test

1. Check out the PR branch and enable guest authors.
2. Edit any post and open the Authors metabox.
3. Search for an author by display name, user login, email, and user nicename; results appear in every case.
4. Search for a guest author by display name; results appear.
5. Search for something that matches nothing, for example `zzznotfoundzzz`; no results appear.
6. Alternatively hit `/wp-json/coauthors/v1/search?q=<term>` and confirm the same.

Automated coverage: full integration suite passes (372 tests, 1162 assertions) on WP trunk with PHP 8.4 via wp-env. Three tests were added: one proving `terms_clauses` is not hooked during `search_authors()`, one covering `filter_terms_clauses()` as a standalone BC method, and one regression test searching by a nicename that is absent from the term description.